### PR TITLE
parse node geolocation from config and show in xdn service info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,17 +129,26 @@ Use the `bin/xdnd` shell script (driver-machine orchestrator) for multi-host dep
 - `reconfiguration/` — Control plane, replica management; entry point: `ReconfigurableNode.java`
 - `xdn/` — Core XDN logic (see subpackages and key classes below)
 - `nio/` — NIO networking framework
-- `primarybackup/`, `chainreplication/`, `causal/`, `eventual/` — Replication protocol variants
+- `protocoltask/` — Protocol task orchestration framework used by coordinators
+- `primarybackup/`, `chainreplication/`, `causal/`, `eventual/`, `sequential/`, `pram/`, `clientcentric/`, `txn/` — Replication/consistency protocol variants (each maps to a `ConsistencyModel`)
 
 ### XDN Package Substructure (`src/edu/umass/cs/xdn/`)
 - `docker/` — Container management (`DockerComposeManager`)
 - `recorder/` — State diff strategies (`AbstractStateDiffRecorder` and four implementations)
-- `request/` — HTTP request parsing (`XdnRequestParser`, `XdnHttpRequest`, `XdnHttpRequestBatch`)
-- `service/` — Service metadata (`ServiceProperty`, `ServiceComponent`, `ConsistencyModel`)
+- `request/` — HTTP request parsing (`XdnRequestParser`, `XdnHttpRequest`, `XdnHttpRequestBatch`) and internal request types (`XdnGetReplicaInfoRequest`, `XdnStopRequest`, `XDNHttpForwardRequest`, `XDNStatediffApplyRequest`)
+- `service/` — Service metadata (`ServiceProperty`, `ServiceComponent`, `ConsistencyModel`, `ServiceInstance`, `RequestMatcher`)
 - `utils/` — Shell execution helpers, hosts file editing
-- `interfaces/behavior/` — Request behavior abstractions
+- `interfaces/behavior/` — Request behavior abstractions (commutative, key-commutative, etc.)
 - `proto/` — Protocol buffer classes
 - `eval/` — Evaluation and experiment utilities
+- `experiment/` — Experiment harness code and ad-hoc clients (e.g. `XdnBookCatalogAppClient`)
+
+### Top-level XDN helpers (in `src/edu/umass/cs/xdn/`)
+- `XdnServiceProperties` — service-property helpers and defaults consumed elsewhere
+- `XdnHttpRequestBatcher` — batches HTTP requests at the AR frontend when batching is enabled
+- `XdnGeoDemandProfiler`, `XdnReplicaPlacementProfile` — geo-demand tracking and replica placement policies
+- `XdnServiceInitialStateValidator`, `XdnServiceNumReplicasExtractor` — launch-time validators/extractors
+- `HttpDebugProxy`, `HttpDebugWaitProxy`, `HttpDebugIndirectProxy` — diagnostic HTTP proxies used in debugging/tests
 
 ### Key Classes and Request Flow
 
@@ -185,6 +194,12 @@ Supported via `ConsistencyModel`: linearizability (default), sequential, causal,
 eventual, pram, and client-centric variants. 
 Each maps to a coordinator in the corresponding protocol package.
 
+### `xdn-cli` subcommands (`xdn-cli/cmd/`)
+Cobra-based CLI. Top-level verbs include `launch`, `status`, `check`, and the `service` command group. `service` covers: `info`, `destroy`, `move` (relocate a service to new replica hosts; drives synchronous paxos leader change), `leader` (inspect/set the paxos leader). `launch` accepts `--num-replicas`, `--min-replicas`, `--max-replicas` in addition to `--image`, `--state`, `--deterministic`, etc. Mutating subcommands prompt for yes/no confirmation on stdin.
+
+### XDN-internal URL params
+URL query parameters prefixed with `_xdn` (e.g. `_xdnsvc`) are consumed at the XDN/proxy layer and must be stripped from the request URI before it is forwarded to the containerized service. `_xdnsvc` provides the service name directly as a URL param and is used as a developer-experience alternative to setting the `XDN:` header.
+
 ### Configuration
 - `gigapaxos.properties` — Main deployment config
 - `conf/gigapaxos.xdn.local.properties` — Local development (1 RC + 3 AR on loopback)
@@ -202,6 +217,7 @@ For multi-machine/CloudLab deployments, `bin/xdnd` drives remote setup and lifec
 - **ant-build-test.yml**: Build + run `xdn-full-tests` on push/PR to master/main (JDK 21, Docker, FUSE, rsync)
 - **xdn-cli-ci.yml**: gofmt check + CLI binary build on changes to `xdn-cli/`
 - **google-java-format.yml**: Formatting check on XDN Java file changes
