### PR TITLE
Add worker in demand profiler to accumulate geo-demand distribution

### DIFF
--- a/.github/workflows/geo-demand-smoke.yml
+++ b/.github/workflows/geo-demand-smoke.yml
@@ -1,0 +1,182 @@
+name: "Geo-demand placement smoke test"
+
+on:
+  push:
+    branches: [ "master", "main" ]
+    paths:
+      - "src/edu/umass/cs/xdn/**"
+      - "src/edu/umass/cs/reconfiguration/**"
+      - "src/edu/umass/cs/nio/interfaces/Geolocation.java"
+      - "conf/gigapaxos.xdn.local.geodemand.properties"
+      - "xdn-cli/**"
+      - "bin/gpServer.sh"
+      - "bin/gpEnv.sh"
+      - "bin/build_xdn_cli.sh"
+      - "eval/geo_demand_smoke.py"
+      - ".github/workflows/geo-demand-smoke.yml"
+  pull_request:
+    branches: [ "master", "main" ]
+    paths:
+      - "src/edu/umass/cs/xdn/**"
+      - "src/edu/umass/cs/reconfiguration/**"
+      - "src/edu/umass/cs/nio/interfaces/Geolocation.java"
+      - "conf/gigapaxos.xdn.local.geodemand.properties"
+      - "xdn-cli/**"
+      - "bin/gpServer.sh"
+      - "bin/gpEnv.sh"
+      - "bin/build_xdn_cli.sh"
+      - "eval/geo_demand_smoke.py"
+      - ".github/workflows/geo-demand-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'oracle'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: xdn-cli/go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python deps
+        run: pip install requests
+
+      - name: Set up Docker
+        uses: docker-practice/actions-setup-docker@master
+        timeout-minutes: 12
+
+      - name: Verify Docker and pre-pull bookcatalog image
+        run: |
+          set -x
+          docker version
+          docker pull fadhilkurnia/xdn-bookcatalog
+
+      - name: Set up rsync
+        uses: GuillaumeFalourd/setup-rsync@v1.2
+
+      - name: Build XDN jar and CLI
+        run: |
+          set -x
+          ant jar
+          bash bin/build_xdn_cli.sh
+          # build_xdn_cli.sh creates bin/xdn as a symlink to the host binary
+          # (matches the pattern used in ant-build-test.yml).
+          ln -sf "$(pwd)/bin/xdn" /usr/local/bin/xdn
+
+      - name: Start XDN cluster with geodemand config
+        run: |
+          set -x
+          mkdir -p /tmp/xdn /tmp/gigapaxos
+          # gpServer.sh forks JVMs and detaches; redirect its output to a log we
+          # can inspect after the fact for reconfiguration evidence.
+          ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.geodemand.properties start all > /tmp/xdn-cluster.log 2>&1
+          # Wait until the Reconfigurator HTTP endpoint is up (max 90s).
+          for i in $(seq 1 90); do
+            if grep -q "HttpReconfigurator ready" /tmp/xdn-cluster.log; then
+              echo "Cluster ready after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+          grep -q "HttpReconfigurator ready" /tmp/xdn-cluster.log || {
+            echo "Cluster failed to come up. Tail of log:"
+            tail -100 /tmp/xdn-cluster.log
+            exit 1
+          }
+
+      - name: Launch bookcatalog service
+        env:
+          XDN_CONTROL_PLANE: localhost
+        run: |
+          set -x
+          xdn launch bookcatalog \
+            --image=fadhilkurnia/xdn-bookcatalog \
+            --state=/app/data/ \
+            --deterministic=true
+          # Give containers a few seconds to actually start.
+          sleep 5
+          xdn service info bookcatalog | tee /tmp/initial-placement.txt
+          # Sanity: must be at epoch=0 right after launch.
+          grep -q "epoch=0" /tmp/initial-placement.txt
+
+      - name: Send us-east-1 biased traffic
+        run: |
+          set -x
+          # 600 requests over ~24s spans at least two demand-report windows
+          # (MIN_DEMAND_REPORT_PERIOD_MS = 10s).
+          python3 eval/geo_demand_smoke.py --region us-east-1 --requests 600 --rate 25
+
+      - name: Verify reconfiguration toward us-east-1
+        env:
+          XDN_CONTROL_PLANE: localhost
+        run: |
+          set -x
+          # Poll for the active set to advance past epoch=0 (max 60s).
+          for i in $(seq 1 30); do
+            xdn service info bookcatalog > /tmp/final-placement.txt 2>&1 || true
+            if grep -qE "epoch=[1-9]" /tmp/final-placement.txt; then
+              echo "Reconfiguration observed after ${i} polls"
+              break
+            fi
+            sleep 2
+          done
+          cat /tmp/final-placement.txt
+          if ! grep -qE "epoch=[1-9]" /tmp/final-placement.txt; then
+            echo "FAIL: reconfiguration never fired"
+            exit 1
+          fi
+          # Biasing demand to us-east-1 puts the centroid near (38.5, -78).
+          # The 3 closest actives to that point are east1a, east1b, and the
+          # nearer of {west1a, west1b}, so the post-reconfig group must contain
+          # both us-east-1 nodes. Counting placement-table lines that mention an
+          # east1* node gives us a structural invariant that does not depend on
+          # which initial group the RC happened to pick.
+          east_count=$(grep -cE "east1[ab]" /tmp/final-placement.txt || true)
+          if [ "${east_count}" -lt 2 ]; then
+            echo "FAIL: expected >=2 us-east-1 nodes in active set, saw ${east_count}"
+            echo "--- placement ---"
+            cat /tmp/final-placement.txt
+            echo "--- relevant log lines ---"
+            grep -E "shouldReport=true|getNewActivesPlacement|received DemandReport|shouldReconfigure2" /tmp/xdn-cluster.log | tail -30
+            exit 1
+          fi
+          # The preferred coordinator should be in us-east-1 too; the placement
+          # table renders the leader on its own row with role=leader.
+          leader_line=$(grep "leader" /tmp/final-placement.txt || true)
+          if ! echo "${leader_line}" | grep -qE "east1[ab]"; then
+            echo "FAIL: leader is not in us-east-1: ${leader_line}"
+            exit 1
+          fi
+
+      - name: Dump cluster log on failure
+        if: failure()
+        run: |
+          echo "=== cluster log (last 200 lines) ==="
+          tail -200 /tmp/xdn-cluster.log || true
+          echo "=== docker ps ==="
+          docker ps -a || true
+          echo "=== xdn service info ==="
+          XDN_CONTROL_PLANE=localhost xdn service info bookcatalog || true
+
+      - name: Tear down cluster
+        if: always()
+        run: |
+          ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.geodemand.properties forceclear all || true
+          docker rm -f $(docker ps -aq --filter "name=bookcatalog") 2>/dev/null || true

--- a/conf/gigapaxos.xdn.local.geodemand.properties
+++ b/conf/gigapaxos.xdn.local.geodemand.properties
@@ -11,7 +11,7 @@ HIBERNATE_OPTION=true
 SYNC=true
 
 # 768MB
-# Needed for large non-deterministic state transfer packets 
+# Needed for large non-deterministic state transfer packets
 # (observed ~663MB in logs).
 NIO_MAX_PAYLOAD_SIZE=805306368
 
