### PR TITLE
parse client geolocation from X-Client-Location header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,13 @@ Supported via `ConsistencyModel`: linearizability (default), sequential, causal,
 eventual, pram, and client-centric variants. 
 Each maps to a coordinator in the corresponding protocol package.
 
+### Node Geolocation
+Each node's `(lat, lon)` can be set in the gigapaxos properties file (see
+`conf/gigapaxos.xdnlat.template.properties`) and is parsed via
+`PaxosConfig` / `DefaultNodeConfig` into the `edu.umass.cs.nio.interfaces.Geolocation`
+type. It flows through `ReconfigurableNodeConfig` and `Reconfigurator` into
+`GetReplicaPlacementRequest`, and is surfaced by `xdn service info`.
+
 ### `xdn-cli` subcommands (`xdn-cli/cmd/`)
 Cobra-based CLI. Top-level verbs include `launch`, `status`, `check`, and the `service` command group. `service` covers: `info`, `destroy`, `move` (relocate a service to new replica hosts; drives synchronous paxos leader change), `leader` (inspect/set the paxos leader). `launch` accepts `--num-replicas`, `--min-replicas`, `--max-replicas` in addition to `--image`, `--state`, `--deterministic`, etc. Mutating subcommands prompt for yes/no confirmation on stdin.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ To deploy a stateful service with this existing provider, simply follow the step
 1. Start the control plane (i.e., Reconfigurator/RC) and the edge servers (i.e., ActiveReplica/AR), 
    using the default configuration.
    ```bash
-   ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.local.properties start all
+   ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.properties start all
    ```
    Which will start these 4 local servers:
     - 1 Reconfigurator at localhost:3000.
@@ -172,7 +172,7 @@ To deploy a stateful service with this existing provider, simply follow the step
 
 > To stop xdn, we need to stop the Reconfigurator and ActiveReplicas and clean all the state:
 > ```bash
->  sudo ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.local.properties forceclear all
+>  sudo ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.properties forceclear all
 >  sudo rm -rf /tmp/gigapaxos
 >  sudo rm -rf /tmp/xdn
 > ```