+- **test-report.yml**: JUnit test-result reporter (currently disabled — `if: false` — gated on the XDN test workflow)
 
 ## Conventions
 - Java code follows Google Java Style (enforced by formatter)

--- a/src/edu/umass/cs/gigapaxos/PaxosConfig.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosConfig.java
@@ -39,6 +39,7 @@ import edu.umass.cs.gigapaxos.paxosutil.E2ELatencyAwareRedirector;
 import edu.umass.cs.nio.NIOTransport;
 import edu.umass.cs.nio.SSLDataProcessingWorker;
 import edu.umass.cs.nio.SSLDataProcessingWorker.SSL_MODES;
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.nio.interfaces.NodeConfig;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableNodeConfig;
 import edu.umass.cs.reconfiguration.interfaces.ReplicableRequest;
@@ -167,6 +168,52 @@ public class PaxosConfig {
 						Util.getInetSocketAddressFromString(config
 								.getProperty(key)));
 			}
+		}
+		return map;
+	}
+
+	/**
+	 * Geolocation suffix for per-active-replica geolocation property keys,
+	 * as in {@code active.<name>.geolocation="latitude,longitude"}.
+	 */
+	public static final String GEOLOCATION_SUFFIX = ".geolocation";
+
+	/**
+	 * @return A map of active-replica names to their parsed {@link Geolocation}
+	 *         as declared in properties like
+	 *         {@code active.<name>.geolocation="lat,lon"}. Entries with
+	 *         unparseable or out-of-range values are skipped with a
+	 *         {@code WARNING} log so one malformed line does not prevent the
+	 *         rest of the map from loading. Actives declared without a
+	 *         matching geolocation property do not appear in the map.
+	 */
+	public static Map<String, Geolocation> getActiveGeolocations() {
+		Map<String, Geolocation> map = new HashMap<String, Geolocation>();
+		Properties config = getAsProperties();
+
+		Set<String> keys = config.stringPropertyNames();
+		String geoKeyRegexPattern = String.format(
+				"^[ \t]*%s[a-zA-Z0-9\\-_]*%s$",
+				DEFAULT_SERVER_PREFIX, java.util.regex.Pattern.quote(GEOLOCATION_SUFFIX));
+		for (String key : keys) {
+			String trimmed = key.trim();
+			if (!trimmed.startsWith(DEFAULT_SERVER_PREFIX)
+					|| !trimmed.endsWith(GEOLOCATION_SUFFIX)
+					|| !key.matches(geoKeyRegexPattern)) {
+				continue;
+			}
+			String nodeName = trimmed
+					.substring(DEFAULT_SERVER_PREFIX.length(),
+							trimmed.length() - GEOLOCATION_SUFFIX.length());
+			String raw = config.getProperty(key);
+			Geolocation geo = Geolocation.parse(raw);
+			if (geo == null) {
+				getLogger().log(Level.WARNING,
+						"Ignoring malformed geolocation for {0}: {1}",
+						new Object[]{nodeName, raw});
+				continue;
+			}
+			map.put(nodeName, geo);
 		}
 		return map;
 	}