@@ -29,17 +29,17 @@ XDN_HTTP_MAX_POOL_SIZE=128
 DEMAND_PROFILE_TYPE=edu.umass.cs.xdn.XdnGeoDemandProfiler
 
 # format: active.<active_server_name>=host:port
-active.AR0=127.0.0.1:2000
-active.AR1=127.0.0.1:2001
-active.AR2=127.0.0.1:2002
-active.AR3=127.0.0.1:2003
+active.east1a=127.0.0.1:2000
+active.east1b=127.0.0.1:2001
+active.west1a=127.0.0.1:2002
+active.west1b=127.0.0.1:2003
 
 # format: active.<active_server_name>.geolocation="latitude,longitude"
-# AR0, AR1 in us-east-1 (Northern Virginia); AR2, AR3 in us-west-1 (Northern California).
-active.AR0.geolocation="38.1300,-78.4500"
-active.AR1.geolocation="38.9500,-77.4500"
-active.AR2.geolocation="37.7800,-122.4200"
-active.AR3.geolocation="37.3600,-121.9200"
+# east1a, east1b in us-east-1 (Northern Virginia); west1a, west1b in us-west-1 (Northern California).
+active.east1a.geolocation="38.1300,-78.4500"
+active.east1b.geolocation="38.9500,-77.4500"
+active.west1a.geolocation="37.7800,-122.4200"
+active.west1b.geolocation="37.3600,-121.9200"
 
 # format: reconfigurator.<active_server_name>=host:port
 reconfigurator.RC0=127.0.0.1:3000

--- a/eval/geo_demand_smoke.py
+++ b/eval/geo_demand_smoke.py
@@ -100,6 +100,14 @@ def parse_args() -> argparse.Namespace:
         default=5.0,
         help="Per-request timeout in seconds. Default: 5",
     )
+    parser.add_argument(
+        "--max-fail-pct",
+        type=float,
+        default=5.0,
+        help="Exit non-zero if the percentage of failed requests exceeds this. "
+        "Default: 5.0. Brief failures are expected during the leader-change "
+        "window that this test deliberately triggers.",
+    )
     return parser.parse_args()
 
 
@@ -162,12 +170,23 @@ def main() -> int:
                 time.sleep(sleep_for)
 
     elapsed = time.monotonic() - start
-    print(f"done. sent={sent} ok={ok} failed={failed} elapsed={elapsed:.1f}s")
+    fail_pct = (100.0 * failed / sent) if sent > 0 else 0.0
+    print(
+        f"done. sent={sent} ok={ok} failed={failed} ({fail_pct:.2f}%) "
+        f"elapsed={elapsed:.1f}s"
+    )
     print(
         "Wait > 10s for the demand report to flush, then run "
         f"`xdn service info {args.service}` to check the new active set."
     )