--- a/eval/xdn-latency-proxy/go/main.go
+++ b/eval/xdn-latency-proxy/go/main.go
@@ -15,9 +15,10 @@ import (
 
 // Proxy is our proxy handler that holds shared config data.
 type Proxy struct {
-	serverLocations map[string]ServerLocation
-	slowdownFactor  float64
-	httpClient      *http.Client
+	serverLocations       map[string]ServerLocation
+	slowdownFactor        float64
+	forwardClientLocation bool
+	httpClient            *http.Client
 }
 
 // ServeHTTP implements the http.Handler interface, handling each request.
@@ -66,9 +67,14 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	delayCalcDone := time.Now()
 
-	// Remove the special headers so they won't be forwarded upstream
+	// Remove the special headers so they won't be forwarded upstream.
+	// X-Request-Delay is always proxy-only. X-Client-Location is stripped by
+	// default (legacy behavior); set -forward-client-location to pass it
+	// through so the upstream XDN replica can parse it for demand profiling.
 	r.Header.Del("X-Request-Delay")
-	r.Header.Del("X-Client-Location")
+	if !p.forwardClientLocation {
+		r.Header.Del("X-Client-Location")
+	}
 
 	// Emulate the delay with sleep.
 	if requestDelayNs > 0 {
@@ -144,6 +150,9 @@ func main() {
 		os.Exit(1)
 	}
 	configPath := flag.String("config", "", "Path to JSON config file")
+	forwardClientLoc := flag.Bool("forward-client-location", false,
+		"If true, pass X-Client-Location through to the upstream server. "+
+			"Default: strip it (legacy behavior).")
 	flag.Parse()
 	if *configPath == "" {
 		flag.Usage()
@@ -170,9 +179,13 @@ func main() {
 
 	// Prepare our proxy and attach it to the default server mux.
 	proxy := &Proxy{
-		serverLocations: cfg.ServerLocations,
-		slowdownFactor:  cfg.SlowdownFactor,
-		httpClient:      client,
+		serverLocations:       cfg.ServerLocations,
+		slowdownFactor:        cfg.SlowdownFactor,
+		forwardClientLocation: *forwardClientLoc,
+		httpClient:            client,
+	}
+	if proxy.forwardClientLocation {
+		log.Printf(" Forwarding X-Client-Location header to upstream")
 	}
 	http.Handle("/", proxy)
 

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -2442,6 +2442,10 @@ public class XdnGigapaxosApp
             httpRequest.getHttpRequest().uri(),
             copiedContent);
     copy.headers().set(httpRequest.getHttpRequest().headers());
+    // Drop XDN-layer signals from the outbound copy so the containerized
+    // service never sees them. The header is preserved on the original
+    // request so followers can still reconstruct the parsed geolocation.
+    copy.headers().remove(XdnHttpRequest.X_CLIENT_LOCATION_HEADER);
     if (httpRequest.getHttpRequest() instanceof FullHttpRequest fullHttpRequest) {
       copy.trailingHeaders().set(fullHttpRequest.trailingHeaders());
     }

--- a/src/edu/umass/cs/xdn/proto/XdnHttpRequestProto.java
+++ b/src/edu/umass/cs/xdn/proto/XdnHttpRequestProto.java
@@ -243,6 +243,50 @@ public final class XdnHttpRequestProto {
      */
     edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.ResponseOrBuilder
         getResponseOrBuilder();
+
+    /**
+     *
+     *
+     * <pre>
+     * End-user/client geolocation. Populated at the entry replica from the
+     * X-Client-Location HTTP header; replaces the raw-header wire encoding
+     * so followers don't pay the ~40-byte header cost per request.
+     * </pre>
+     *
+     * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+     *
+     * @return Whether the clientGeolocation field is set.
+     */
+    boolean hasClientGeolocation();
+
+    /**
+     *
+     *
+     * <pre>
+     * End-user/client geolocation. Populated at the entry replica from the
+     * X-Client-Location HTTP header; replaces the raw-header wire encoding
+     * so followers don't pay the ~40-byte header cost per request.
+     * </pre>
+     *
+     * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+     *
+     * @return The clientGeolocation.
+     */
+    edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation getClientGeolocation();
+
+    /**
+     *
+     *
+     * <pre>
+     * End-user/client geolocation. Populated at the entry replica from the
+     * X-Client-Location HTTP header; replaces the raw-header wire encoding
+     * so followers don't pay the ~40-byte header cost per request.
+     * </pre>
+     *
+     * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+     */
+    edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder
+        getClientGeolocationOrBuilder();
   }
 
   /** Protobuf type {@code xdn.XdnHttpRequest} */
@@ -1291,6 +1335,591 @@ public final class XdnHttpRequestProto {
 
       @java.lang.Override
       public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Header
+          getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+    }
+
+    public interface GeolocationOrBuilder
+        extends
+        // @@protoc_insertion_point(interface_extends:xdn.XdnHttpRequest.Geolocation)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>double latitude = 1;</code>
+       *
+       * @return The latitude.
+       */
+      double getLatitude();
+
+      /**
+       * <code>double longitude = 2;</code>
+       *
+       * @return The longitude.
+       */
+      double getLongitude();
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Geographic location as (latitude, longitude) in decimal degrees.
+     * Range validation lives on the Java side (Geolocation record); the
+     * proto itself just carries raw doubles.
+     * </pre>
+     *
+     * Protobuf type {@code xdn.XdnHttpRequest.Geolocation}
+     */
+    public static final class Geolocation extends com.google.protobuf.GeneratedMessage
+        implements
+        // @@protoc_insertion_point(message_implements:xdn.XdnHttpRequest.Geolocation)
+        GeolocationOrBuilder {
+      private static final long serialVersionUID = 0L;
+
+      static {
+        com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+            com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+            /* major= */ 4,
+            /* minor= */ 28,
+            /* patch= */ 2,
+            /* suffix= */ "",
+            Geolocation.class.getName());
+      }
+
+      // Use Geolocation.newBuilder() to construct.
+      private Geolocation(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+        super(builder);
+      }
+
+      private Geolocation() {}
+
+      public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+        return edu.umass.cs.xdn.proto.XdnHttpRequestProto
+            .internal_static_xdn_XdnHttpRequest_Geolocation_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return edu.umass.cs.xdn.proto.XdnHttpRequestProto
+            .internal_static_xdn_XdnHttpRequest_Geolocation_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.class,
+                edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder
+                    .class);
+      }
+
+      public static final int LATITUDE_FIELD_NUMBER = 1;
+      private double latitude_ = 0D;
+
+      /**
+       * <code>double latitude = 1;</code>
+       *
+       * @return The latitude.
+       */
+      @java.lang.Override
+      public double getLatitude() {
+        return latitude_;
+      }
+
+      public static final int LONGITUDE_FIELD_NUMBER = 2;
+      private double longitude_ = 0D;
+
+      /**
+       * <code>double longitude = 2;</code>
+       *
+       * @return The longitude.
+       */
+      @java.lang.Override
+      public double getLongitude() {
+        return longitude_;
+      }
+
+      private byte memoizedIsInitialized = -1;
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
+        if (java.lang.Double.doubleToRawLongBits(latitude_) != 0) {
+          output.writeDouble(1, latitude_);
+        }
+        if (java.lang.Double.doubleToRawLongBits(longitude_) != 0) {
+          output.writeDouble(2, longitude_);
+        }
+        getUnknownFields().writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (java.lang.Double.doubleToRawLongBits(latitude_) != 0) {
+          size += com.google.protobuf.CodedOutputStream.computeDoubleSize(1, latitude_);
+        }
+        if (java.lang.Double.doubleToRawLongBits(longitude_) != 0) {
+          size += com.google.protobuf.CodedOutputStream.computeDoubleSize(2, longitude_);
+        }
+        size += getUnknownFields().getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+          return true;
+        }
+        if (!(obj
+            instanceof edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation)) {
+          return super.equals(obj);
+        }
+        edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation other =
+            (edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation) obj;
+
+        if (java.lang.Double.doubleToLongBits(getLatitude())
+            != java.lang.Double.doubleToLongBits(other.getLatitude())) return false;
+        if (java.lang.Double.doubleToLongBits(getLongitude())
+            != java.lang.Double.doubleToLongBits(other.getLongitude())) return false;
+        if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+        return true;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        hash = (37 * hash) + LATITUDE_FIELD_NUMBER;
+        hash =
+            (53 * hash)
+                + com.google.protobuf.Internal.hashLong(
+                    java.lang.Double.doubleToLongBits(getLatitude()));
+        hash = (37 * hash) + LONGITUDE_FIELD_NUMBER;
+        hash =
+            (53 * hash)
+                + com.google.protobuf.Internal.hashLong(
+                    java.lang.Double.doubleToLongBits(getLongitude()));
+        hash = (29 * hash) + getUnknownFields().hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          java.io.InputStream input) throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessage.parseWithIOException(PARSER, input);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessage.parseWithIOException(
+            PARSER, input, extensionRegistry);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+          parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessage.parseDelimitedWithIOException(PARSER, input);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+          parseDelimitedFrom(
+              java.io.InputStream input,
+              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+              throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessage.parseDelimitedWithIOException(
+            PARSER, input, extensionRegistry);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          com.google.protobuf.CodedInputStream input) throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessage.parseWithIOException(PARSER, input);
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessage.parseWithIOException(
+            PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() {
+        return newBuilder();
+      }
+
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+
+      public static Builder newBuilder(
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * Geographic location as (latitude, longitude) in decimal degrees.
+       * Range validation lives on the Java side (Geolocation record); the
+       * proto itself just carries raw doubles.
+       * </pre>
+       *
+       * Protobuf type {@code xdn.XdnHttpRequest.Geolocation}
+       */
+      public static final class Builder
+          extends com.google.protobuf.GeneratedMessage.Builder<Builder>
+          implements
+          // @@protoc_insertion_point(builder_implements:xdn.XdnHttpRequest.Geolocation)
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
+          return edu.umass.cs.xdn.proto.XdnHttpRequestProto
+              .internal_static_xdn_XdnHttpRequest_Geolocation_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return edu.umass.cs.xdn.proto.XdnHttpRequestProto
+              .internal_static_xdn_XdnHttpRequest_Geolocation_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.class,
+                  edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder
+                      .class);
+        }
+
+        // Construct using
+        // edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.newBuilder()
+        private Builder() {}
+
+        private Builder(com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+          super(parent);
+        }
+
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          bitField0_ = 0;
+          latitude_ = 0D;
+          longitude_ = 0D;
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
+          return edu.umass.cs.xdn.proto.XdnHttpRequestProto
+              .internal_static_xdn_XdnHttpRequest_Geolocation_descriptor;
+        }
+
+        @java.lang.Override
+        public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+            getDefaultInstanceForType() {
+          return edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+              .getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation build() {
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation result =
+              buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+            buildPartial() {
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation result =
+              new edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation(this);
+          if (bitField0_ != 0) {
+            buildPartial0(result);
+          }
+          onBuilt();
+          return result;
+        }
+
+        private void buildPartial0(
+            edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation result) {
+          int from_bitField0_ = bitField0_;
+          if (((from_bitField0_ & 0x00000001) != 0)) {
+            result.latitude_ = latitude_;
+          }
+          if (((from_bitField0_ & 0x00000002) != 0)) {
+            result.longitude_ = longitude_;
+          }
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other
+              instanceof edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation) {
+            return mergeFrom(
+                (edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation) other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(
+            edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation other) {
+          if (other
+              == edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+                  .getDefaultInstance()) return this;
+          if (other.getLatitude() != 0D) {
+            setLatitude(other.getLatitude());
+          }
+          if (other.getLongitude() != 0D) {
+            setLongitude(other.getLongitude());
+          }
+          this.mergeUnknownFields(other.getUnknownFields());
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          if (extensionRegistry == null) {
+            throw new java.lang.NullPointerException();
+          }
+          try {
+            boolean done = false;
+            while (!done) {
+              int tag = input.readTag();
+              switch (tag) {
+                case 0:
+                  done = true;
+                  break;
+                case 9:
+                  {
+                    latitude_ = input.readDouble();
+                    bitField0_ |= 0x00000001;
+                    break;
+                  } // case 9
+                case 17:
+                  {
+                    longitude_ = input.readDouble();
+                    bitField0_ |= 0x00000002;
+                    break;
+                  } // case 17
+                default:
+                  {
+                    if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                      done = true; // was an endgroup tag
+                    }
+                    break;
+                  } // default:
+              } // switch (tag)
+            } // while (!done)
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            throw e.unwrapIOException();
+          } finally {
+            onChanged();
+          } // finally
+          return this;
+        }
+
+        private int bitField0_;
+
+        private double latitude_;
+
+        /**
+         * <code>double latitude = 1;</code>
+         *
+         * @return The latitude.
+         */
+        @java.lang.Override
+        public double getLatitude() {
+          return latitude_;
+        }
+
+        /**
+         * <code>double latitude = 1;</code>
+         *
+         * @param value The latitude to set.
+         * @return This builder for chaining.
+         */
+        public Builder setLatitude(double value) {
+
+          latitude_ = value;
+          bitField0_ |= 0x00000001;
+          onChanged();
+          return this;
+        }
+
+        /**
+         * <code>double latitude = 1;</code>
+         *
+         * @return This builder for chaining.
+         */
+        public Builder clearLatitude() {
+          bitField0_ = (bitField0_ & ~0x00000001);
+          latitude_ = 0D;
+          onChanged();
+          return this;
+        }
+
+        private double longitude_;
+
+        /**
+         * <code>double longitude = 2;</code>
+         *
+         * @return The longitude.
+         */
+        @java.lang.Override
+        public double getLongitude() {
+          return longitude_;
+        }
+
+        /**
+         * <code>double longitude = 2;</code>
+         *
+         * @param value The longitude to set.
+         * @return This builder for chaining.
+         */
+        public Builder setLongitude(double value) {
+
+          longitude_ = value;
+          bitField0_ |= 0x00000002;
+          onChanged();
+          return this;
+        }
+
+        /**
+         * <code>double longitude = 2;</code>
+         *
+         * @return This builder for chaining.
+         */
+        public Builder clearLongitude() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          longitude_ = 0D;
+          onChanged();
+          return this;
+        }
+
+        // @@protoc_insertion_point(builder_scope:xdn.XdnHttpRequest.Geolocation)
+      }
+
+      // @@protoc_insertion_point(class_scope:xdn.XdnHttpRequest.Geolocation)
+      private static final edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+          DEFAULT_INSTANCE;
+
+      static {
+        DEFAULT_INSTANCE =
+            new edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation();
+      }
+
+      public static edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+          getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      private static final com.google.protobuf.Parser<Geolocation> PARSER =
+          new com.google.protobuf.AbstractParser<Geolocation>() {
+            @java.lang.Override
+            public Geolocation parsePartialFrom(
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+              Builder builder = newBuilder();
+              try {
+                builder.mergeFrom(input, extensionRegistry);
+              } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                throw e.setUnfinishedMessage(builder.buildPartial());
+              } catch (com.google.protobuf.UninitializedMessageException e) {
+                throw e.asInvalidProtocolBufferException()
+                    .setUnfinishedMessage(builder.buildPartial());
+              } catch (java.io.IOException e) {
+                throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                    .setUnfinishedMessage(builder.buildPartial());
+              }
+              return builder.buildPartial();
+            }
+          };
+
+      public static com.google.protobuf.Parser<Geolocation> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Geolocation> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
           getDefaultInstanceForType() {
         return DEFAULT_INSTANCE;
       }