--- a/src/edu/umass/cs/nio/interfaces/Geolocation.java
+++ b/src/edu/umass/cs/nio/interfaces/Geolocation.java
@@ -1,0 +1,49 @@
+package edu.umass.cs.nio.interfaces;
+
+/**
+ * Typed geographic coordinate for a node. Latitude is in [-90, 90] degrees,
+ * longitude in [-180, 180] degrees.
+ */
+public record Geolocation(double latitude, double longitude) {
+
+  public Geolocation {
+    if (latitude < -90.0 || latitude > 90.0) {
+      throw new IllegalArgumentException("latitude out of range [-90, 90]: " + latitude);
+    }
+    if (longitude < -180.0 || longitude > 180.0) {
+      throw new IllegalArgumentException("longitude out of range [-180, 180]: " + longitude);
+    }
+  }
+
+  /**
+   * Parses {@code "lat,lon"}. Surrounding double quotes and whitespace are tolerated. Returns
+   * {@code null} on malformed input (non-numeric parts, wrong cardinality, out-of-range values,
+   * or {@code null} input) so callers can warn-and-skip.
+   */
+  public static Geolocation parse(String raw) {
+    if (raw == null) {
+      return null;
+    }
+    String trimmed = raw.trim();
+    if (trimmed.startsWith("\"") && trimmed.endsWith("\"") && trimmed.length() >= 2) {
+      trimmed = trimmed.substring(1, trimmed.length() - 1).trim();
+    }
+    String[] parts = trimmed.split(",");
+    if (parts.length != 2) {
+      return null;
+    }
+    try {
+      double lat = Double.parseDouble(parts[0].trim());
+      double lon = Double.parseDouble(parts[1].trim());
+      return new Geolocation(lat, lon);
+    } catch (IllegalArgumentException e) {
+      // covers both NumberFormatException (parseDouble) and range-check failures
+      return null;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return latitude + "," + longitude;
+  }
+}

--- a/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurableNode.java
@@ -108,7 +108,8 @@ public abstract class ReconfigurableNode<NodeIDType> {
         SQLReconfiguratorDB.dropState(server,
                 new ConsistentReconfigurableNodeConfig<String>(
                         new DefaultNodeConfig<String>(PaxosConfig.getActives(),
-                                ReconfigurationConfig.getReconfigurators())));
+                                ReconfigurationConfig.getReconfigurators(),
+                                PaxosConfig.getActiveGeolocations())));
 
     }
 
@@ -490,7 +491,8 @@ public abstract class ReconfigurableNode<NodeIDType> {
                             + ReconfigurableNode.class);
         ReconfigurableNodeConfig<String> nodeConfig = new DefaultNodeConfig<String>(
                 PaxosConfig.getActives(),
-                ReconfigurationConfig.getReconfigurators());
+                ReconfigurationConfig.getReconfigurators(),
+                PaxosConfig.getActiveGeolocations());
         PaxosConfig.sanityCheck(nodeConfig);
 
         if (Config.getGlobalBoolean(PC.EMULATE_DELAYS))
@@ -507,7 +509,8 @@ public abstract class ReconfigurableNode<NodeIDType> {
                                     new DefaultNodeConfig<String>(PaxosConfig
                                             .getActives(),
                                             ReconfigurationConfig
-                                                    .getReconfigurators())));
+                                                    .getReconfigurators(),
+                                            PaxosConfig.getActiveGeolocations())));
                 } catch (Exception e) {
                     /* ignore all exceptions as they correspond to non-local
                      * nodes */
@@ -551,7 +554,8 @@ public abstract class ReconfigurableNode<NodeIDType> {
                             // must use a different nodeConfig for each
                             new DefaultNodeConfig<String>(
                                     PaxosConfig.getActives(),
-                                    ReconfigurationConfig.getReconfigurators()),
+                                    ReconfigurationConfig.getReconfigurators(),
+                                    PaxosConfig.getActiveGeolocations()),
                             appArgs,
                             false
                     )

--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -46,6 +46,7 @@ import edu.umass.cs.nio.JSONMessenger;
 import edu.umass.cs.nio.MessageNIOTransport;
 import edu.umass.cs.nio.SSLDataProcessingWorker.SSL_MODES;
 import edu.umass.cs.nio.interfaces.AddressMessenger;
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.nio.interfaces.Messenger;
 import edu.umass.cs.nio.interfaces.PacketDemultiplexer;
 import edu.umass.cs.nio.interfaces.SSLMessenger;
@@ -1325,6 +1326,14 @@ public class Reconfigurator<NodeIDType> implements
         request.setReplicaAddresses(addresses);
         request.setReplicaHttpAddresses(httpAddresses);
         request.setPlacementEpochNumber(record.getEpoch());
+
+        // attach per-node geolocation parsed from the gigapaxos config (may be null
+        // if a node has no configured geolocation)
+        List<Geolocation> geolocations = new ArrayList<>();
+        for (NodeIDType node : nodeIds) {
+            geolocations.add(this.consistentNodeConfig.getNodeGeolocation(node));
+        }
+        request.setReplicaGeolocations(geolocations);
 
         // TODO: query the replica roles and metadata by contacting them
         // TODO: add service/name metadata in the reconfiguration record.