-    return 0 if failed == 0 else 1
+    if fail_pct > args.max_fail_pct:
+        print(
+            f"FAIL: failure rate {fail_pct:.2f}% exceeds threshold "
+            f"{args.max_fail_pct:.2f}%",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/eval/geo_demand_smoke.py
+++ b/eval/geo_demand_smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+geo_demand_smoke.py — Send HTTP requests to the local XDN cluster with the
+X-Client-Location header biased to one of the configured AR regions, so the
+XdnGeoDemandProfiler will steer the replica group toward that region.
+
+Usage:
+    python3 geo_demand_smoke.py --region tokyo --service bookcatalog
+    python3 geo_demand_smoke.py --region ohio --requests 500 --rate 30
+    python3 geo_demand_smoke.py --lat 48.85 --lon 2.35 --requests 200
+
+The script reads the AR HTTP frontend ports from defaults that match
+conf/gigapaxos.xdn.local.properties (AR0..AR3 on 2300..2303). It rotates
+across replicas to spread load. Each request adds a small lat/lon jitter so
+the profiler sees several adjacent grid cells biased to one region rather
+than a single cell, which exercises the centroid math more realistically.
+
+Pre-flight:
+  - Cluster running with DEMAND_PROFILE_TYPE=edu.umass.cs.xdn.XdnGeoDemandProfiler
+  - Service deployed (e.g. xdn launch bookcatalog --image=fadhilkurnia/xdn-bookcatalog ...)
+
+After the run, wait > MIN_DEMAND_REPORT_PERIOD_MS (10s) plus a reconfiguration
+window, then check `xdn service info <name>` to see whether the active set
+shifted toward the chosen region.
+"""
+
+import argparse
+import random
+import sys
+import time
+
+import requests
+
+# Regions match conf/gigapaxos.xdn.local.properties active.AR*.geolocation.
+# AR0, AR1 sit in us-east-1; AR2, AR3 sit in us-west-1.
+REGIONS = {
+    "us-east-1": (38.5400, -77.9500),  # midpoint of AR0 + AR1
+    "us-west-1": (37.5700, -122.1700),  # midpoint of AR2 + AR3
+}
+
+# AR HTTP frontend port. The default targets one AR known to be in any service's
+# initial group; pass --ar-ports to rotate. Sending to an AR that is NOT part of
+# the service's replica group will hang since the local-cluster proxy has no peer
+# to forward to.
+DEFAULT_AR_PORTS = [2301]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--service",
+        default="bookcatalog",
+        help="Service name (also sent in the XDN header). Default: bookcatalog",
+    )
+    parser.add_argument(
+        "--path",
+        default="/api/books",
+        help="HTTP request path on the service. Default: /api/books",
+    )
+    parser.add_argument(
+        "--region",
+        choices=sorted(REGIONS.keys()),
+        help="Bias requests toward one of the configured AR regions.",
+    )
+    parser.add_argument("--lat", type=float, help="Override centroid latitude.")
+    parser.add_argument("--lon", type=float, help="Override centroid longitude.")
+    parser.add_argument(
+        "--jitter-deg",
+        type=float,
+        default=2.0,
+        help="Uniform +/- jitter in degrees added to each request's lat/lon. "
+        "Default: 2.0 (covers ~220km — well within one AR region).",
+    )
+    parser.add_argument(
+        "--requests",
+        type=int,
+        default=200,
+        help="Total number of requests to send. Default: 200",
+    )
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=20.0,
+        help="Requests per second (best effort). Default: 20",
+    )
+    parser.add_argument(
+        "--ar-ports",
+        type=lambda s: [int(p) for p in s.split(",")],
+        default=DEFAULT_AR_PORTS,
+        help="Comma-separated AR HTTP frontend ports. Default: 2301",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="AR host. Default: 127.0.0.1",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Per-request timeout in seconds. Default: 5",
+    )
+    return parser.parse_args()
+
+
+def resolve_centroid(args: argparse.Namespace) -> tuple[float, float]:
+    if args.lat is not None and args.lon is not None:
+        return args.lat, args.lon
+    if args.region is None:
+        sys.exit("error: must specify --region or both --lat and --lon")
+    return REGIONS[args.region]
+
+
+def main() -> int:
+    args = parse_args()
+    centroid_lat, centroid_lon = resolve_centroid(args)
+    period = 1.0 / args.rate if args.rate > 0 else 0.0
+
+    print(
+        f"target centroid=({centroid_lat:.4f},{centroid_lon:.4f}) "
+        f"jitter=+/-{args.jitter_deg} requests={args.requests} rate={args.rate}/s "
+        f"service={args.service} ports={args.ar_ports}"
+    )
+
+    sent = 0
+    ok = 0
+    failed = 0
+    start = time.monotonic()
+    for i in range(args.requests):
+        port = args.ar_ports[i % len(args.ar_ports)]
+        url = f"http://{args.host}:{port}{args.path}"
+
+        # Clamp lat/lon to legal ranges; the profiler's parser rejects out-of-range
+        # values and would silently drop the sample.
+        lat = max(-90.0, min(90.0, centroid_lat + random.uniform(-args.jitter_deg, args.jitter_deg)))
+        lon = max(-180.0, min(180.0, centroid_lon + random.uniform(-args.jitter_deg, args.jitter_deg)))
+        headers = {
+            "XDN": args.service,
+            "X-Client-Location": f"{lat:.6f},{lon:.6f}",
+        }
+
+        try:
+            resp = requests.get(url, headers=headers, timeout=args.timeout)
+            sent += 1
+            if 200 <= resp.status_code < 500:
+                ok += 1
+            else:
+                failed += 1
+        except requests.RequestException as e:
+            sent += 1
+            failed += 1
+            print(f"  request {i} -> {url} failed: {e}", file=sys.stderr)
+
+        if (i + 1) % 50 == 0:
+            elapsed = time.monotonic() - start
+            print(f"  sent={sent} ok={ok} failed={failed} elapsed={elapsed:.1f}s")
+
+        if period > 0:
+            target = start + (i + 1) * period
+            sleep_for = target - time.monotonic()
+            if sleep_for > 0:
+                time.sleep(sleep_for)
+
+    elapsed = time.monotonic() - start
+    print(f"done. sent={sent} ok={ok} failed={failed} elapsed={elapsed:.1f}s")
+    print(
+        "Wait > 10s for the demand report to flush, then run "
+        f"`xdn service info {args.service}` to check the new active set."
+    )
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -2240,6 +2240,20 @@ public class Reconfigurator<NodeIDType> implements
                 return Reconfigurator.this.consistentNodeConfig
                         .getAllActiveReplicas();
             }
+
+            @Override
+            public Map<String, Geolocation> getActiveReplicaGeolocations() {
+                Map<String, Geolocation> result = new HashMap<>();
+                for (NodeIDType id : Reconfigurator.this.consistentNodeConfig
+                        .getActiveReplicas()) {
+                    Geolocation geo = Reconfigurator.this.consistentNodeConfig
+                            .getNodeGeolocation(id);
+                    if (geo != null) {
+                        result.put(id.toString(), geo);
+                    }
+                }
+                return result;
+            }
         };
     }
 

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
@@ -943,6 +943,10 @@ public class HttpActiveReplica {
                     sendAsyncResponse(rctx, null, timeoutTask,
                             new RuntimeException("Request was not handled"));
                 }
+                if (handled) {
+                    this.arFunctions.updateDemandStatsFromHttp(
+                            httpRequest, clientInetSocketAddress.getAddress());
+                }
             });
         }
 
@@ -965,6 +969,8 @@ public class HttpActiveReplica {
                         } else {
                             sendAsyncResponse(
                                     rctx, completedRequest.getHttpResponse(), timeoutTask, null);
+                            arFunctions.updateDemandStatsFromHttp(
+                                    completedRequest, clientInetSocketAddress.getAddress());
                         }
                     });
         }

--- a/src/edu/umass/cs/reconfiguration/interfaces/ReconfigurableAppInfo.java
+++ b/src/edu/umass/cs/reconfiguration/interfaces/ReconfigurableAppInfo.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.reconfiguration.reconfigurationutils.AbstractDemandProfile;
 
 /**
@@ -42,4 +43,14 @@ public interface ReconfigurableAppInfo {
 	 *         to or removed from the system.
 	 */
 	public Map<String, InetSocketAddress> getAllActiveReplicas();
+
+	/**
+	 * @return A map from active-replica node ID to its configured
+	 *         {@link Geolocation}, for those nodes that have one configured.
+	 *         Nodes without a geolocation are omitted. Implementations that do
+	 *         not surface geolocation should return an empty map (the default).
+	 */
+	default Map<String, Geolocation> getActiveReplicaGeolocations() {
+		return Map.of();
+	}
 }

--- a/src/edu/umass/cs/xdn/XdnGeoDemandProfiler.java
+++ b/src/edu/umass/cs/xdn/XdnGeoDemandProfiler.java
@@ -6,6 +6,7 @@ import edu.umass.cs.reconfiguration.interfaces.ReconfigurableAppInfo;
 import edu.umass.cs.reconfiguration.reconfigurationutils.AbstractDemandProfile;
 import edu.umass.cs.reconfiguration.reconfigurationutils.NodeIdsMetadataPair;
 import edu.umass.cs.xdn.request.XdnHttpRequest;
+import edu.umass.cs.xdn.request.XdnHttpRequestBatch;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -118,22 +119,22 @@ public class XdnGeoDemandProfiler extends AbstractDemandProfile {
       return false;
     }
     // Prototype: only clients that supply X-Client-Location contribute demand.
-    if (!(request instanceof XdnHttpRequest xdnReq)) {
-      return false;
-    }
-    Geolocation clientGeo = xdnReq.getClientGeolocation();
-    if (clientGeo == null) {
-      return false;
-    }
-
-    if (!eventQueue.offer(clientGeo)) {
-      LOGGER.log(
-          Level.FINE,
-          "XdnGeoDemandProfiler event queue full, dropping demand sample for {0}",
-          this.name);
+    // When HTTP batching is enabled requests arrive as XdnHttpRequestBatch; iterate
+    // its entries so per-request client locations still flow through.
+    boolean enqueuedAny = false;
+    if (request instanceof XdnHttpRequest xdnReq) {
+      enqueuedAny = enqueueIfGeo(xdnReq);
+    } else if (request instanceof XdnHttpRequestBatch batch) {
+      for (XdnHttpRequest sub : batch.getRequests()) {
+        enqueuedAny |= enqueueIfGeo(sub);
+      }
     } else {
-      ensureWorkerStarted();
+      return false;
     }
+    if (!enqueuedAny) {
+      return false;
+    }
+    ensureWorkerStarted();
 
     long now = System.currentTimeMillis();
     long last = lastDemandReportTimestamp.get();
@@ -147,6 +148,21 @@ public class XdnGeoDemandProfiler extends AbstractDemandProfile {
       return true;
     }
     return false;
+  }
+
+  private boolean enqueueIfGeo(XdnHttpRequest req) {
+    Geolocation geo = req.getClientGeolocation();
+    if (geo == null) {
+      return false;
+    }
+    if (!eventQueue.offer(geo)) {
+      LOGGER.log(
+          Level.FINE,
+          "XdnGeoDemandProfiler event queue full, dropping demand sample for {0}",
+          this.name);
+      return false;
+    }
+    return true;
   }
 
   private void ensureWorkerStarted() {

--- a/src/edu/umass/cs/xdn/XdnGeoDemandProfiler.java
+++ b/src/edu/umass/cs/xdn/XdnGeoDemandProfiler.java
@@ -1,178 +1,231 @@
 package edu.umass.cs.xdn;
 
 import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.nio.interfaces.Geolocation;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableAppInfo;
 import edu.umass.cs.reconfiguration.reconfigurationutils.AbstractDemandProfile;
 import edu.umass.cs.reconfiguration.reconfigurationutils.NodeIdsMetadataPair;
+import edu.umass.cs.xdn.request.XdnHttpRequest;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.*;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * This demand profiler splits the Earth into multiple square grid cells, based on the latitude and
- * longitude. The number of rows and columns are specified by the `NUM_GRID_ROWS` and
- * `NUM_GRID_COLUMNS` constant. This profiler aggregate the number of requests coming from each grid
- * cells, as the information for RC to chose the most appropriate replica placement.
+ * Demand profiler that splits Earth into a {@code NUM_GRID_ROWS x NUM_GRID_COLUMNS} latitude /
+ * longitude grid and accumulates per-cell request counts from clients that explicitly supply their
+ * geolocation via the {@code X-Client-Location} HTTP header (parsed into {@link
+ * XdnHttpRequest#getClientGeolocation()}).
  *
- * <p>TODO: improve the implementation to consider different type of request. - number of
- * coordinated requests - number of local-execution requests - record the request rate instead pf
- * the total number of request
+ * <p>Aggregation runs on a background worker per profiler instance: {@code shouldReportDemandStats}
+ * only computes the cell index and enqueues it, keeping the request hot path cheap. {@code
+ * getDemandStats} snapshots the sparse counts, serializes them, then resets the local map so each
+ * report covers demand since the previous report (the reconfigurator's {@link #combine} accumulates
+ * across reports).
+ *
+ * <p>On the reconfigurator side, {@link #getNewActivesPlacement} computes the weighted centroid of
+ * observed demand and picks the {@code curActives.size()} node IDs closest to that centroid (using
+ * node geolocations from {@link ReconfigurableAppInfo#getActiveReplicaGeolocations()}). The closest
+ * node is also surfaced via the {@code PREFERRED_COORDINATOR} placement metadata so the paxos layer
+ * can try to make it the leader.
+ *
+ * <p>Prototype limitations (future work): IP → (lat, lon) inference for clients that don't send
+ * {@code X-Client-Location}; threading the service's configured {@code --num-replicas} through
+ * {@link edu.umass.cs.xdn.service.ServiceProperty} (today the replica count is derived from the
+ * current group size); top-K serialization truncation can discard tail demand under the 4 KB DB
+ * cap.
  */
 public class XdnGeoDemandProfiler extends AbstractDemandProfile {
 
-  /**
-   * Geolocation has Latitude and Longitude component. Latitude indicates the vertical location
-   * (i.e., y-axis) while Longitude indicates the horizontal location (i.e., x-axis). One degree in
-   * Latitude and Longitude is roughly 111000 meters. Thus, if we want to capture 1x1 km grid, we
-   * need to split earth surfaces into 40030 x 19980 matrix. Note that this is mainly true near the
-   * equator.
-   */
-  private static final int NUM_GRID_ROWS = 10;
+  private static final int NUM_GRID_ROWS = 1000;
+  private static final int NUM_GRID_COLUMNS = 1000;
 
-  private static final int NUM_GRID_COLUMNS = 10;
+  // At most one demand report every 10 seconds per profiler instance.
+  private static final long MIN_DEMAND_REPORT_PERIOD_MS = 10_000;
 
-  // Defines the periodic time in which new demand statistics need to be reported
-  // to the control plane (i.e., RC).
-  private static final long MIN_DEMAND_REPORT_PERIOD_MS = 10_000; // 10 seconds.
+  // ReconfigurationConfig.MAX_DEMAND_PROFILE_SIZE defaults to 4096 bytes. Each serialized cell is
+  // 8 bytes (int32 index, int32 count) plus a 4-byte header; base64 inflates the string 4:3; the
+  // JSONObject also carries "name" and "num_reqs". 300 entries is a safe conservative budget.
+  private static final int MAX_GRID_ENTRIES_PER_REPORT = 300;
 
-  // Stores the accumulated number of request in all the grid cells.
-  int[][] gridTotalRequests = new int[NUM_GRID_ROWS][NUM_GRID_COLUMNS];
-  long totalRequests = 0;
+  // Bounded queue for the hot path; drops on overflow rather than back-pressuring request handling.
+  private static final int EVENT_QUEUE_CAPACITY = 16_384;
 
-  // Last timestamp when this profiler send the stats to the control plane.
-  Long lastDemandReportTimestamp = null;
+  private static final String KEY_NUM_REQS = "num_reqs";
+  private static final String KEY_GRID_SPARSE_B64 = "grid_sparse_b64";
+  private static final String KEY_NAME = "name";
 
   private static final Logger LOGGER = Logger.getLogger(XdnGeoDemandProfiler.class.getName());
 
-  // Dummy const data for server locations.
-  // TODO: load from config
-  private final Map<String, int[]> serverLocations =
-      Map.ofEntries(
-          Map.entry("AR0", new int[] {0, 0}),
-          Map.entry("AR1", new int[] {1, 1}),
-          Map.entry("AR2", new int[] {2, 2}),
-          Map.entry("AR3", new int[] {3, 3}),
-          Map.entry("AR4", new int[] {4, 4}),
-          Map.entry("AR5", new int[] {5, 5}),
-          Map.entry("AR6", new int[] {6, 6}),
-          Map.entry("AR7", new int[] {7, 7}),
-          Map.entry("AR8", new int[] {8, 8}),
-          Map.entry("AR9", new int[] {9, 9}));
+  // The hot path only captures the client Geolocation reference; lat/lon -> (row, col)
+  // conversion is deferred to the worker so shouldReportDemandStats stays minimal.
+  // Sparse cell counts, key = row * NUM_GRID_COLUMNS + col. Written only by the worker thread or by
+  // the constructor path; read by getDemandStats() under mapLock.
+  private final HashMap<Integer, Integer> sparseGrid = new HashMap<>();
+  private long totalRequests = 0;
+  private final ReentrantLock mapLock = new ReentrantLock();
 
-  /**
-   * @param name The name of service handled by this demand profiler.
-   */
+  private final AtomicLong lastDemandReportTimestamp = new AtomicLong(0);
+
+  // Lazily started worker: one daemon thread per profiler instance.
+  private final LinkedBlockingQueue<Geolocation> eventQueue =
+      new LinkedBlockingQueue<>(EVENT_QUEUE_CAPACITY);
+  private volatile ExecutorService worker;
+
   public XdnGeoDemandProfiler(String name) {
     super(name);
-
-    // Initialize the accumulated number of requests.
-    for (int i = 0; i < NUM_GRID_ROWS; i++) {
-      for (int j = 0; j < NUM_GRID_COLUMNS; j++) {
-        gridTotalRequests[i][j] = 0;
-      }
-    }
-
-    this.totalRequests = 0;
   }
 
   public XdnGeoDemandProfiler(JSONObject stats) throws JSONException {
-    super(stats.getString("name"));
-
-    if (stats.has("num_reqs")) {
-      this.totalRequests = stats.getLong("num_reqs");
+    super(stats.getString(KEY_NAME));
+    if (stats.has(KEY_NUM_REQS)) {
+      this.totalRequests = stats.getLong(KEY_NUM_REQS);
     }
-
-    Object rawData = stats.opt("grid_total_reqs");
-    if (rawData == null) {
+    String b64 = stats.optString(KEY_GRID_SPARSE_B64, null);
+    if (b64 == null || b64.isEmpty()) {
       return;
     }
-
-    // Parses and validates the provided demand data, the type could be int[][] or JSONArray.
-    if (rawData instanceof int[][] data) {
-      assert data.length == NUM_GRID_ROWS : "Invalid grid dimension";
-      assert data[0].length == NUM_GRID_COLUMNS : "Invalid grid dimension";
-      for (int i = 0; i < NUM_GRID_ROWS; i++) {
-        System.arraycopy(data[i], 0, gridTotalRequests[i], 0, NUM_GRID_COLUMNS);
-      }
-      return;
+    byte[] raw = Base64.getDecoder().decode(b64);
+    ByteBuffer buf = ByteBuffer.wrap(raw);
+    int n = buf.getInt();
+    for (int i = 0; i < n; i++) {
+      int idx = buf.getInt();
+      int count = buf.getInt();
+      sparseGrid.put(idx, count);
     }
-    if (rawData instanceof JSONArray data) {
-      assert data.length() == NUM_GRID_ROWS : "Invalid grid dimension";
-      Object firstRowData = data.opt(0);
-      assert firstRowData instanceof JSONArray : "Unexpected grid data format";
-      assert data.getJSONArray(0).length() == NUM_GRID_COLUMNS : "Invalid grid dimension";
-      for (int i = 0; i < NUM_GRID_ROWS; i++) {
-        JSONArray rowData = data.getJSONArray(i);
-        for (int j = 0; j < NUM_GRID_COLUMNS; j++) {
-          gridTotalRequests[i][j] = rowData.getInt(j);
-        }
-      }
-      return;
-    }
-
-    throw new RuntimeException(
-        "Unexpected type for the statistic data of "
-            + rawData.getClass().getSimpleName()
-            + ". Expecting int[][] or JSONArray.");
   }
 
   @Override
   public boolean shouldReportDemandStats(
       Request request, InetAddress sender, ReconfigurableAppInfo nodeConfig) {
-    // TODO: client-ip to fake geolocation mapping.
-    LOGGER.log(
-        Level.FINEST,
-        ">>> XdnGeoDemandProfiler - name="
-            + this.name
-            + " request="
-            + (request != null ? request.getClass().getSimpleName() : null)
-            + " sender="
-            + sender);
-
-    // Ignores requests for different service name.
     if (request == null || !request.getServiceName().equals(this.name)) {
       return false;
     }
-
-    this.totalRequests++;
-    if (lastDemandReportTimestamp == null) {
-      System.out.println(">>> XdnGeoDemandProfiler - Initializing the first timestamp ....");
-      this.lastDemandReportTimestamp = System.currentTimeMillis();
+    // Prototype: only clients that supply X-Client-Location contribute demand.
+    if (!(request instanceof XdnHttpRequest xdnReq)) {
+      return false;
+    }
+    Geolocation clientGeo = xdnReq.getClientGeolocation();
+    if (clientGeo == null) {
+      return false;
     }
 
-    // TODO: Converts IP address into Geolocation, then converts it into location in our cell
-    // this.gridTotalRequests[NUM_GRID_COLUMNS - 1][NUM_GRID_COLUMNS - 1]++;
-    this.gridTotalRequests[5][5]++;
+    if (!eventQueue.offer(clientGeo)) {
+      LOGGER.log(
+          Level.FINE,
+          "XdnGeoDemandProfiler event queue full, dropping demand sample for {0}",
+          this.name);
+    } else {
+      ensureWorkerStarted();
+    }
 
-    long currentTimestamp = System.currentTimeMillis();
-    if (currentTimestamp - this.lastDemandReportTimestamp >= MIN_DEMAND_REPORT_PERIOD_MS) {
-      System.out.println(">>> trigger reconfiguration at " + currentTimestamp);
+    long now = System.currentTimeMillis();
+    long last = lastDemandReportTimestamp.get();
+    if (last == 0) {
+      // Treat the first observation as the start of the reporting window.
+      lastDemandReportTimestamp.compareAndSet(0, now);
+      return false;
+    }
+    if (now - last >= MIN_DEMAND_REPORT_PERIOD_MS
+        && lastDemandReportTimestamp.compareAndSet(last, now)) {
       return true;
     }
-
     return false;
+  }
+
+  private void ensureWorkerStarted() {
+    if (worker != null) {
+      return;
+    }
+    synchronized (this) {
+      if (worker != null) {
+        return;
+      }
+      ThreadFactory tf =
+          r -> {
+            Thread t = new Thread(r, "xdn-geoprofiler-" + this.name);
+            t.setDaemon(true);
+            return t;
+          };
+      ExecutorService es = Executors.newSingleThreadExecutor(tf);
+      es.submit(this::workerLoop);
+      worker = es;
+    }
+  }
+
+  private void workerLoop() {
+    try {
+      while (!Thread.currentThread().isInterrupted()) {
+        Geolocation geo = eventQueue.take();
+        int row = latToRow(geo.latitude());
+        int col = lonToCol(geo.longitude());
+        int idx = row * NUM_GRID_COLUMNS + col;
+        mapLock.lock();
+        try {
+          sparseGrid.merge(idx, 1, Integer::sum);
+          totalRequests++;
+        } finally {
+          mapLock.unlock();
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   @Override
   public JSONObject getDemandStats() {
+    // Snapshot + reset under the lock so each report covers demand since the previous report.
+    List<int[]> entries;
+    long numReqs;
+    mapLock.lock();
+    try {
+      entries = new ArrayList<>(sparseGrid.size());
+      for (Map.Entry<Integer, Integer> e : sparseGrid.entrySet()) {
+        entries.add(new int[] {e.getKey(), e.getValue()});
+      }
+      numReqs = totalRequests;
+      sparseGrid.clear();
+      totalRequests = 0;
+    } finally {
+      mapLock.unlock();
+    }
+
+    // Top-K trim to stay under ReconfigurationConfig.MAX_DEMAND_PROFILE_SIZE.
+    if (entries.size() > MAX_GRID_ENTRIES_PER_REPORT) {
+      entries.sort((a, b) -> Integer.compare(b[1], a[1]));
+      entries = entries.subList(0, MAX_GRID_ENTRIES_PER_REPORT);
+    }
+
+    ByteBuffer buf = ByteBuffer.allocate(4 + entries.size() * 8);
+    buf.putInt(entries.size());
+    for (int[] e : entries) {
+      buf.putInt(e[0]);
+      buf.putInt(e[1]);
+    }
+    String b64 = Base64.getEncoder().encodeToString(buf.array());
+
     JSONObject stats = new JSONObject();
     try {
-      stats.put("name", this.name);
-      stats.put("num_reqs", this.totalRequests);
-      JSONArray gridData = new JSONArray();
-      for (int i = 0; i < NUM_GRID_ROWS; i++) {
-        JSONArray rowData = new JSONArray();
-        for (int j = 0; j < NUM_GRID_COLUMNS; j++) {
-          rowData.put(this.gridTotalRequests[i][j]);
-        }
-        gridData.put(rowData);
-      }
-      stats.put("grid_total_reqs", gridData);
+      stats.put(KEY_NAME, this.name);
+      stats.put(KEY_NUM_REQS, numReqs);
+      stats.put(KEY_GRID_SPARSE_B64, b64);
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
@@ -182,122 +235,126 @@ public class XdnGeoDemandProfiler extends AbstractDemandProfile {
   @Override
   public void combine(AbstractDemandProfile update) {
     assert update instanceof XdnGeoDemandProfiler : "Invalid profiler type";
-    XdnGeoDemandProfiler incomingProfiler = (XdnGeoDemandProfiler) update;
-    assert incomingProfiler.name.equals(this.name) : "Expecting profiler for the same service";
-    assert incomingProfiler.gridTotalRequests.length == NUM_GRID_ROWS : "Invalid grid dimension";
-    assert incomingProfiler.gridTotalRequests[0].length == NUM_GRID_COLUMNS
-        : "Invalid grid dimension";
+    XdnGeoDemandProfiler incoming = (XdnGeoDemandProfiler) update;
+    assert incoming.name.equals(this.name) : "Expecting profiler for the same service";
 
-    this.totalRequests += incomingProfiler.totalRequests;
-
-    for (int i = 0; i < NUM_GRID_ROWS; i++) {
-      for (int j = 0; j < NUM_GRID_COLUMNS; j++) {
-        gridTotalRequests[i][j] += incomingProfiler.gridTotalRequests[i][j];
+    mapLock.lock();
+    try {
+      this.totalRequests += incoming.totalRequests;
+      for (Map.Entry<Integer, Integer> e : incoming.sparseGrid.entrySet()) {
+        this.sparseGrid.merge(e.getKey(), e.getValue(), Integer::sum);
       }
+    } finally {
+      mapLock.unlock();
     }
   }
 
   @Override
   public Set<String> reconfigure(Set<String> curActives, ReconfigurableAppInfo appInfo) {
     NodeIdsMetadataPair<String> result = this.getNewActivesPlacement(curActives, appInfo);
-    if (result == null) return null;
-    return result.nodeIds();
+    return result == null ? null : result.nodeIds();
   }
 
   @Override
   public NodeIdsMetadataPair<String> getNewActivesPlacement(
       Set<String> curActives, ReconfigurableAppInfo appInfo) {
-    if (this.totalRequests == 0) {
+    if (this.totalRequests == 0 || this.sparseGrid.isEmpty()) {
+      return null;
+    }
+    if (curActives == null || curActives.isEmpty()) {
       return null;
     }
 
-    Map<String, InetSocketAddress> actives = appInfo.getAllActiveReplicas();
-    for (Map.Entry<String, InetSocketAddress> entry : actives.entrySet()) {
-      System.out.println(">>>> " + entry.getKey() + " " + entry.getValue());
+    Map<String, Geolocation> nodeGeo = appInfo.getActiveReplicaGeolocations();
+    // TODO: thread ServiceProperty.numReplicas through a future ReconfigurableAppInfo method so
+    // replica-count changes (scale up / down) are honored. For now we target the current group
+    // size, which equals the configured --num-replicas in steady state.
+    int targetReplicas = Math.min(curActives.size(), nodeGeo.size());
+    if (targetReplicas == 0 || nodeGeo.size() < curActives.size()) {
+      // Not enough geolocated nodes to place a full replica group; skip reconfiguration.
+      return null;
     }
 
-    // TODO: pick servers based on the demand stats
-    //   - calculate centroids
-    //   - pick the closest leader
-    //   - pick other machines
-    //   Currently we return null, which means no reconfiguration is needed.
+    double[] centroid = calculateCentroidLatLon();
+    Set<String> newActives = findClosestServers(centroid[0], centroid[1], targetReplicas, nodeGeo);
+    String preferredCoordinator =
+        findClosestServers(centroid[0], centroid[1], 1, nodeGeo).iterator().next();
 
-    // Find the 3 closest servers to the centroid
-    int[] centroid = this.calculateCentroid();
-    Set<String> closestServers = this.findClosestServers(centroid[0], centroid[1], 3);
-    System.out.println(">>> centroid " + Arrays.toString(centroid));
-    System.out.println(">>> servers: " + closestServers);
-
-    // Metadata stores the Node ID of the preferred leader
-    Set<String> centroidServer = this.findClosestServers(centroid[0], centroid[1], 1);
-    String preferredCoordinatorNodeId = centroidServer.iterator().next();
     JSONObject metadataJson = new JSONObject();
     try {
-      metadataJson.put(Keys.PREFERRED_COORDINATOR.toString(), preferredCoordinatorNodeId);
+      metadataJson.put(Keys.PREFERRED_COORDINATOR.toString(), preferredCoordinator);
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
-    String metadata = metadataJson.toString();
-    LOGGER.log(Level.FINE, "metadata: " + metadata);
+    LOGGER.log(
+        Level.FINE,
+        "XdnGeoDemandProfiler placement for {0}: centroid=({1},{2}) actives={3} coord={4}",
+        new Object[] {this.name, centroid[0], centroid[1], newActives, preferredCoordinator});
 
-    return new NodeIdsMetadataPair<>(closestServers, metadata);
+    return new NodeIdsMetadataPair<>(newActives, metadataJson.toString());
   }
 
-  private int[] calculateCentroid() {
-    // Iterate over the matrix to calculate the weighted sums
-    var matrix = this.gridTotalRequests;
+  private double[] calculateCentroidLatLon() {
     double totalWeight = 0;
-    double weightedRowSum = 0;
-    double weightedColSum = 0;
-    for (int row = 0; row < matrix.length; row++) {
-      for (int col = 0; col < matrix[row].length; col++) {
-        int weight = matrix[row][col];
-        totalWeight += weight;
-        weightedRowSum += row * weight;
-        weightedColSum += col * weight;
-      }
+    double weightedLatSum = 0;
+    double weightedLonSum = 0;
+    for (Map.Entry<Integer, Integer> e : sparseGrid.entrySet()) {
+      int idx = e.getKey();
+      int count = e.getValue();
+      int row = idx / NUM_GRID_COLUMNS;
+      int col = idx % NUM_GRID_COLUMNS;
+      double lat = rowCenterToLat(row);
+      double lon = colCenterToLon(col);
+      totalWeight += count;
+      weightedLatSum += lat * count;
+      weightedLonSum += lon * count;
     }
-
-    // Handle edge case: if total weight is zero, return the center of the matrix
     if (totalWeight == 0) {
-      return new int[] {0, 0};
+      return new double[] {0.0, 0.0};
     }
-
-    // Calculate the centroid as weighted averages
-    double centroidRow = weightedRowSum / totalWeight;
-    double centroidCol = weightedColSum / totalWeight;
-
-    return new int[] {(int) centroidRow, (int) centroidCol};
+    return new double[] {weightedLatSum / totalWeight, weightedLonSum / totalWeight};
   }
 
-  private Set<String> findClosestServers(int row, int col, int numClosestServers) {
+  private Set<String> findClosestServers(
+      double lat, double lon, int numClosest, Map<String, Geolocation> nodeGeo) {
     record ServerDistance(String id, double distance) {}
-    ;
-    List<ServerDistance> servers = new ArrayList<>();
-
-    for (Map.Entry<String, int[]> entry : this.serverLocations.entrySet()) {
-      int serverRow = entry.getValue()[0];
-      int serverCol = entry.getValue()[1];
-      String serverId = entry.getKey();
-
-      double distance = Math.sqrt(Math.pow(col - serverCol, 2) + Math.pow(row - serverRow, 2));
-
-      servers.add(new ServerDistance(serverId, distance));
+    List<ServerDistance> servers = new ArrayList<>(nodeGeo.size());
+    for (Map.Entry<String, Geolocation> e : nodeGeo.entrySet()) {
+      Geolocation g = e.getValue();
+      double dLat = g.latitude() - lat;
+      double dLon = g.longitude() - lon;
+      servers.add(new ServerDistance(e.getKey(), dLat * dLat + dLon * dLon));
     }
-
-    servers.sort(Comparator.comparingDouble(s -> s.distance));
-
+    servers.sort(Comparator.comparingDouble(ServerDistance::distance));
     Set<String> result = new HashSet<>();
-    for (int i = 0; i < numClosestServers; i++) {
-      result.add(servers.get(i).id);
+    for (int i = 0; i < numClosest && i < servers.size(); i++) {
+      result.add(servers.get(i).id());
     }
     return result;
   }
 
-  // TODO: update reconfigure to also compute metadata (e.g., which node should be the leader).
-
   @Override
   public void justReconfigured() {
-    // do nothing
+    // no-op
+  }
+
+  // Cell math: latitude ∈ [-90, 90] maps north-to-south to row ∈ [0, NUM_GRID_ROWS), longitude ∈
+  // [-180, 180] maps west-to-east to col ∈ [0, NUM_GRID_COLUMNS).
+  private static int latToRow(double latitude) {
+    int row = (int) Math.floor((90.0 - latitude) * NUM_GRID_ROWS / 180.0);
+    return Math.max(0, Math.min(NUM_GRID_ROWS - 1, row));
+  }
+
+  private static int lonToCol(double longitude) {
+    int col = (int) Math.floor((longitude + 180.0) * NUM_GRID_COLUMNS / 360.0);
+    return Math.max(0, Math.min(NUM_GRID_COLUMNS - 1, col));
+  }
+
+  private static double rowCenterToLat(int row) {
+    return 90.0 - (row + 0.5) * 180.0 / NUM_GRID_ROWS;
+  }
+
+  private static double colCenterToLon(int col) {
+    return -180.0 + (col + 0.5) * 360.0 / NUM_GRID_COLUMNS;
   }
 }

--- a/test/edu/umass/cs/xdn/XdnGeoDemandProfilerTest.java
+++ b/test/edu/umass/cs/xdn/XdnGeoDemandProfilerTest.java
@@ -1,0 +1,235 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.nio.interfaces.Geolocation;
+import edu.umass.cs.reconfiguration.interfaces.ReconfigurableAppInfo;
+import edu.umass.cs.reconfiguration.reconfigurationutils.NodeIdsMetadataPair;
+import edu.umass.cs.xdn.request.XdnHttpRequest;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+public class XdnGeoDemandProfilerTest {
+
+  private static final String SERVICE_NAME = "svc-geo-test";
+
+  @Test
+  public void testRoundTripAndResetOnReport() throws Exception {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+
+    // Feed 5 events from Boston-ish coordinates.
+    for (int i = 0; i < 5; i++) {
+      profiler.shouldReportDemandStats(makeRequest(42.36, -71.06), null, null);
+    }
+    awaitWorkerDrain(profiler, 5);
+
+    JSONObject first = profiler.getDemandStats();
+    assertEquals(SERVICE_NAME, first.getString("name"));
+    assertEquals(5L, first.getLong("num_reqs"));
+
+    // Round-trip through the JSON ctor.
+    XdnGeoDemandProfiler round = new XdnGeoDemandProfiler(first);
+    JSONObject rehydrated = round.getDemandStats();
+    assertEquals(5L, rehydrated.getLong("num_reqs"));
+    // The rehydrated profiler's sparse map matches the original.
+    assertEquals(first.getString("grid_sparse_b64"), rehydrated.getString("grid_sparse_b64"));
+
+    // Second call on the original should now be empty (reset-on-report).
+    JSONObject second = profiler.getDemandStats();
+    assertEquals(0L, second.getLong("num_reqs"));
+  }
+
+  @Test
+  public void testNullClientGeoIsIgnored() throws Exception {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+    // No X-Client-Location header.
+    Request req = makeRequestNoGeo();
+    assertFalse(profiler.shouldReportDemandStats(req, null, null));
+
+    JSONObject stats = profiler.getDemandStats();
+    assertEquals(0L, stats.getLong("num_reqs"));
+  }
+
+  @Test
+  public void testWrongServiceIsIgnored() throws Exception {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+    // Build a request for a different service name.
+    Request other = makeRequestForService("different-svc", 42.0, -71.0);
+    assertFalse(profiler.shouldReportDemandStats(other, null, null));
+    assertEquals(0L, profiler.getDemandStats().getLong("num_reqs"));
+  }
+
+  @Test
+  public void testCentroidPicksClosestReplicaGroup() throws Exception {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+
+    // Demand biased to (42, -71) — Boston area.
+    for (int i = 0; i < 50; i++) {
+      profiler.shouldReportDemandStats(makeRequest(42.0, -71.0), null, null);
+    }
+    awaitWorkerDrain(profiler, 50);
+
+    Map<String, Geolocation> nodeGeo = new HashMap<>();
+    nodeGeo.put("AR_boston", new Geolocation(42.3, -71.1));
+    nodeGeo.put("AR_london", new Geolocation(51.5, -0.1));
+    nodeGeo.put("AR_tokyo", new Geolocation(35.7, 139.7));
+    nodeGeo.put("AR_sydney", new Geolocation(-33.9, 151.2));
+
+    ReconfigurableAppInfo appInfo = makeAppInfo(nodeGeo);
+    Set<String> curActives = Set.of("AR_london", "AR_tokyo");
+    NodeIdsMetadataPair<String> result = profiler.getNewActivesPlacement(curActives, appInfo);
+
+    assertNotNull(result);
+    assertEquals(2, result.nodeIds().size());
+    assertTrue(result.nodeIds().contains("AR_boston"), "Boston must be among closest to demand");
+    assertTrue(result.placementMetadata().contains("AR_boston"), "Boston must be preferred coord");
+  }
+
+  @Test
+  public void testNoReconfigWhenNoDemand() {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+    Map<String, Geolocation> nodeGeo = new HashMap<>();
+    nodeGeo.put("AR_a", new Geolocation(0.0, 0.0));
+    nodeGeo.put("AR_b", new Geolocation(10.0, 10.0));
+    ReconfigurableAppInfo appInfo = makeAppInfo(nodeGeo);
+    assertNull(profiler.getNewActivesPlacement(Set.of("AR_a", "AR_b"), appInfo));
+  }
+
+  @Test
+  public void testNoReconfigWhenAppInfoHasNoGeo() throws Exception {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+    profiler.shouldReportDemandStats(makeRequest(42.0, -71.0), null, null);
+    awaitWorkerDrain(profiler, 1);
+    ReconfigurableAppInfo appInfo = makeAppInfo(Map.of());
+    assertNull(profiler.getNewActivesPlacement(Set.of("AR_a", "AR_b"), appInfo));
+  }
+
+  @Test
+  public void testTopKTrimUnderSizeCap() throws Exception {
+    XdnGeoDemandProfiler profiler = new XdnGeoDemandProfiler(SERVICE_NAME);
+
+    // Populate many distinct cells so the sparse map exceeds the top-K budget.
+    // Walk latitude in 0.1-degree steps and send a few hits per cell.
+    int sent = 0;
+    for (int i = 0; i < 500; i++) {
+      double lat = -70.0 + 0.25 * i;
+      if (lat > 70.0) break;
+      double lon = -170.0 + 0.25 * i;
+      if (lon > 170.0) break;
+      int hits = (i % 5) + 1; // 1..5 hits per cell
+      for (int h = 0; h < hits; h++) {
+        profiler.shouldReportDemandStats(makeRequest(lat, lon), null, null);
+        sent++;
+      }
+    }
+    awaitWorkerDrain(profiler, sent);
+
+    JSONObject stats = profiler.getDemandStats();
+    // Payload must fit within the configured DB cap (4096 bytes).
+    assertTrue(
+        stats.toString().length() < 4096,
+        "Serialized stats exceed MAX_DEMAND_PROFILE_SIZE: " + stats.toString().length());
+    // Round-trip survives and does not crash on truncation.
+    XdnGeoDemandProfiler round = new XdnGeoDemandProfiler(stats);
+    assertNotNull(round.getDemandStats());
+  }
+
+  // --- helpers ---
+
+  private static void awaitWorkerDrain(XdnGeoDemandProfiler profiler, long expectedTotal)
+      throws Exception {
+    // getDemandStats() blocks on the same ReentrantLock the worker uses, but the queue drain is
+    // asynchronous. Poll a few times to let the worker catch up.
+    long deadline = System.currentTimeMillis() + 2000;
+    while (System.currentTimeMillis() < deadline) {
+      // Peek num_reqs via a dummy snapshot call isn't ideal because it resets state. Instead we
+      // just sleep a short while — worker consumes events well under 1 ms each.
+      Thread.sleep(25);
+      // Snapshot-and-return: we consume and then re-inject so the next caller sees the same
+      // aggregate. This keeps the test helper non-destructive.
+      JSONObject s = profiler.getDemandStats();
+      long gotReqs = s.getLong("num_reqs");
+      // Re-inject by combining a rehydrated profiler back in.
+      if (gotReqs > 0) {
+        profiler.combine(new XdnGeoDemandProfiler(s));
+      }
+      if (gotReqs >= expectedTotal) {
+        return;
+      }
+    }
+    throw new AssertionError(
+        "Worker did not drain " + expectedTotal + " events in time for " + profiler);
+  }
+
+  private static Request makeRequest(double lat, double lon) {
+    return makeRequestForService(SERVICE_NAME, lat, lon);
+  }
+
+  private static Request makeRequestForService(String serviceName, double lat, double lon) {
+    HttpRequest raw =
+        new DefaultHttpRequest(
+            HttpVersion.HTTP_1_1,
+            HttpMethod.GET,
+            "/?_xdnsvc=" + serviceName,
+            new DefaultHttpHeaders()
+                .add("XDN", serviceName)
+                .add(XdnHttpRequest.X_CLIENT_LOCATION_HEADER, lat + "," + lon));
+    HttpContent content =
+        new DefaultHttpContent(Unpooled.copiedBuffer("x".getBytes(StandardCharsets.UTF_8)));
+    return new XdnHttpRequest(raw, content);
+  }
+
+  private static Request makeRequestNoGeo() {
+    HttpRequest raw =
+        new DefaultHttpRequest(
+            HttpVersion.HTTP_1_1,
+            HttpMethod.GET,
+            "/?_xdnsvc=" + SERVICE_NAME,
+            new DefaultHttpHeaders().add("XDN", SERVICE_NAME));
+    HttpContent content =
+        new DefaultHttpContent(Unpooled.copiedBuffer("x".getBytes(StandardCharsets.UTF_8)));
+    return new XdnHttpRequest(raw, content);
+  }
+
+  private static ReconfigurableAppInfo makeAppInfo(Map<String, Geolocation> nodeGeo) {
+    return new ReconfigurableAppInfo() {
+      @Override
+      public Set<String> getReplicaGroup(String serviceName) {
+        return nodeGeo.keySet();
+      }
+
+      @Override
+      public String snapshot(String serviceName) {
+        return null;
+      }
+
+      @Override
+      public Map<String, InetSocketAddress> getAllActiveReplicas() {
+        Map<String, InetSocketAddress> m = new HashMap<>();
+        for (String id : nodeGeo.keySet()) {
+          m.put(id, new InetSocketAddress("127.0.0.1", 0));
+        }
+        return m;
+      }
+
+      @Override
+      public Map<String, Geolocation> getActiveReplicaGeolocations() {
+        return nodeGeo;
+      }
+    };
+  }
+}


### PR DESCRIPTION
  Continues the XdnGeoDemandProfiler prototype so it can drive geo-aware replica placement from real client and node geolocations instead of hardcoded placeholders.

  - **Async worker on the AR side.** 
   shouldReportDemandStats is now a hot-path no-op for unattributed traffic and a single queue.offer(clientGeo) + atomic time check for the rest. 
  A per-profiler daemon worker pulls events off a 16k-capacity LinkedBlockingQueue, does the lat/lon → cell math, and updates the sparse grid under a ReentrantLock. 
  Pattern follows FailureDetection / RequestBatcher.
  - **Sparse 1000×1000 grid + compact wire format.** 
   Counters live in a HashMap<Integer,Integer>. 
   getDemandStats snapshots the map, serializes as int32 numEntries + (int32 idx, int32 count) pairs base64-encoded into grid_sparse_b64, then resets the local map so each report covers demand since the previous report (the RC's combine() accumulates across reports). 
   Top-K trim caps each report at 300 entries to stay under the 4 KB MAX_DEMAND_PROFILE_SIZE DB cap.
  - **Real (lat,lon) on both sides.** 
  XdnHttpRequest.getClientGeolocation() (X-Client-Location header, already parsed upstream) is the per-request input; the dummy diagonal serverLocations map is gone. 
  ReconfigurableAppInfo gains a default method getActiveReplicaGeolocations() returning Map<String, Geolocation>; Reconfigurator overrides it by walking consistentNodeConfig.getActiveReplicas() + getNodeGeolocation(id). 
  Centroid math is now in real lat/lon; closest-server selection uses squared-Euclidean.
  - **Replica count from curActives.size().** 
   Replaces the hardcoded 3. 
   Documented as a prototype proxy until ServiceProperty.numReplicas is plumbed through.
  - **Test coverage.** 
   New XdnGeoDemandProfilerTest (7 cases): JSON round-trip + reset-on-report, null-client-geo skip, wrong-service skip, centroid-picks-closest replica group, no-reconfig-when-no-demand, no-reconfig-when-no-geo, top-K trim under the size cap.

  Out of scope (future work, called out in the class javadoc): 
  IP → lat/lon inference for clients that don't send X-Client-Location; per-coordinator placement heuristics (the RC doesn't know a service's ConsistencyModel today).