@@ -3117,6 +3746,70 @@ public final class XdnHttpRequestProto {
           : response_;
     }
 
+    public static final int CLIENT_GEOLOCATION_FIELD_NUMBER = 8;
+    private edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+        clientGeolocation_;
+
+    /**
+     *
+     *
+     * <pre>
+     * End-user/client geolocation. Populated at the entry replica from the
+     * X-Client-Location HTTP header; replaces the raw-header wire encoding
+     * so followers don't pay the ~40-byte header cost per request.
+     * </pre>
+     *
+     * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+     *
+     * @return Whether the clientGeolocation field is set.
+     */
+    @java.lang.Override
+    public boolean hasClientGeolocation() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * End-user/client geolocation. Populated at the entry replica from the
+     * X-Client-Location HTTP header; replaces the raw-header wire encoding
+     * so followers don't pay the ~40-byte header cost per request.
+     * </pre>
+     *
+     * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+     *
+     * @return The clientGeolocation.
+     */
+    @java.lang.Override
+    public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+        getClientGeolocation() {
+      return clientGeolocation_ == null
+          ? edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+              .getDefaultInstance()
+          : clientGeolocation_;
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * End-user/client geolocation. Populated at the entry replica from the
+     * X-Client-Location HTTP header; replaces the raw-header wire encoding
+     * so followers don't pay the ~40-byte header cost per request.
+     * </pre>
+     *
+     * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+     */
+    @java.lang.Override
+    public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder
+        getClientGeolocationOrBuilder() {
+      return clientGeolocation_ == null
+          ? edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+              .getDefaultInstance()
+          : clientGeolocation_;
+    }
+
     private byte memoizedIsInitialized = -1;
 
     @java.lang.Override
@@ -3155,6 +3848,9 @@ public final class XdnHttpRequestProto {
       if (((bitField0_ & 0x00000002) != 0)) {
         output.writeMessage(7, getResponse());
       }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        output.writeMessage(8, getClientGeolocation());
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -3188,6 +3884,9 @@ public final class XdnHttpRequestProto {
       if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.CodedOutputStream.computeMessageSize(7, getResponse());
       }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.CodedOutputStream.computeMessageSize(8, getClientGeolocation());
+      }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
       return size;
@@ -3216,6 +3915,10 @@ public final class XdnHttpRequestProto {
       if (hasResponse() != other.hasResponse()) return false;
       if (hasResponse()) {
         if (!getResponse().equals(other.getResponse())) return false;
+      }
+      if (hasClientGeolocation() != other.hasClientGeolocation()) return false;
+      if (hasClientGeolocation()) {
+        if (!getClientGeolocation().equals(other.getClientGeolocation())) return false;
       }
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
@@ -3247,6 +3950,10 @@ public final class XdnHttpRequestProto {
       if (hasResponse()) {
         hash = (37 * hash) + RESPONSE_FIELD_NUMBER;
         hash = (53 * hash) + getResponse().hashCode();
+      }
+      if (hasClientGeolocation()) {
+        hash = (37 * hash) + CLIENT_GEOLOCATION_FIELD_NUMBER;
+        hash = (53 * hash) + getClientGeolocation().hashCode();
       }
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
@@ -3384,6 +4091,7 @@ public final class XdnHttpRequestProto {
         if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
           getRequestHeadersFieldBuilder();
           getResponseFieldBuilder();
+          getClientGeolocationFieldBuilder();
         }
       }
 
@@ -3407,6 +4115,11 @@ public final class XdnHttpRequestProto {
         if (responseBuilder_ != null) {
           responseBuilder_.dispose();
           responseBuilder_ = null;
+        }
+        clientGeolocation_ = null;
+        if (clientGeolocationBuilder_ != null) {
+          clientGeolocationBuilder_.dispose();
+          clientGeolocationBuilder_ = null;
         }
         return this;
       }
@@ -3479,6 +4192,13 @@ public final class XdnHttpRequestProto {
           result.response_ = responseBuilder_ == null ? response_ : responseBuilder_.build();
           to_bitField0_ |= 0x00000002;
         }
+        if (((from_bitField0_ & 0x00000080) != 0)) {
+          result.clientGeolocation_ =
+              clientGeolocationBuilder_ == null
+                  ? clientGeolocation_
+                  : clientGeolocationBuilder_.build();
+          to_bitField0_ |= 0x00000004;
+        }
         result.bitField0_ |= to_bitField0_;
       }
 
@@ -3541,6 +4261,9 @@ public final class XdnHttpRequestProto {
         }
         if (other.hasResponse()) {
           mergeResponse(other.getResponse());
+        }
+        if (other.hasClientGeolocation()) {
+          mergeClientGeolocation(other.getClientGeolocation());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -3618,6 +4341,13 @@ public final class XdnHttpRequestProto {
                   bitField0_ |= 0x00000040;
                   break;
                 } // case 58
+              case 66:
+                {
+                  input.readMessage(
+                      getClientGeolocationFieldBuilder().getBuilder(), extensionRegistry);
+                  bitField0_ |= 0x00000080;
+                  break;
+                } // case 66
               default:
                 {
                   if (!super.parseUnknownField(input, extensionRegistry, tag)) {
@@ -4679,6 +5409,230 @@ public final class XdnHttpRequestProto {
         return responseBuilder_;
       }
 
+      private edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+          clientGeolocation_;
+      private com.google.protobuf.SingleFieldBuilder<
+              edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation,
+              edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder,
+              edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder>
+          clientGeolocationBuilder_;
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       *
+       * @return Whether the clientGeolocation field is set.
+       */
+      public boolean hasClientGeolocation() {
+        return ((bitField0_ & 0x00000080) != 0);
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       *
+       * @return The clientGeolocation.
+       */
+      public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+          getClientGeolocation() {
+        if (clientGeolocationBuilder_ == null) {
+          return clientGeolocation_ == null
+              ? edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+                  .getDefaultInstance()
+              : clientGeolocation_;
+        } else {
+          return clientGeolocationBuilder_.getMessage();
+        }
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      public Builder setClientGeolocation(
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation value) {
+        if (clientGeolocationBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          clientGeolocation_ = value;
+        } else {
+          clientGeolocationBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return this;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      public Builder setClientGeolocation(
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder
+              builderForValue) {
+        if (clientGeolocationBuilder_ == null) {
+          clientGeolocation_ = builderForValue.build();
+        } else {
+          clientGeolocationBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return this;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      public Builder mergeClientGeolocation(
+          edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation value) {
+        if (clientGeolocationBuilder_ == null) {
+          if (((bitField0_ & 0x00000080) != 0)
+              && clientGeolocation_ != null
+              && clientGeolocation_
+                  != edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+                      .getDefaultInstance()) {
+            getClientGeolocationBuilder().mergeFrom(value);
+          } else {
+            clientGeolocation_ = value;
+          }
+        } else {
+          clientGeolocationBuilder_.mergeFrom(value);
+        }
+        if (clientGeolocation_ != null) {
+          bitField0_ |= 0x00000080;
+          onChanged();
+        }
+        return this;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      public Builder clearClientGeolocation() {
+        bitField0_ = (bitField0_ & ~0x00000080);
+        clientGeolocation_ = null;
+        if (clientGeolocationBuilder_ != null) {
+          clientGeolocationBuilder_.dispose();
+          clientGeolocationBuilder_ = null;
+        }
+        onChanged();
+        return this;
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder
+          getClientGeolocationBuilder() {
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return getClientGeolocationFieldBuilder().getBuilder();
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      public edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder
+          getClientGeolocationOrBuilder() {
+        if (clientGeolocationBuilder_ != null) {
+          return clientGeolocationBuilder_.getMessageOrBuilder();
+        } else {
+          return clientGeolocation_ == null
+              ? edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation
+                  .getDefaultInstance()
+              : clientGeolocation_;
+        }
+      }
+
+      /**
+       *
+       *
+       * <pre>
+       * End-user/client geolocation. Populated at the entry replica from the
+       * X-Client-Location HTTP header; replaces the raw-header wire encoding
+       * so followers don't pay the ~40-byte header cost per request.
+       * </pre>
+       *
+       * <code>optional .xdn.XdnHttpRequest.Geolocation client_geolocation = 8;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+              edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation,
+              edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder,
+              edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder>
+          getClientGeolocationFieldBuilder() {
+        if (clientGeolocationBuilder_ == null) {
+          clientGeolocationBuilder_ =
+              new com.google.protobuf.SingleFieldBuilder<
+                  edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation,
+                  edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.Geolocation.Builder,
+                  edu.umass.cs.xdn.proto.XdnHttpRequestProto.XdnHttpRequest.GeolocationOrBuilder>(
+                  getClientGeolocation(), getParentForChildren(), isClean());
+          clientGeolocation_ = null;
+        }
+        return clientGeolocationBuilder_;
+      }
+
       // @@protoc_insertion_point(builder_scope:xdn.XdnHttpRequest)
     }
 
@@ -4740,6 +5694,10 @@ public final class XdnHttpRequestProto {
   private static final com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_xdn_XdnHttpRequest_Header_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+      internal_static_xdn_XdnHttpRequest_Geolocation_descriptor;
+  private static final com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_xdn_XdnHttpRequest_Geolocation_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
       internal_static_xdn_XdnHttpRequest_Response_descriptor;
   private static final com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_xdn_XdnHttpRequest_Response_fieldAccessorTable;
@@ -4753,7 +5711,7 @@ public final class XdnHttpRequestProto {
   static {
     java.lang.String[] descriptorData = {
       "\n"
-          + "1src/edu/umass/cs/xdn/proto/xdn_http_request.proto\022\003xdn\"\326\005\n"
+          + "1src/edu/umass/cs/xdn/proto/xdn_http_request.proto\022\003xdn\"\343\006\n"
           + "\016XdnHttpRequest\022\022\n\n"
           + "request_id\030\001 \001(\003\022A\n"
           + "\020protocol_version\030\002 \001("
@@ -4763,16 +5721,20 @@ public final class XdnHttpRequestProto {
           + "\017request_headers\030\005 \003(\0132\032.xdn.XdnHttpRequest.Header\022\031\n"
           + "\014request_body\030\006 \001(\014H\000\210\001\001\0223\n"
           + "\010response\030\007"
-          + " \001(\0132\034.xdn.XdnHttpRequest.ResponseH\001\210\001\001\032%\n"
+          + " \001(\0132\034.xdn.XdnHttpRequest.ResponseH\001\210\001\001\022@\n"
+          + "\022client_geolocation\030\010 \001(\013"
+          + "2\037.xdn.XdnHttpRequest.GeolocationH\002\210\001\001\032%\n"
           + "\006Header\022\014\n"
           + "\004name\030\001 \001(\t\022\r\n"
-          + "\005value\030\002 \001(\t\032\275\001\n"
+          + "\005value\030\002 \001(\t\0322\n"
+          + "\013Geolocation\022\020\n"
+          + "\010latitude\030\001 \001(\001\022\021\n"
+          + "\tlongitude\030\002 \001(\001\032\275\001\n"
           + "\010Response\022A\n"
           + "\020protocol_version\030\001"
           + " \001(\0162\'.xdn.XdnHttpRequest.HttpProtocolVersion\022\023\n"
           + "\013status_code\030\002 \001(\005\022+\n"
-          + "\007headers\030\003 \003(\0132\032.xdn.XdnHttpRequest.Header\022\032\n"
-          + "\r"
+          + "\007headers\030\003 \003(\0132\032.xdn.XdnHttpRequest.Header\022\032\n\r"
           + "response_body\030\004 \001(\014H\000\210\001\001B\020\n"
           + "\016_response_body\"c\n\n"
           + "HttpMethod\022\007\n"
@@ -4788,7 +5750,8 @@ public final class XdnHttpRequestProto {
           + "\010HTTP_1_0\020\000\022\014\n"
           + "\010HTTP_1_1\020\001B\017\n\r"
           + "_request_bodyB\013\n"
-          + "\t_responseB-\n"
+          + "\t_responseB\025\n"
+          + "\023_client_geolocationB-\n"
           + "\026edu.umass.cs.xdn.protoB\023XdnHttpRequestProtob\006proto3"
     };
     descriptor =
@@ -4806,6 +5769,7 @@ public final class XdnHttpRequestProto {
               "RequestHeaders",
               "RequestBody",
               "Response",
+              "ClientGeolocation",
             });
     internal_static_xdn_XdnHttpRequest_Header_descriptor =
         internal_static_xdn_XdnHttpRequest_descriptor.getNestedTypes().get(0);
@@ -4815,8 +5779,16 @@ public final class XdnHttpRequestProto {
             new java.lang.String[] {
               "Name", "Value",
             });
-    internal_static_xdn_XdnHttpRequest_Response_descriptor =
+    internal_static_xdn_XdnHttpRequest_Geolocation_descriptor =
         internal_static_xdn_XdnHttpRequest_descriptor.getNestedTypes().get(1);
+    internal_static_xdn_XdnHttpRequest_Geolocation_fieldAccessorTable =
+        new com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+            internal_static_xdn_XdnHttpRequest_Geolocation_descriptor,
+            new java.lang.String[] {
+              "Latitude", "Longitude",
+            });
+    internal_static_xdn_XdnHttpRequest_Response_descriptor =
+        internal_static_xdn_XdnHttpRequest_descriptor.getNestedTypes().get(2);
     internal_static_xdn_XdnHttpRequest_Response_fieldAccessorTable =
         new com.google.protobuf.GeneratedMessage.FieldAccessorTable(
             internal_static_xdn_XdnHttpRequest_Response_descriptor,

--- a/src/edu/umass/cs/xdn/proto/xdn_http_request.proto
+++ b/src/edu/umass/cs/xdn/proto/xdn_http_request.proto
@@ -37,6 +37,14 @@ message XdnHttpRequest {
     string value = 2;
   }
 
+  // Geographic location as (latitude, longitude) in decimal degrees.
+  // Range validation lives on the Java side (Geolocation record); the
+  // proto itself just carries raw doubles.
+  message Geolocation {
+    double latitude = 1;
+    double longitude = 2;
+  }
+
   // Defines Http Response, embedded inside a Request.
   message Response {
     // Protocol used for the response. Examples: "HTTP/1.1", "HTTP/2".
@@ -70,4 +78,9 @@ message XdnHttpRequest {
 
   // The response for this request, empty if there is no response yet.
   optional Response response = 7;
+
+  // End-user/client geolocation. Populated at the entry replica from the
+  // X-Client-Location HTTP header; replaces the raw-header wire encoding
+  // so followers don't pay the ~40-byte header cost per request.
+  optional Geolocation client_geolocation = 8;
 }

--- a/src/edu/umass/cs/xdn/request/XdnHttpRequest.java
+++ b/src/edu/umass/cs/xdn/request/XdnHttpRequest.java
@@ -10,6 +10,7 @@ import edu.umass.cs.clientcentric.interfaces.TimestampedRequest;
 import edu.umass.cs.clientcentric.interfaces.TimestampedResponse;
 import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
 import edu.umass.cs.nio.interfaces.Byteable;
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.xdn.interfaces.behavior.BehavioralRequest;
 import edu.umass.cs.xdn.interfaces.behavior.RequestBehaviorType;
@@ -49,6 +50,12 @@ public class XdnHttpRequest extends XdnRequest
   // the server sets Set-Cookie: XDN=<service> in response to an _xdnsvc URL.
   public static final String XDN_SVC_COOKIE_NAME = "XDN";
 
+  // HTTP header carrying the end-user/client geolocation as "lat,lon" (commas
+  // per Geolocation.parse, though "lat; lon" from the eval latency proxy is
+  // also tolerated). Consumed at the XDN layer (parsed into a typed
+  // Geolocation and stripped before the request reaches the container).
+  public static final String X_CLIENT_LOCATION_HEADER = "X-Client-Location";
+
   public static final List<RequestMatcher> defaultSingletonRequestMatchers =
       ServiceProperty.createDefaultMatchers();
 
@@ -73,6 +80,11 @@ public class XdnHttpRequest extends XdnRequest
   // httpResponse. In XDN, the instance is created via createFromString() in non entry-replica
   // node, and thus we can discard and release the httpResponse immediately.
   private final boolean isCreatedFromString;
+
+  // Parsed client geolocation from the X-Client-Location header, or null when
+  // the header is absent or malformed. Populated at construction on both the
+  // entry replica and on followers (the raw header survives proto transit).
+  private final Geolocation clientGeolocation;
 
   // The set for BehavioralRequest interface that requires returning
   // the behaviors of this HttpRequest. Note that requestMatcher must
@@ -131,6 +143,11 @@ public class XdnHttpRequest extends XdnRequest
             : defaultSingletonRequestMatchers;
 
     this.isCreatedFromString = isCreatedFromString;
+
+    // Parse X-Client-Location into a typed Geolocation. Left in the headers so
+    // followers reconstruct the same value from the proto wire form; stripped
+    // later at the forwarder boundary so the containerized service never sees it.
+    this.clientGeolocation = parseClientGeolocation(this.httpRequest);
   }
 
   // In general, we infer the HTTP request ID based on these headers:
@@ -258,6 +275,22 @@ public class XdnHttpRequest extends XdnRequest
       }
     }
     return null;
+  }
+
+  // Returns the client geolocation from the X-Client-Location header, or null
+  // if the header is absent or malformed. Accepts both "lat,lon" and the
+  // "lat; lon" form emitted by the eval latency proxy by normalizing the
+  // separator before delegating to Geolocation.parse (which already handles
+  // whitespace, surrounding quotes, range checks, and null-on-error).
+  private static Geolocation parseClientGeolocation(HttpRequest httpRequest) {
+    if (httpRequest.headers() == null) {
+      return null;
+    }
+    String raw = httpRequest.headers().get(X_CLIENT_LOCATION_HEADER);
+    if (raw == null || raw.isEmpty()) {
+      return null;
+    }
+    return Geolocation.parse(raw.replace(';', ','));
   }
 
   // Removes any query param whose key starts with XDN_RESERVED_QUERY_PREFIX from
@@ -446,6 +479,12 @@ public class XdnHttpRequest extends XdnRequest
 
   public HttpRequest getHttpRequest() {
     return this.httpRequest;
+  }
+
+  // Returns the parsed end-user/client geolocation from X-Client-Location, or
+  // null if the header was absent or malformed at construction time.
+  public Geolocation getClientGeolocation() {
+    return this.clientGeolocation;
   }
 
   public HttpContent getHttpRequestContent() {

--- a/src/edu/umass/cs/xdn/request/XdnHttpRequest.java
+++ b/src/edu/umass/cs/xdn/request/XdnHttpRequest.java
@@ -93,7 +93,7 @@ public class XdnHttpRequest extends XdnRequest
   private List<RequestMatcher> requestMatchers;
 
   public XdnHttpRequest(HttpRequest request, HttpContent content) {
-    this(null, request, content, null, false);
+    this(null, request, content, null, false, null);
   }
 
   private XdnHttpRequest(
@@ -101,7 +101,8 @@ public class XdnHttpRequest extends XdnRequest
       HttpRequest request,
       HttpContent content,
       List<RequestMatcher> requestMatchers,
-      boolean isCreatedFromString) {
+      boolean isCreatedFromString,
+      Geolocation providedClientGeolocation) {
     assert request != null : "HttpRequest must be specified";
     assert content != null : "HttpContent must be specified";
 
@@ -144,10 +145,15 @@ public class XdnHttpRequest extends XdnRequest
 
     this.isCreatedFromString = isCreatedFromString;
 
-    // Parse X-Client-Location into a typed Geolocation. Left in the headers so
-    // followers reconstruct the same value from the proto wire form; stripped
-    // later at the forwarder boundary so the containerized service never sees it.
-    this.clientGeolocation = parseClientGeolocation(this.httpRequest);
+    // Parse X-Client-Location into a typed Geolocation. On entry replicas the
+    // value comes from the header; on followers reconstructed via createFromString,
+    // a typed value from the proto's client_geolocation field is passed in and
+    // takes precedence over the header. The forwarder-boundary strip keeps the
+    // raw header away from the containerized service.
+    this.clientGeolocation =
+        providedClientGeolocation != null
+            ? providedClientGeolocation
+            : parseClientGeolocation(this.httpRequest);
   }
 
   // In general, we infer the HTTP request ID based on these headers:
@@ -526,6 +532,16 @@ public class XdnHttpRequest extends XdnRequest
       builder.setResponse(buildResponseProto());
     }
 
+    // Prefer the typed wire encoding. getHeaderList filters X-Client-Location
+    // out of request_headers so the proto doesn't carry a duplicate copy.
+    if (this.clientGeolocation != null) {
+      builder.setClientGeolocation(
+          XdnHttpRequestProto.XdnHttpRequest.Geolocation.newBuilder()
+              .setLatitude(this.clientGeolocation.latitude())
+              .setLongitude(this.clientGeolocation.longitude())
+              .build());
+    }
+
     byte[] protoBytes = builder.build().toByteArray();
     byte[] serialized = new byte[Integer.BYTES + protoBytes.length];
     ByteBuffer.wrap(serialized).putInt(packetType).put(protoBytes);
@@ -548,6 +564,12 @@ public class XdnHttpRequest extends XdnRequest
     List<XdnHttpRequestProto.XdnHttpRequest.Header> headerList = new ArrayList<>();
     while (it.hasNext()) {
       Map.Entry<String, String> e = it.next();
+      // Skip X-Client-Location: it is carried on the wire as the typed
+      // client_geolocation proto field instead, to avoid the ~40-byte
+      // string-header cost. Case-insensitive per HTTP semantics.
+      if (X_CLIENT_LOCATION_HEADER.equalsIgnoreCase(e.getKey())) {
+        continue;
+      }
       XdnHttpRequestProto.XdnHttpRequest.Header header =
           XdnHttpRequestProto.XdnHttpRequest.Header.newBuilder()
               .setName(e.getKey())
@@ -679,8 +701,24 @@ public class XdnHttpRequest extends XdnRequest
     HttpResponse httpResponse =
         decodedProto.hasResponse() ? buildHttpResponse(decodedProto.getResponse()) : null;
 
+    // Prefer the typed client_geolocation proto field (new wire form). If the
+    // sender is an older binary that didn't emit the typed field, the private
+    // constructor falls back to parsing the X-Client-Location header from
+    // request_headers.
+    Geolocation clientGeo = null;
+    if (decodedProto.hasClientGeolocation()) {
+      XdnHttpRequestProto.XdnHttpRequest.Geolocation protoGeo = decodedProto.getClientGeolocation();
+      try {
+        clientGeo = new Geolocation(protoGeo.getLatitude(), protoGeo.getLongitude());
+      } catch (IllegalArgumentException e) {
+        // Out-of-range doubles on the wire → treat as absent.
+        clientGeo = null;
+      }
+    }
+
     XdnHttpRequest decodedRequest =
-        new XdnHttpRequest(decodedProto.getRequestId(), httpRequest, httpContent, null, true);
+        new XdnHttpRequest(
+            decodedProto.getRequestId(), httpRequest, httpContent, null, true, clientGeo);
     if (httpResponse != null) {
       decodedRequest.setHttpResponse(httpResponse);
     }

--- a/test/edu/umass/cs/xdn/request/XdnHttpRequestTest.java
+++ b/test/edu/umass/cs/xdn/request/XdnHttpRequestTest.java
@@ -586,6 +586,87 @@ public class XdnHttpRequestTest {
     throw new RuntimeException("unimplemented");
   }
 
+  @Test
+  public void testClientGeolocation_Absent() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNull(httpRequest.getClientGeolocation());
+  }
+
+  @Test
+  public void testClientGeolocation_CommaFormat() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "39.9526,-75.1652");
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNotNull(httpRequest.getClientGeolocation());
+    assertEquals(39.9526, httpRequest.getClientGeolocation().latitude(), 1e-9);
+    assertEquals(-75.1652, httpRequest.getClientGeolocation().longitude(), 1e-9);
+  }
+
+  @Test
+  public void testClientGeolocation_SemicolonSpaceFormat() {
+    // The eval latency proxy emits "lat; lon"; XdnHttpRequest normalizes it
+    // to "lat,lon" before calling Geolocation.parse.
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "39.9526; -75.1652");
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNotNull(httpRequest.getClientGeolocation());
+    assertEquals(39.9526, httpRequest.getClientGeolocation().latitude(), 1e-9);
+    assertEquals(-75.1652, httpRequest.getClientGeolocation().longitude(), 1e-9);
+  }
+
+  @Test
+  public void testClientGeolocation_Empty() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "");
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNull(httpRequest.getClientGeolocation());
+  }
+
+  @Test
+  public void testClientGeolocation_MalformedNonNumeric() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "abc,def");
+    // Must not throw; Geolocation.parse returns null on bad input.
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNull(httpRequest.getClientGeolocation());
+  }
+
+  @Test
+  public void testClientGeolocation_MalformedOutOfRange() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "100,200");
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNull(httpRequest.getClientGeolocation());
+  }
+
+  @Test
+  public void testClientGeolocation_MalformedWrongCardinality() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "42.0");
+    XdnHttpRequest httpRequest = new XdnHttpRequest(request, content);
+    assertNull(httpRequest.getClientGeolocation());
+  }
+
+  @Test
+  public void testClientGeolocation_HeaderSurvivesConstruction() {
+    // The constructor must leave the raw header in place so followers that
+    // deserialize the proto see it and re-parse into the same typed value.
+    // Stripping happens later, at the forwarder boundary in XdnGigapaxosApp.
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "39.9526,-75.1652");
+    new XdnHttpRequest(request, content);
+    assertEquals("39.9526,-75.1652", request.headers().get("X-Client-Location"));
+  }
+
   private static HttpRequest helpCreateDummyHttpRequest() {
     String serviceName = "dummyServiceName";
     return new DefaultHttpRequest(

--- a/test/edu/umass/cs/xdn/request/XdnHttpRequestTest.java
+++ b/test/edu/umass/cs/xdn/request/XdnHttpRequestTest.java
@@ -6,11 +6,14 @@ import edu.umass.cs.clientcentric.VectorTimestamp;
 import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
 import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
 import edu.umass.cs.xdn.XdnGigapaxosApp;
+import edu.umass.cs.xdn.proto.XdnHttpRequestProto;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Disabled;
@@ -665,6 +668,107 @@ public class XdnHttpRequestTest {
     request.headers().add("X-Client-Location", "39.9526,-75.1652");
     new XdnHttpRequest(request, content);
     assertEquals("39.9526,-75.1652", request.headers().get("X-Client-Location"));
+  }
+
+  @Test
+  public void testClientGeolocation_SurvivesProtoRoundTrip() {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "39.9526,-75.1652");
+    XdnHttpRequest original = new XdnHttpRequest(request, content);
+
+    byte[] bytes = original.toBytes();
+    XdnHttpRequest rehydrated =
+        XdnHttpRequest.createFromString(new String(bytes, StandardCharsets.ISO_8859_1));
+
+    assertNotNull(rehydrated);
+    assertNotNull(rehydrated.getClientGeolocation());
+    assertEquals(39.9526, rehydrated.getClientGeolocation().latitude(), 1e-9);
+    assertEquals(-75.1652, rehydrated.getClientGeolocation().longitude(), 1e-9);
+  }
+
+  @Test
+  public void testClientGeolocation_ProtoUsesTypedFieldNotHeader() throws Exception {
+    // Direct gate on the wire-size win: the typed field must be populated,
+    // and the raw X-Client-Location header must NOT appear in request_headers.
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    request.headers().add("X-Client-Location", "39.9526,-75.1652");
+    XdnHttpRequest xdnReq = new XdnHttpRequest(request, content);
+
+    byte[] bytes = xdnReq.toBytes();
+    // Strip the 4-byte packet-type prefix that XdnHttpRequest prepends in toBytes().
+    byte[] protoBytes = Arrays.copyOfRange(bytes, Integer.BYTES, bytes.length);
+    XdnHttpRequestProto.XdnHttpRequest proto =
+        XdnHttpRequestProto.XdnHttpRequest.parseFrom(protoBytes);
+
+    assertTrue(proto.hasClientGeolocation());
+    assertEquals(39.9526, proto.getClientGeolocation().getLatitude(), 1e-9);
+    assertEquals(-75.1652, proto.getClientGeolocation().getLongitude(), 1e-9);
+
+    for (XdnHttpRequestProto.XdnHttpRequest.Header h : proto.getRequestHeadersList()) {
+      assertFalse(
+          "X-Client-Location".equalsIgnoreCase(h.getName()),
+          "X-Client-Location must not be carried in request_headers; found: " + h.getName());
+    }
+  }
+
+  @Test
+  public void testClientGeolocation_AbsentRoundTrip() throws Exception {
+    HttpRequest request = helpCreateDummyHttpRequest();
+    HttpContent content = helpCreateDummyHttpContent(64);
+    XdnHttpRequest original = new XdnHttpRequest(request, content);
+
+    byte[] bytes = original.toBytes();
+    byte[] protoBytes = Arrays.copyOfRange(bytes, Integer.BYTES, bytes.length);
+    XdnHttpRequestProto.XdnHttpRequest proto =
+        XdnHttpRequestProto.XdnHttpRequest.parseFrom(protoBytes);
+    assertFalse(proto.hasClientGeolocation());
+
+    XdnHttpRequest rehydrated =
+        XdnHttpRequest.createFromString(new String(bytes, StandardCharsets.ISO_8859_1));
+    assertNotNull(rehydrated);
+    assertNull(rehydrated.getClientGeolocation());
+  }
+
+  @Test
+  public void testClientGeolocation_BackwardCompatHeaderFallback() {
+    // Simulate an old-binary sender: proto has no client_geolocation field,
+    // but carries X-Client-Location in request_headers. The new decode path
+    // must still populate the typed value from the header.
+    XdnHttpRequestProto.XdnHttpRequest proto =
+        XdnHttpRequestProto.XdnHttpRequest.newBuilder()
+            .setRequestId(12345L)
+            .setProtocolVersion(XdnHttpRequestProto.XdnHttpRequest.HttpProtocolVersion.HTTP_1_1)
+            .setRequestMethod(XdnHttpRequestProto.XdnHttpRequest.HttpMethod.GET)
+            .setRequestUri("/")
+            .addRequestHeaders(
+                XdnHttpRequestProto.XdnHttpRequest.Header.newBuilder()
+                    .setName("XDN")
+                    .setValue("dummyServiceName")
+                    .build())
+            .addRequestHeaders(
+                XdnHttpRequestProto.XdnHttpRequest.Header.newBuilder()
+                    .setName("X-Client-Location")
+                    .setValue("42.3736,-71.1097")
+                    .build())
+            .build();
+
+    byte[] protoBytes = proto.toByteArray();
+    byte[] packetTypePrefix = new byte[Integer.BYTES];
+    java.nio.ByteBuffer.wrap(packetTypePrefix)
+        .putInt(edu.umass.cs.xdn.request.XdnRequestType.XDN_SERVICE_HTTP_REQUEST.getInt());
+    byte[] wire = new byte[Integer.BYTES + protoBytes.length];
+    System.arraycopy(packetTypePrefix, 0, wire, 0, Integer.BYTES);
+    System.arraycopy(protoBytes, 0, wire, Integer.BYTES, protoBytes.length);
+
+    XdnHttpRequest rehydrated =
+        XdnHttpRequest.createFromString(new String(wire, StandardCharsets.ISO_8859_1));
+    assertNotNull(rehydrated);
+    Geolocation geo = rehydrated.getClientGeolocation();
+    assertNotNull(geo);
+    assertEquals(42.3736, geo.latitude(), 1e-9);
+    assertEquals(-71.1097, geo.longitude(), 1e-9);
   }
 
   private static HttpRequest helpCreateDummyHttpRequest() {


### PR DESCRIPTION
 - `XdnHttpRequest` now exposes `getClientGeolocation(): Geolocation` populated from the `X-Client-Location` HTTP header at construction. Accepts both `"lat,lon"` and the eval-proxy `"lat; lon"` form via a single `replace(';', ',')`
  before delegating to the existing null-safe `Geolocation.parse`. Null when the header is absent or malformed.
  - `XdnGigapaxosApp.copyHttpRequest` strips `X-Client-Location` from the outbound copy before forwarding, so the containerized service never sees the XDN-layer signal. The original Netty request keeps the header so followers
  reconstruct the same typed value from the proto wire form.
  - `eval/xdn-latency-proxy/go/main.go` adds a `-forward-client-location` flag (default `false`, matching today's behavior of stripping the header at the proxy boundary). Set the flag when you want the upstream AR to observe client
  location in benchmarks.
  - Adds `message Geolocation { double latitude; double longitude; }` and `optional Geolocation client_geolocation = 8;` to `XdnHttpRequest` in `xdn_http_request.proto`, and regenerates `XdnHttpRequestProto.java`.
  - `toBytes()` populates the typed field; `getHeaderList()` skips `X-Client-Location` so the raw header is no longer duplicated in `request_headers`. `createFromString()` reads the typed field and plumbs it through a new
  `providedClientGeolocation` override on the private constructor.
  - Cuts ~20 bytes per request off the wire (typed two-`double` vs ~40-byte string header + proto framing).