--- a/src/edu/umass/cs/reconfiguration/interfaces/ReconfigurableNodeConfig.java
+++ b/src/edu/umass/cs/reconfiguration/interfaces/ReconfigurableNodeConfig.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.nio.interfaces.NodeConfig;
 
 /**
@@ -61,6 +62,16 @@ public interface ReconfigurableNodeConfig<NodeIDType> extends
 							.getNodePort(node)));
 		}
 		return map;
+	}
+
+	/**
+	 * @param id
+	 * @return Geolocation for the given node, or {@code null} if none is
+	 *         configured. Default returns {@code null} so pre-existing
+	 *         implementations compile unchanged.
+	 */
+	default Geolocation getNodeGeolocation(NodeIDType id) {
+		return null;
 	}
 
 }

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/GetReplicaPlacementRequest.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/GetReplicaPlacementRequest.java
@@ -1,5 +1,6 @@
 package edu.umass.cs.reconfiguration.reconfigurationpackets;
 
+import edu.umass.cs.nio.interfaces.Geolocation;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -16,6 +17,7 @@ public class GetReplicaPlacementRequest extends ClientReconfigurationPacket {
     private List<String> replicaHttpAddresses;
     private List<String> replicaRoles;
     private List<String> replicaMetadata;
+    private List<Geolocation> replicaGeolocations;
     private String serviceMetadata;
 
     public GetReplicaPlacementRequest(InetSocketAddress initiator, String name) {
@@ -26,6 +28,7 @@ public class GetReplicaPlacementRequest extends ClientReconfigurationPacket {
         replicaHttpAddresses = new ArrayList<>();
         replicaRoles = new ArrayList<>();
         replicaMetadata = new ArrayList<>();
+        replicaGeolocations = new ArrayList<>();
         serviceMetadata = "";
     }
 
@@ -53,6 +56,10 @@ public class GetReplicaPlacementRequest extends ClientReconfigurationPacket {
         this.replicaMetadata = replicaMetadata;
     }
 
+    public void setReplicaGeolocations(List<Geolocation> replicaGeolocations) {
+        this.replicaGeolocations = replicaGeolocations;
+    }
+
     public void setServiceMetadata(String serviceMetadata) {
         this.serviceMetadata = serviceMetadata;
     }
@@ -71,6 +78,15 @@ public class GetReplicaPlacementRequest extends ClientReconfigurationPacket {
                     replicaHttpAddresses.size() >= i+1 ? replicaHttpAddresses.get(i) : "");
             nodeInfo.put("ROLE", replicaRoles.size() >= i+1 ? replicaRoles.get(i) : "");
             nodeInfo.put("METADATA", replicaMetadata.size() >= i+1 ? replicaMetadata.get(i) : "");
+            Geolocation geo = replicaGeolocations.size() >= i+1 ? replicaGeolocations.get(i) : null;
+            if (geo != null) {
+                JSONObject geoJson = new JSONObject();
+                geoJson.put("LATITUDE", geo.latitude());
+                geoJson.put("LONGITUDE", geo.longitude());
+                nodeInfo.put("GEOLOCATION", geoJson);
+            } else {
+                nodeInfo.put("GEOLOCATION", JSONObject.NULL);
+            }
             nodeArray.put(i, nodeInfo);
         }
         dataJsonObject.put("NODES", nodeArray);

--- a/src/edu/umass/cs/reconfiguration/reconfigurationutils/ConsistentReconfigurableNodeConfig.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationutils/ConsistentReconfigurableNodeConfig.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.nio.nioutils.RTTEstimator;
 import edu.umass.cs.reconfiguration.ReconfigurationConfig;
 import edu.umass.cs.reconfiguration.ReconfigurationConfig.RC;
@@ -116,6 +117,11 @@ public class ConsistentReconfigurableNodeConfig<NodeIDType> extends
 	@Override
 	public Set<NodeIDType> getActiveReplicas() {
 		return this.nodeConfig.getActiveReplicas();
+	}
+
+	@Override
+	public Geolocation getNodeGeolocation(NodeIDType id) {
+		return this.nodeConfig.getNodeGeolocation(id);
 	}
 
 	/**

--- a/src/edu/umass/cs/reconfiguration/reconfigurationutils/DefaultNodeConfig.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationutils/DefaultNodeConfig.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.json.JSONArray;
 import org.json.JSONException;
 
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.reconfiguration.interfaces.ModifiableReconfigurableNodeConfig;
 
 /**
@@ -25,6 +26,7 @@ public class DefaultNodeConfig<NodeIDType> implements
 
 	final ConcurrentHashMap<NodeIDType, InetSocketAddress> actives = new ConcurrentHashMap<NodeIDType, InetSocketAddress>();
 	final ConcurrentHashMap<NodeIDType, InetSocketAddress> reconfigurators = new ConcurrentHashMap<NodeIDType, InetSocketAddress>();
+	final ConcurrentHashMap<NodeIDType, Geolocation> geolocations = new ConcurrentHashMap<NodeIDType, Geolocation>();
 
 	/**
 	 * @param actives
@@ -32,8 +34,21 @@ public class DefaultNodeConfig<NodeIDType> implements
 	 */
 	public DefaultNodeConfig(Map<NodeIDType, InetSocketAddress> actives,
 			Map<NodeIDType, InetSocketAddress> reconfigurators) {
+		this(actives, reconfigurators, Collections.emptyMap());
+	}
+
+	/**
+	 * @param actives
+	 * @param reconfigurators
+	 * @param geolocations Per-node geolocation; nodes with no entry will
+	 *        return {@code null} from {@link #getNodeGeolocation}.
+	 */
+	public DefaultNodeConfig(Map<NodeIDType, InetSocketAddress> actives,
+			Map<NodeIDType, InetSocketAddress> reconfigurators,
+			Map<NodeIDType, Geolocation> geolocations) {
 		this.actives.putAll(actives);
 		this.reconfigurators.putAll(reconfigurators);
+		this.geolocations.putAll(geolocations);
 	}
 
 	@Override
@@ -83,6 +98,11 @@ public class DefaultNodeConfig<NodeIDType> implements
 		Set<NodeIDType> nodes = this.getActiveReplicas();
 		nodes.addAll(this.getReconfigurators());
 		return nodes;
+	}
+
+	@Override
+	public Geolocation getNodeGeolocation(NodeIDType id) {
+		return this.geolocations.get(id);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/edu/umass/cs/reconfiguration/reconfigurationutils/SimpleReconfiguratorNodeConfig.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationutils/SimpleReconfiguratorNodeConfig.java
@@ -111,6 +111,11 @@ public class SimpleReconfiguratorNodeConfig<NodeIDType> implements
 	}
 
 	@Override
+	public edu.umass.cs.nio.interfaces.Geolocation getNodeGeolocation(NodeIDType id) {
+		return this.nodeConfig.getNodeGeolocation(id);
+	}
+
+	@Override
 	public NodeIDType valueOf(String strValue) {
 		return this.nodeConfig.valueOf(strValue);
 	}

--- a/xdn-cli/cmd/service.go
+++ b/xdn-cli/cmd/service.go
@@ -98,6 +98,7 @@ var ServiceInfoCmd = &cobra.Command{
 		//        "ID": "AR1",
 		//        "ROLE": "replica",										// This is not implemented yet (TODO)
 		//        "METADATA": "Created 2 minutes ago; Up 2 minutes", 		// This is not implemented yet (TODO)
+		//        "GEOLOCATION": {"LATITUDE": 3.1490, "LONGITUDE": 37.0425}, // null if node has no configured geolocation
 		//      },
 		//      {
 		//        "ADDRESS": "/127.0.0.1:2002",
@@ -216,6 +217,14 @@ var ServiceInfoCmd = &cobra.Command{
 					}
 				}
 			}
+			geoStr := ""
+			if geoIf, ok := node["GEOLOCATION"].(map[string]interface{}); ok {
+				lat, latOK := geoIf["LATITUDE"].(float64)
+				lon, lonOK := geoIf["LONGITUDE"].(float64)
+				if latOK && lonOK {
+					geoStr = fmt.Sprintf("%.4f,%.4f", lat, lon)
+				}
+			}
 			replicas = append(replicas, placementReplica{
 				nodeID:      nodeId,
 				host:        host,
@@ -223,6 +232,7 @@ var ServiceInfoCmd = &cobra.Command{
 				tcpPort:     port,
 				httpPort:    httpPort,
 				httpBaseURL: httpBaseURL,
+				geolocation: geoStr,
 			})
 		}
 		numReplicas := len(replicas)
@@ -298,7 +308,7 @@ var ServiceInfoCmd = &cobra.Command{
 		fmt.Printf(" %s\n", titleColorPrint.Sprintf("Current replicas placement (epoch=%s):", epochNumberStr))
 
 		type replicaRow struct {
-			machineID, ipAddress, webPort, role, created, status, svcReplicaURL string
+			geolocation, machineID, ipAddress, webPort, role, created, status, svcReplicaURL string
 		}
 		rows := make([]replicaRow, len(replicas))
 		for idx, r := range replicas {
@@ -309,6 +319,10 @@ var ServiceInfoCmd = &cobra.Command{
 			webPortStr := "-"
 			if r.httpPort != 0 {
 				webPortStr = strconv.Itoa(r.httpPort)
+			}
+			geoStr := "-"
+			if r.geolocation != "" {
+				geoStr = r.geolocation
 			}
 			svcReplicaURLStr := "-"
 			if r.httpBaseURL != "" {
@@ -327,10 +341,10 @@ var ServiceInfoCmd = &cobra.Command{
 				}
 			}
 			rows[idx] = replicaRow{
-				r.nodeID, displayAddr, webPortStr, roleStr, createdStr, statusStr, svcReplicaURLStr,
+				geoStr, r.nodeID, displayAddr, webPortStr, roleStr, createdStr, statusStr, svcReplicaURLStr,
 			}
 		}
-		wID, wIP, wPort := len("NODE ID"), len("IP ADDRESS"), len("WEB PORT")
+		wID, wIP, wGeo, wPort := len("NODE ID"), len("IP ADDRESS"), len("GEOLOCATION"), len("WEB PORT")
 		wRole, wCreated, wStatus := len("ROLE"), len("CREATED"), len("STATUS")
 		wURL := len("SVC REPLICA URL")
 		for _, row := range rows {
@@ -339,6 +353,9 @@ var ServiceInfoCmd = &cobra.Command{
 			}
 			if n := len(row.ipAddress); n > wIP {
 				wIP = n
+			}
+			if n := len(row.geolocation); n > wGeo {
+				wGeo = n
 			}
 			if n := len(row.webPort); n > wPort {
 				wPort = n
@@ -356,7 +373,8 @@ var ServiceInfoCmd = &cobra.Command{
 				wURL = n
 			}
 		}
-		fmt.Printf("  | %s | %s | %s | %s | %s | %s | %s |\n",
+		fmt.Printf("  | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+			columnColorPrint.Sprintf("%-*s", wGeo, "GEOLOCATION"),
 			columnColorPrint.Sprintf("%-*s", wID, "NODE ID"),
 			columnColorPrint.Sprintf("%-*s", wIP, "IP ADDRESS"),
 			columnColorPrint.Sprintf("%-*s", wPort, "WEB PORT"),
@@ -367,9 +385,10 @@ var ServiceInfoCmd = &cobra.Command{
 		for _, row := range rows {
 			roleCell := colorForRole(row.role).Sprint(fmt.Sprintf("%-*s", wRole, row.role))
 			statusCell := colorForStatus(row.status).Sprint(fmt.Sprintf("%-*s", wStatus, row.status))
-			fmt.Printf("  | %-*s | %-*s | %-*s | %s | %-*s | %s | %-*s |\n",
-				wID, row.machineID, wIP, row.ipAddress, wPort, row.webPort,
-				roleCell, wCreated, row.created, statusCell, wURL, row.svcReplicaURL)
+			fmt.Printf("  | %-*s | %-*s | %-*s | %-*s | %s | %-*s | %s | %-*s |\n",
+				wGeo, row.geolocation, wID, row.machineID, wIP, row.ipAddress,
+				wPort, row.webPort, roleCell, wCreated, row.created,
+				statusCell, wURL, row.svcReplicaURL)
 		}
 
 		if primaryInfo == nil {
@@ -835,6 +854,7 @@ type placementReplica struct {
 	tcpPort     int
 	httpPort    int    // 0 if HTTP_ADDRESS missing from the RC response
 	httpBaseURL string // empty if HTTP_ADDRESS missing from the RC response
+	geolocation string // "lat,lon" display string; empty if not configured
 }
 
 type replicaInfo struct {


### PR DESCRIPTION
 - Parse `active.<name>.geolocation="lat,lon"` from gigapaxos `.properties`
    into a typed `Geolocation(double lat, double lon)` record and store it
    per-node in the reconfigurator's `NodeConfig`. Malformed or out-of-range
    values log a single WARN and are skipped rather than crashing startup.
  - Emit geolocation as a structured `{"LATITUDE": ..., "LONGITUDE": ...}`
    object on the `/api/v2/services/{name}/placement` response (or
    `null` when a node has no configured geolocation).
  - Add a `GEOLOCATION` column to `xdn service info`, rendered as the
    first column left of `NODE ID`. Falls back to `-` when absent.
  - Lays groundwork for demand-aware replica placement: `XdnGeoDemandProfiler`
    and `XdnReplicaPlacementProfile` will consume `NodeConfig.getNodeGeolocation`
    in a follow-up PR (the hardcoded `serverLocations` TODO in
    `XdnGeoDemandProfiler.java:52-65` can finally go away).