### PR TITLE
Add xdn-bw-trace: inter-replica bandwidth/latency tracer

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -136,19 +136,29 @@ jobs:
       run: |
         set -x
         sudo apt-get update
-        sudo apt-get install -y pkg-config libfuse3-dev fuse3
-        sudo modprobe fuse
+        sudo apt-get install -y pkg-config libfuse3-dev libzstd-dev fuse3
+        sudo modprobe fuse  # Ensure FUSE kernel module is loaded
         sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
         ls -l /dev/fuse
         grep user_allow_other /etc/fuse.conf
         fusermount3 -V
-
-    - name: 🏗️ Build jar and link binaries
+    - name: 🐹 Set up Go  # Required for build_xdn_cli.sh
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: xdn-cli/go.mod
+    - name: 🦀 Set up Rust  # Required for build_xdn_fuselog.sh (fuserust)
+      uses: dtolnay/rust-toolchain@stable
+    - name: 🏗️ Build jar and prepare binaries
       run: |
+        set -x
         ant jar
-        ln -sf "$(pwd)/bin/fuselog" /usr/local/bin/fuselog
-        ln -sf "$(pwd)/bin/fuselog-apply" /usr/local/bin/fuselog-apply
-        ln -sf "$(pwd)/bin/xdn" /usr/local/bin/xdn
+        # Both build scripts compile their host binaries and install them
+        # under /usr/local/bin/ themselves. The Java state-diff recorders
+        # (FuselogStateDiffRecorder, FuseRustStateDiffRecorder) hardcode
+        # those absolute paths.
+        bash bin/build_xdn_cli.sh
+        bash bin/build_xdn_fuselog.sh install
+        # xdnd is a checked-in shell script; no build script wraps it.
         ln -sf "$(pwd)/bin/xdnd" /usr/local/bin/xdnd
 
     - name: 🏗️ Compile tests

--- a/.github/workflows/geo-demand-smoke.yml
+++ b/.github/workflows/geo-demand-smoke.yml
@@ -75,10 +75,9 @@ jobs:
         run: |
           set -x
           ant jar
+          # build_xdn_cli.sh builds the host binary, symlinks bin/xdn to it,
+          # and installs /usr/local/bin/xdn (with sudo fallback if needed).
           bash bin/build_xdn_cli.sh
-          # build_xdn_cli.sh creates bin/xdn as a symlink to the host binary
-          # (matches the pattern used in ant-build-test.yml).
-          ln -sf "$(pwd)/bin/xdn" /usr/local/bin/xdn
 
       - name: Start XDN cluster with geodemand config
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ screen_logs
 merge-review
 *-paper/
 .claude
+*.tar.gz
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Use the `bin/xdnd` shell script (driver-machine orchestrator) for multi-host dep
 - **Java**: Core platform — GigaPaxos consensus, replication protocols, reconfiguration, XDN service management
 - **Go**: CLI tool (`xdn-cli/`) using Cobra; DNS server (`xdn-dns/`) built on CoreDNS — each is a separate Go module
 - **Rust/C++**: Filesystem layer (`xdn-fs/`) for state differential recording via FUSE
+- **Python**: Top-level `eval/` (experiment harness, k6 load drivers, plot/analysis scripts) and `xdn-bw-trace/` (bpftrace-based bandwidth tracer + plotters). Note this is distinct from the Java `eval/` *subpackage* under `src/edu/umass/cs/xdn/eval/`.
 
 ### Key Java Packages (`src/edu/umass/cs/`)
 - `gigapaxos/` — Paxos consensus protocol implementation
@@ -208,11 +209,23 @@ Each node's `(lat, lon)` can be set in the gigapaxos properties file (see
 type. It flows through `ReconfigurableNodeConfig` and `Reconfigurator` into
 `GetReplicaPlacementRequest`, and is surfaced by `xdn service info`.
 
+### Client Geolocation and Geo-Demand Profiling
+Clients can advertise their location via the `X-Client-Location: <lat>,<lon>`
+HTTP header. `XdnGeoDemandProfiler` parses that header on the AR frontend and
+accumulates per-region demand in a background worker; the demand distribution
+feeds into `XdnReplicaPlacementProfile` so the Reconfigurator can re-place
+replicas closer to where load is actually coming from. The geo-demand
+end-to-end pipeline is exercised by `eval/geo_demand_smoke.py` (driven by
+the `geo-demand-smoke.yml` CI job).
+
 ### `xdn-cli` subcommands (`xdn-cli/cmd/`)
 Cobra-based CLI. Top-level verbs include `launch`, `status`, `check`, and the `service` command group. `service` covers: `info`, `destroy`, `move` (relocate a service to new replica hosts; drives synchronous paxos leader change), `leader` (inspect/set the paxos leader). `launch` accepts `--num-replicas`, `--min-replicas`, `--max-replicas` in addition to `--image`, `--state`, `--deterministic`, etc. Mutating subcommands prompt for yes/no confirmation on stdin.
 
 ### XDN-internal URL params
 URL query parameters prefixed with `_xdn` (e.g. `_xdnsvc`) are consumed at the XDN/proxy layer and must be stripped from the request URI before it is forwarded to the containerized service. `_xdnsvc` provides the service name directly as a URL param and is used as a developer-experience alternative to setting the `XDN:` header.
+
+### Bandwidth/Latency Tracing (`xdn-bw-trace/`)
+Per-service inter-replica + client⇄replica TCP bandwidth tracer built on bpftrace, with companion plotting scripts. `inter_replica_bw.bt` attaches kprobes on `tcp_sendmsg`/`tcp_cleanup_rbuf` and aggregates bytes by `(pid, local_port, peer_ip, peer_port)`. `trace_bw.py` discovers cluster topology from the RC HTTP API, drives a mixed read/write workload across replicas, and emits a CSV + `.meta.json` sidecar to `xdn-bw-trace/results/`. `plot_bw_graph.py` and `plot_lat_graph.py` render directed bandwidth graphs and analytic (Haversine + fiber-speed) latency graphs from the geolocation in `gigapaxos.properties`. Linux only; requires `bpftrace` ≥ 0.21 and `CAP_BPF` (run as root or passwordless sudo).
 
 ### Configuration
 - `gigapaxos.properties` — Main deployment config
@@ -222,6 +235,7 @@ URL query parameters prefixed with `_xdn` (e.g. `_xdnsvc`) are consumed at the X
 - `conf/gigapaxos.xdn.cloudlab.local.{10,13}nodes.properties` — Multi-node CloudLab variants
 - `conf/gigapaxos.xdn.3way.properties`, `conf/gigapaxos.xdn.3way.cloudlab.properties` — 3-way replication variants (local + cloudlab)
 - `conf/gigapaxos.xdn.tpcc-java-pb.cloudlab.properties`, `conf/gigapaxos.xdn.wordpress-pb.cloudlab.properties` — App-specific primary-backup eval configs
+- `conf/gigapaxos.xdnlat.template.properties` — Template showing the `(lat, lon)` syntax for node geolocation
 - `testing.properties` — Test configuration (nodes, load, batch settings)
 
 Key config properties: `APPLICATION`, `REPLICA_COORDINATOR_CLASS`, `XDN_PB_STATEDIFF_RECORDER_TYPE`, `HTTP_AR_FRONTEND_BATCH_ENABLED`, `NIO_MAX_PAYLOAD_SIZE` (default 128MB).

--- a/bin/build_xdn_cli.sh
+++ b/bin/build_xdn_cli.sh
@@ -34,12 +34,13 @@ function main() {
   HOST_OS="$(uname -s)"
   HOST_ARCH="$(uname -m)"
 
+  local HOST_BIN=""
   case "${HOST_OS}-${HOST_ARCH}" in
     Linux-x86_64)
-      ln -sf "${LINUX_AMD64_BIN}" "${BIN_DIR}/xdn"
+      HOST_BIN="${LINUX_AMD64_BIN}"
       ;;
     Darwin-arm64)
-      ln -sf "${DARWIN_ARM64_BIN}" "${BIN_DIR}/xdn"
+      HOST_BIN="${DARWIN_ARM64_BIN}"
       ;;
     *)
       echo "Warning: Unsupported host (${HOST_OS}/${HOST_ARCH})."
@@ -50,15 +51,27 @@ function main() {
       ;;
   esac
 
+  local SYSTEM_LINK="/usr/local/bin/xdn"
+  if [[ -n "${HOST_BIN}" ]]; then
+    ln -sf "${HOST_BIN}" "${BIN_DIR}/xdn"
+
+    # Also expose `xdn` system-wide so it resolves on $PATH without manual setup.
+    # Try without sudo first (works on CI runners and on macOS where
+    # /usr/local/bin is user-writable); fall back to sudo on Linux dev machines.
+    if ln -sf "${HOST_BIN}" "${SYSTEM_LINK}" 2>/dev/null; then
+      echo "Symlink created: ${SYSTEM_LINK} -> ${HOST_BIN}"
+    elif command -v sudo &> /dev/null && sudo ln -sf "${HOST_BIN}" "${SYSTEM_LINK}"; then
+      echo "Symlink created (with sudo): ${SYSTEM_LINK} -> ${HOST_BIN}"
+    else
+      echo "Warning: could not create ${SYSTEM_LINK}. To install manually:"
+      echo "  sudo ln -sf ${HOST_BIN} ${SYSTEM_LINK}"
+    fi
+  fi
+
   echo "Success! binaries generated:"
   echo "  ${LINUX_AMD64_BIN}"
   echo "  ${DARWIN_ARM64_BIN}"
-  echo "Alias (if supported) at ${BIN_DIR}/xdn"
-  echo ""
-  echo "To run 'xdn' from anywhere in your machine, add XDN's binary directory into your \$PATH:"
-  echo "  export PATH=$XDN_ROOT/bin/:\$PATH"
-  echo ""
-  echo "assuming \$XDN_ROOT is $XDN_ROOT"
+  echo "Alias (if supported) at ${BIN_DIR}/xdn and ${SYSTEM_LINK}"
 }
 
 main "$@"

--- a/bin/build_xdn_fuselog.sh
+++ b/bin/build_xdn_fuselog.sh
@@ -10,6 +10,10 @@
 #   ./bin/build_xdn_fuselog.sh test      # Build and run C++ unit tests (GoogleTest)
 #   ./bin/build_xdn_fuselog.sh bench     # Build and run compute_diff microbenchmark
 #   ./bin/build_xdn_fuselog.sh install   # Build both and install to /usr/local/bin
+#
+# Every target also installs /usr/local/bin/ symlinks for whatever was built.
+# The Java state-diff recorders (FuselogStateDiffRecorder, FuseRustStateDiffRecorder)
+# look up these binaries by absolute path under /usr/local/bin/.
 
 set -e
 
@@ -53,12 +57,7 @@ function main() {
       echo "Build complete."
       exit 0
       ;;
-    install)
-      build_cpp
-      build_rust
-      install_binaries
-      ;;
-    all)
+    all|install)
       build_cpp
       build_rust
       ;;
@@ -70,6 +69,7 @@ function main() {
   esac
 
   stage_project_binaries
+  install_symlinks
   echo "Build complete."
 }
 
@@ -183,32 +183,32 @@ function stage_project_binaries() {
   fi
 }
 
-function install_binaries() {
-  echo "=== Installing binaries to /usr/local/bin/ ==="
+function install_symlinks() {
+  echo "=== Installing symlinks at /usr/local/bin/ ==="
 
   local INSTALL_DIR="/usr/local/bin"
+  local names=(fuselog fuselog-apply fuserust fuserust-apply)
+  local name src dst
 
-  # C++ binaries
-  if [[ -f "$CPP_DIR/fuselog" ]]; then
-    cp "$CPP_DIR/fuselog" "$INSTALL_DIR/fuselog"
-    echo "  Installed fuselog"
-  fi
-  if [[ -f "$CPP_DIR/fuselog-apply" ]]; then
-    cp "$CPP_DIR/fuselog-apply" "$INSTALL_DIR/fuselog-apply"
-    echo "  Installed fuselog-apply"
-  fi
+  for name in "${names[@]}"; do
+    src="$BIN_DIR/$name"
+    dst="$INSTALL_DIR/$name"
 
-  # Rust binaries
-  if [[ -f "$RUST_DIR/target/release/fuselog_core" ]]; then
-    cp "$RUST_DIR/target/release/fuselog_core" "$INSTALL_DIR/fuserust"
-    echo "  Installed fuserust"
-  fi
-  if [[ -f "$RUST_DIR/target/release/fuselog_apply" ]]; then
-    cp "$RUST_DIR/target/release/fuselog_apply" "$INSTALL_DIR/fuserust-apply"
-    echo "  Installed fuserust-apply"
-  fi
+    # Only symlink binaries that this invocation actually built+staged.
+    # `cpp` runs leave fuserust* missing; `rust` runs leave fuselog* missing.
+    [[ -f "$src" ]] || continue
 
-  echo "  Installation complete."
+    # Try without sudo first (works on CI runners and on macOS where
+    # /usr/local/bin is user-writable); fall back to sudo on Linux dev machines.
+    if ln -sf "$src" "$dst" 2>/dev/null; then
+      echo "  Symlinked: $dst -> $src"
+    elif command -v sudo &>/dev/null && sudo ln -sf "$src" "$dst"; then
+      echo "  Symlinked (with sudo): $dst -> $src"
+    else
+      echo "  Warning: could not create $dst. To install manually:"
+      echo "    sudo ln -sf $src $dst"
+    fi
+  done
 }
 
 main "$@"

--- a/conf/gigapaxos.xdn.5way.cloudlab.properties
+++ b/conf/gigapaxos.xdn.5way.cloudlab.properties
@@ -1,0 +1,48 @@
+APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp
+
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+
+ENABLE_ACTIVE_REPLICA_HTTP=true
+ENABLE_RECONFIGURATOR_HTTP=true
+BATCHING_ENABLED=false
+REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator
+ENABLE_STARTUP_LEADER_ELECTION=false
+HIBERNATE_OPTION=true
+
+# 768MB
+# Needed for large non-deterministic state transfer packets (observed ~663MB in logs).
+NIO_MAX_PAYLOAD_SIZE=805306368
+
+INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator
+INITIAL_STATE_NUM_REPLICAS_EXTRACTOR_CLASS=edu.umass.cs.xdn.XdnServiceNumReplicasExtractor
+XDN_PB_STATEDIFF_RECORDER_TYPE=FUSELOG
+XDN_FUSELOG_BASE_DIR=/dev/shm/xdn/state/fuselog/
+XDN_PB_ENABLE_NON_DETERMINISTIC_INIT=true
+
+REPLICATE_ALL=false
+EMULATE_UNREPLICATED=false
+HTTP_AR_FRONTEND_BATCH_ENABLED=true
+HTTP_AR_FRONTEND_REQUEST_TIMEOUT_MS=600000
+XDN_HTTP_MAX_POOL_SIZE=128
+
+# 5 ARs across 3 hosts. Co-located ARs share a host so they MUST use distinct
+# NIO ports (and therefore distinct HTTP ports, which are NIO+300).
+#   10.10.1.1 → AR0 (2000), AR3 (2003)
+#   10.10.1.2 → AR1 (2000), AR4 (2004)
+#   10.10.1.3 → AR2 (2000)
+# format: active.<active_server_name>=host:port
+active.AR0=10.10.1.1:2000
+active.AR1=10.10.1.2:2000
+active.AR2=10.10.1.3:2000
+active.AR3=10.10.1.1:2003
+active.AR4=10.10.1.2:2004
+
+active.AR0.geolocation="39.5832,-82.3511"
+active.AR1.geolocation="3.1490,37.0425"
+active.AR2.geolocation="81.3236,11.4012"
+active.AR3.geolocation="48.8566,2.3522"
+active.AR4.geolocation="-33.8688,151.2093"
+
+# format: reconfigurator.<active_server_name>=host:port
+reconfigurator.RC0=10.10.1.4:3000
+SYNC=true

--- a/conf/gigapaxos.xdn.5way.numeric.cloudlab.properties
+++ b/conf/gigapaxos.xdn.5way.numeric.cloudlab.properties
@@ -1,0 +1,50 @@
+APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp
+
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+
+ENABLE_ACTIVE_REPLICA_HTTP=true
+ENABLE_RECONFIGURATOR_HTTP=true
+BATCHING_ENABLED=false
+REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator
+ENABLE_STARTUP_LEADER_ELECTION=false
+HIBERNATE_OPTION=true
+
+# 768MB
+# Needed for large non-deterministic state transfer packets (observed ~663MB in logs).
+NIO_MAX_PAYLOAD_SIZE=805306368
+
+INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator
+INITIAL_STATE_NUM_REPLICAS_EXTRACTOR_CLASS=edu.umass.cs.xdn.XdnServiceNumReplicasExtractor
+XDN_PB_STATEDIFF_RECORDER_TYPE=FUSELOG
+XDN_FUSELOG_BASE_DIR=/dev/shm/xdn/state/fuselog/
+XDN_PB_ENABLE_NON_DETERMINISTIC_INIT=true
+
+REPLICATE_ALL=false
+EMULATE_UNREPLICATED=false
+HTTP_AR_FRONTEND_BATCH_ENABLED=true
+HTTP_AR_FRONTEND_REQUEST_TIMEOUT_MS=600000
+XDN_HTTP_MAX_POOL_SIZE=128
+
+# Numeric node IDs to engage IntegerMap.allInt() => byteification path in
+# RequestPacket.toBytes() (otherwise gigapaxos falls back to JSON, which is
+# materially larger on the wire). Topology identical to
+# gigapaxos.xdn.5way.cloudlab.properties:
+#   10.10.1.1 → 0 (port 2000), 3 (port 2003)
+#   10.10.1.2 → 1 (port 2000), 4 (port 2004)
+#   10.10.1.3 → 2 (port 2000)
+# format: active.<active_server_name>=host:port
+active.0=10.10.1.1:2000
+active.1=10.10.1.2:2000
+active.2=10.10.1.3:2000
+active.3=10.10.1.1:2003
+active.4=10.10.1.2:2004
+
+active.0.geolocation="39.5832,-82.3511"
+active.1.geolocation="3.1490,37.0425"
+active.2.geolocation="81.3236,11.4012"
+active.3.geolocation="48.8566,2.3522"
+active.4.geolocation="-33.8688,151.2093"
+
+# format: reconfigurator.<active_server_name>=host:port
+reconfigurator.5=10.10.1.4:3000
+SYNC=true

--- a/conf/gigapaxos.xdn.local.numeric.properties
+++ b/conf/gigapaxos.xdn.local.numeric.properties
@@ -11,7 +11,7 @@ HIBERNATE_OPTION=true
 SYNC=true
 
 # 768MB
-# Needed for large non-deterministic state transfer packets 
+# Needed for large non-deterministic state transfer packets
 # (observed ~663MB in logs).
 NIO_MAX_PAYLOAD_SIZE=805306368
 
@@ -28,20 +28,22 @@ XDN_HTTP_MAX_POOL_SIZE=128
 
 DEMAND_PROFILE_TYPE=edu.umass.cs.xdn.XdnGeoDemandProfiler
 
+# Numeric node IDs to engage IntegerMap.allInt() => byteification path
+# in RequestPacket.toBytes(). Identical to gigapaxos.xdn.local.properties
+# in every other respect.
 # format: active.<active_server_name>=host:port
-active.AR0=127.0.0.1:2000
-active.AR1=127.0.0.1:2001
-active.AR2=127.0.0.1:2002
-active.AR3=127.0.0.1:2003
-active.AR4=127.0.0.1:2004
+active.0=127.0.0.1:2000
+active.1=127.0.0.1:2001
+active.2=127.0.0.1:2002
+active.3=127.0.0.1:2003
+active.4=127.0.0.1:2004
 
 # format: active.<active_server_name>.geolocation="latitude,longitude"
-# AR0, AR1 in us-east-1 (Northern Virginia); AR2, AR3 in us-west-1 (Northern California).
-active.AR0.geolocation="38.1300,-78.4500"
-active.AR1.geolocation="38.9500,-77.4500"
-active.AR2.geolocation="37.7800,-122.4200"
-active.AR3.geolocation="37.3600,-121.9200"
-active.AR4.geolocation="37.3600,-120.9200"
+active.0.geolocation="38.1300,-78.4500"
+active.1.geolocation="38.9500,-77.4500"
+active.2.geolocation="37.7800,-122.4200"
+active.3.geolocation="37.3600,-121.9200"
+active.4.geolocation="37.3600,-120.9200"
 
 # format: reconfigurator.<active_server_name>=host:port
-reconfigurator.RC0=127.0.0.1:3000
+reconfigurator.5=127.0.0.1:3000

--- a/conf/logging.debug.properties
+++ b/conf/logging.debug.properties
@@ -1,0 +1,45 @@
+################################################################################
+#   Gigapaxos Debug Logging — captures per-request timing for failure analysis
+################################################################################
+
+handlers=java.util.logging.ConsoleHandler, java.util.logging.FileHandler
+
+# Default global level — keep at WARNING so unrelated classes don't flood.
+.level=WARNING
+
+java.util.logging.FileHandler.level=INFO
+java.util.logging.FileHandler.pattern=./output/gigapaxos.log
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS.%1$tN [%4$s] %5$s%6$s%n
+java.util.logging.FileHandler.limit=20000000
+java.util.logging.FileHandler.count=10
+
+java.util.logging.ConsoleHandler.level=FINEST
+
+################################################################################
+# Per-class levels — INFO for the classes that log execute / forward / propose
+# timings; WARNING for everything else to keep the signal-to-noise high.
+################################################################################
+edu.umass.cs.level=WARNING
+
+# These three log timings around the slow path:
+#  - XdnGigapaxosApp: per-request "execution within Xms" (line 265 of XdnGigapaxosApp.java)
+#  - XdnHttpForwarderClient: forward attempts, errors, slowness
+#  - AwReplicaCoordinator: "AwRC propose-to-callback Xms" (line 117 of AwReplicaCoordinator.java)
+edu.umass.cs.xdn.XdnGigapaxosApp.level=INFO
+edu.umass.cs.xdn.XdnHttpForwarderClient.level=FINE
+edu.umass.cs.sequential.AwReplicaCoordinator.level=FINE
+
+# Keep the rest at WARNING.
+edu.umass.cs.xdn.XdnGeoDemandProfiler.level=WARNING
+edu.umass.cs.xdn.XdnReplicaCoordinator.level=WARNING
+edu.umass.cs.xdn.XdnHttpRequestBatcher.level=WARNING
+edu.umass.cs.reconfiguration.http.HttpActiveReplica.level=WARNING
+edu.umass.cs.reconfiguration.ReconfigurableNode.level=WARNING
+edu.umass.cs.causal.CausalReplicaCoordinator.level=WARNING
+edu.umass.cs.clientcentric.BayouReplicaCoordinator.level=WARNING
+edu.umass.cs.reconfiguration.PaxosReplicaCoordinator.level=WARNING
+edu.umass.cs.gigapaxos.PaxosConfig.level=WARNING
+edu.umass.cs.gigapaxos.PaxosManager.level=WARNING
+edu.umass.cs.primarybackup.PrimaryBackupManager.level=WARNING
+edu.umass.cs.xdn.recorder.FuselogStateDiffRecorder.level=WARNING

--- a/src/edu/umass/cs/causal/CausalReplicaCoordinator.java
+++ b/src/edu/umass/cs/causal/CausalReplicaCoordinator.java
@@ -379,16 +379,13 @@ public class CausalReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordin
             return;
         }
 
-        // Execute the write-only request. The deserialized request may carry a
-        // stale httpResponse from the sender's execution — clear it so
-        // forwardHttpRequestToContainerizedService can set a fresh response.
+        // Execute the write-only request. The forwarded packet's wire form
+        // strips the sender's response (CausalWriteForwardPacket calls
+        // toBytes(false)), so app.execute() always sees a response-less request.
         ClientRequest clientRequest = packet.getClientWriteOnlyRequest();
         assert clientRequest instanceof BehavioralRequest behavioralRequest &&
                 behavioralRequest.isWriteOnlyRequest() :
                 "Expecting WriteOnlyRequest but got " + clientRequest.getClass().getSimpleName();
-        if (clientRequest instanceof XdnHttpRequest xhr && xhr.getHttpResponse() != null) {
-            xhr.clearHttpResponse();
-        }
         boolean isExecSuccess = this.app.execute(clientRequest);
         assert isExecSuccess;
 
@@ -454,14 +451,13 @@ public class CausalReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordin
 
             CausalWriteForwardPacket currPacket = entry.getValue();
 
-            // Execute the pending write-only request
+            // Execute the pending write-only request. The forwarded packet's
+            // wire form strips the sender's response (see
+            // CausalWriteForwardPacket#encodeRequestForForwarding).
             ClientRequest clientRequest = currPacket.getClientWriteOnlyRequest();
             assert clientRequest instanceof BehavioralRequest behavioralRequest &&
                     behavioralRequest.isWriteOnlyRequest() :
                     "Expecting WriteOnlyRequest but got " + clientRequest.getClass().getSimpleName();
-            if (clientRequest instanceof XdnHttpRequest xhr && xhr.getHttpResponse() != null) {
-                xhr.clearHttpResponse();
-            }
             boolean isExecSuccess = this.app.execute(clientRequest);
             assert isExecSuccess : "Failed to execute the pending write request";
 

--- a/src/edu/umass/cs/eventual/LazyReplicaCoordinator.java
+++ b/src/edu/umass/cs/eventual/LazyReplicaCoordinator.java
@@ -196,14 +196,8 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
                         "Expecting (Monotonic and WriteOnly) request for LazyReplicaCoordinator");
             }
 
-            if (clientRequest instanceof XdnHttpRequest xhr) {
-                xhr.clearHttpResponse();
-            } else if (clientRequest instanceof XdnHttpRequestBatch batch) {
-                for (XdnHttpRequest xhr: batch.getRequestList()) {
-                    xhr.clearHttpResponse();
-                }
-            }
-
+            // LazyWriteAfterPacket#toBytes strips the sender's response from
+            // the wire, so app.execute() sees a response-less request.
             return this.app.execute(clientRequest, true);
         }
 

--- a/src/edu/umass/cs/pram/PramReplicaCoordinator.java
+++ b/src/edu/umass/cs/pram/PramReplicaCoordinator.java
@@ -264,12 +264,9 @@ public class PramReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
             try {
                 PramWriteAfterPacket writePacket;
                 while ((writePacket = queue.poll()) != null) {
+                    // PramWriteAfterPacket#toBytes strips the sender's response
+                    // from the wire, so app.execute() sees a response-less request.
                     ClientRequest appRequest = writePacket.getClientWriteRequest();
-                    // Clear stale response from sender's execution so
-                    // forwardHttpRequestToContainerizedService can set a fresh one.
-                    if (appRequest instanceof XdnHttpRequest xhr && xhr.getHttpResponse() != null) {
-                        xhr.clearHttpResponse();
-                    }
                     boolean isExecuted = app.execute(appRequest);
                     assert isExecuted : "failed to execute write-after request";
                 }

--- a/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
+++ b/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
@@ -1248,11 +1248,22 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
                                 + executedRequest.getClass().getSimpleName();
 
                 ClientRequest requestWithResponse = (ClientRequest) executedRequest;
+                // ResponsePacket is the one wire form that intentionally carries
+                // the locally-computed response back to the entry replica, so
+                // opt in to including it. The default toBytes() now strips it.
+                byte[] encodedWithResponse;
+                if (requestWithResponse instanceof XdnHttpRequest xhr) {
+                    encodedWithResponse = xhr.toBytes(true);
+                } else if (requestWithResponse instanceof XdnHttpRequestBatch batch) {
+                    encodedWithResponse = batch.toBytes(true);
+                } else {
+                    encodedWithResponse = requestWithResponse.getResponse().toString()
+                            .getBytes(StandardCharsets.ISO_8859_1);
+                }
                 ResponsePacket resp = new ResponsePacket(
                         executedRequest.getServiceName(),
                         rp.getRequestID(),
-                        requestWithResponse.getResponse().toString().
-                                getBytes(StandardCharsets.ISO_8859_1));
+                        encodedWithResponse);
                 String entryNodeIDStr = forwardedRequestPacket.getEntryNodeId();
                 NodeIDType entryNodeID = nodeIDTypeStringifiable.valueOf(entryNodeIDStr);
                 GenericMessagingTask<NodeIDType, ResponsePacket> m =

--- a/src/edu/umass/cs/sequential/AwReplicaCoordinator.java
+++ b/src/edu/umass/cs/sequential/AwReplicaCoordinator.java
@@ -110,12 +110,15 @@ public class AwReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinator
         boolean isLeaderAtPropose = this.paxosManager.isPaxosCoordinator(serviceName);
         long proposeStartNs = System.nanoTime();
         ExecutedCallback instrumentedCallback = (response, handled) -> {
-            long elapsedMs = (System.nanoTime() - proposeStartNs) / 1_000_000;
-            boolean isLeaderAtCallback = this.paxosManager.isPaxosCoordinator(serviceName);
-            System.err.println("AwRC propose-to-callback " + elapsedMs
-                    + "ms leaderAtPropose=" + isLeaderAtPropose
-                    + " leaderAtCallback=" + isLeaderAtCallback
-                    + " node=" + this.myNodeID);
+            if (logger.isLoggable(Level.FINE)) {
+                long elapsedMs = (System.nanoTime() - proposeStartNs) / 1_000_000;
+                boolean isLeaderAtCallback = this.paxosManager.isPaxosCoordinator(serviceName);
+                logger.log(Level.FINE,
+                        "AwRC propose-to-callback {0}ms leaderAtPropose={1}"
+                                + " leaderAtCallback={2} node={3}",
+                        new Object[]{elapsedMs, isLeaderAtPropose,
+                                isLeaderAtCallback, this.myNodeID});
+            }
             callback.executed(response, handled);
         };
         this.paxosManager.propose(serviceName, rcr, instrumentedCallback);

--- a/src/edu/umass/cs/xdn/request/XdnHttpRequest.java
+++ b/src/edu/umass/cs/xdn/request/XdnHttpRequest.java
@@ -515,8 +515,20 @@ public class XdnHttpRequest extends XdnRequest
     this.httpResponseBody = null;
   }
 
+  // The default wire form is the *request* only — execution state (the locally
+  // computed httpResponse) is intentionally not included. Inter-replica
+  // forwarding paths (causal/pram/lazy write-after, paxos propose) all
+  // serialize via plain Byteable.toBytes(), and shipping a sender-computed
+  // response would trip XdnGigapaxosApp's "response must be null on entry"
+  // assertion when peers re-execute. The one path that *does* need the
+  // response on the wire (PB primary→entry response forwarding) opts in via
+  // toBytes(true).
   @Override
   public byte[] toBytes() {
+    return toBytes(false);
+  }
+
+  public byte[] toBytes(boolean includeResponse) {
     final int packetType = this.getRequestType().getInt();
 
     XdnHttpRequestProto.XdnHttpRequest.Builder builder =
@@ -528,7 +540,7 @@ public class XdnHttpRequest extends XdnRequest
             .addAllRequestHeaders(getHeaderList(this.httpRequest.headers()))
             .setRequestBody(extractBodyByteString(this.httpRequestContent.content()));
 
-    if (this.httpResponse != null) {
+    if (includeResponse && this.httpResponse != null) {
       builder.setResponse(buildResponseProto());
     }
 

--- a/src/edu/umass/cs/xdn/request/XdnHttpRequestBatch.java
+++ b/src/edu/umass/cs/xdn/request/XdnHttpRequestBatch.java
@@ -167,13 +167,19 @@ public final class XdnHttpRequestBatch extends XdnRequest
     return this.behaviors;
   }
 
+  // See XdnHttpRequest#toBytes — default wire form is request-only. PB's
+  // response-forwarding path opts in via toBytes(true).
   @Override
   public byte[] toBytes() {
+    return toBytes(false);
+  }
+
+  public byte[] toBytes(boolean includeResponse) {
     byte[][] encodedRequests = new byte[this.requests.length][];
 
     int rawSize = Integer.BYTES; // number of requests
     for (int i = 0; i < this.requests.length; i++) {
-      byte[] encoded = this.requests[i].toBytes();
+      byte[] encoded = this.requests[i].toBytes(includeResponse);
       Objects.requireNonNull(encoded, "Request " + i + " produced null serialization");
       encodedRequests[i] = encoded;
       rawSize += Integer.BYTES + encoded.length;

--- a/test/edu/umass/cs/xdn/request/XdnHttpRequestTest.java
+++ b/test/edu/umass/cs/xdn/request/XdnHttpRequestTest.java
@@ -381,7 +381,11 @@ public class XdnHttpRequestTest {
     response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 5);
     xdnRequest.setHttpResponse(response);
 
-    String encoded = xdnRequest.toString();
+    // The default wire form strips the locally-computed response (see
+    // XdnHttpRequest#toBytes); only the explicit toBytes(true) opt-in carries it.
+    assertFalse(XdnHttpRequest.doesHasResponse(xdnRequest.toString()));
+
+    String encoded = new String(xdnRequest.toBytes(true), StandardCharsets.ISO_8859_1);
     assertTrue(XdnHttpRequest.doesHasResponse(encoded));
 
     HttpResponse decodedResponse = XdnHttpRequest.parseHttpResponse(encoded);

--- a/xdn-bw-trace/.gitignore
+++ b/xdn-bw-trace/.gitignore
@@ -1,0 +1,3 @@
+results
+__pycache__
+

--- a/xdn-bw-trace/README.md
+++ b/xdn-bw-trace/README.md
@@ -1,0 +1,340 @@
+# xdn-bw-trace
+
+Per-service inter-replica + client⇄replica TCP bandwidth tracer for XDN,
+plus a small set of plotting utilities for turning the resulting CSV
+into bandwidth/latency graphs.
+
+## What's in this directory
+
+| File | Purpose |
+|------|---------|
+| `inter_replica_bw.bt` | bpftrace probe: kprobes on `tcp_sendmsg` / `tcp_cleanup_rbuf`, aggregates bytes by `(pid, local_port, peer_ip, peer_port)` and emits per-interval snapshots. |
+| `trace_bw.py` | driver: discovers the cluster via the RC HTTP API, launches the probe, drives a mixed read/write workload at every replica in parallel, writes a per-event CSV plus a `.meta.json` sidecar. Supports four `--mode`s (`local` / `probe` / `driver` / `aggregate`) — see "Distributed deployment" below. |
+| `trace_bw_distributed.py` | SSH orchestrator that runs `trace_bw.py --mode probe` on every AR host, drives the HTTP workload locally, then merges per-host CSVs into a single resolved trace via `--mode aggregate`. |
+| `plot_bw_graph.py` | renders a directed bandwidth graph (`DiGraph`) from the CSV: replicas on a circle, per-replica `client-ARx` vertices on an outer ring. |
+| `plot_lat_graph.py` | renders an inter-replica latency graph computed analytically from each replica's `(lat, lon)` (Haversine / fiber-speed); supports `circle` and `geo` layouts. |
+| `_plotutil.py` | helpers shared by the two plot scripts (Bezier label placement, AR-on-circle layout). |
+| `install_bpftrace.sh` | one-shot installer: pulls the upstream static `bpftrace` AppImage, transparently falls back to `--appimage-extract` on hosts where FUSE auto-mount is broken, symlinks `/usr/local/bin/bpftrace`, and is idempotent + self-healing. |
+| `results/` | default output directory for CSVs, both bandwidth and latency PNGs, and `.meta.json` sidecars. |
+
+## Pre-flight
+
+- Linux host with `bpftrace` ≥ 0.21 (uses kernel BTF, no kernel headers
+  required). The `inter_replica_bw.bt` script does not `#include` any
+  Linux header. **Distro packages are usually too old** — Ubuntu jammy's
+  apt ships 0.14, which rejects builtins like `bswap` used by the probe.
+  Use `install_bpftrace.sh` to grab a current upstream build:
+  ```bash
+  xdn-bw-trace/install_bpftrace.sh                  # pinned default
+  xdn-bw-trace/install_bpftrace.sh --version v0.25.1
+  xdn-bw-trace/install_bpftrace.sh --force          # force reinstall
+  ```
+  The script is self-healing: re-running it detects a previously broken
+  install (e.g. a bare AppImage on a host where FUSE auto-mount fails)
+  and reinstalls into `/opt/bpftrace-<ver>/AppRun` with a symlink at
+  `/usr/local/bin/bpftrace`.
+- An XDN cluster running with the same `gigapaxos.properties` file you
+  pass via `--config`.
+- The service deployed, e.g.:
+  ```
+  xdn launch bookcatalog --image=fadhilkurnia/xdn-bookcatalog \
+      --state=/app/data/ --deterministic=true
+  ```
+- Run as root, or with passwordless `sudo` (bpftrace requires `CAP_BPF`).
+- Python deps: `requests`, `networkx`, `matplotlib`, `numpy`.
+
+## Quick start
+
+```bash
+# 1. Trace: drives 80% GET / 20% PUT at every replica in parallel.
+sudo python3 xdn-bw-trace/trace_bw.py \
+    --config conf/gigapaxos.xdn.local.properties \
+    --service bookcatalog \
+    --duration 30 --interval 5 --rate 20
+
+# 2. Bandwidth graph.
+python3 xdn-bw-trace/plot_bw_graph.py \
+    xdn-bw-trace/results/bookcatalog-<ts>.csv
+
+# 3. Latency graph (estimated from geolocations, no live measurement).
+python3 xdn-bw-trace/plot_lat_graph.py \
+    --config conf/gigapaxos.xdn.local.properties \
+    --service bookcatalog
+```
+
+`trace_bw.py` produces `<service>-<unix-ts>.csv` plus a sibling
+`<service>-<unix-ts>.meta.json` in `xdn-bw-trace/results/`. The plot
+scripts auto-pick up the meta sidecar to render a workload subtitle.
+
+## What `trace_bw.py` captures
+
+The bpftrace probe matches every TCP flow where either endpoint sits in
+the AR NIO range **or** the AR HTTP frontend range, so the CSV includes
+both inter-replica Paxos traffic (NIO listeners) and client⇄replica
+HTTP traffic (HTTP frontends, port = NIO port + 300).
+
+Replica identity is reconstructed in userspace by:
+
+- mapping the kernel `pid` for each event to an AR id via a one-shot
+  scan of `/proc/<pid>/cmdline` for `…ReconfigurableNode AR<N>` (so
+  bpftrace can attach to an already-running cluster — no need to start
+  before the JVMs);
+- mapping listener-port → AR id from the RC's placement endpoint;
+- cross-correlating ephemeral ports against rows where the same number
+  appears as someone else's `local_port` (recovers `(i, j)` even on
+  loopback).
+
+Non-AR participants in HTTP flows collapse into one `client-<AR>`
+vertex per replica (so each replica's external traffic is visible as
+its own pair of edges instead of a shared client hub).
+
+## CSV schema
+
+```
+interval_start_unix,interval_end_unix,direction,
+local_id,local_pid,local_port,
+peer_id,peer_ip,peer_port,
+bytes
+```
+
+`local_id` and `peer_id` are AR ids (`AR0`, `AR1`, …) for inter-replica
+flows or `client-AR<X>` for the client side of HTTP flows. The raw
+`local_pid`, `local_port`, `peer_ip`, `peer_port` columns are kept for
+debugging / re-resolution.
+
+## Meta sidecar
+
+Alongside each CSV, `trace_bw.py` writes a `.meta.json` with:
+service name, target ids, rate / duration / interval / warmup, read
+ratio, read & write request specs, run totals (sent/ok/failed/reads/
+writes/elapsed), and a `service_info` block populated from each AR's
+`/api/v2/services/<svc>/replica/info` endpoint (`protocol`,
+`consistency`, `requested_consistency`, `deterministic`).
+
+`plot_bw_graph.py` renders these fields as the figure's subtitle:
+
+```
+service=bookcatalog · protocol=PaxosReplicaCoordinator ·
+consistency=Linearizability · r/w=80%/20% · rate=20 req/s × 5 replicas ·
+duration=30s
+read=GET /api/books/1 · write=PUT /api/books/1 · sent reads=… writes=…
+```
+
+## Workload mix and seeding
+
+By default the driver sends 80% reads (`GET /api/books/1`) and 20%
+writes (`PUT /api/books/1`) — the read targets a specific id so the
+response payload size is constant per request. Before traffic starts,
+the driver probes `--path` on the first target; if that returns 404 it
+POSTs `--seed-body` to `--seed-path` (default `/api/books`) so the
+read/write targets resolve cleanly.
+
+For services other than bookcatalog, override `--path`, `--write-path`,
+`--write-body`, `--write-method`, and either `--seed-path`/`--seed-body`
+or pass `--no-seed`.
+
+## CLI flags — `trace_bw.py`
+
+Discovery / topology:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--config` | (required) | gigapaxos properties (used to derive RC endpoint and report node geolocations) |
+| `--service` | (required) | service name; sent in `XDN:` header and used to query the RC's placement endpoint |
+| `--reconfigurator` | derived from `--config` | `host[:port]` override for the RC HTTP endpoint (port defaults to NIO port + 300) |
+| `--target` | every replica in the placement | comma-separated allowlist of replica ids (e.g. `AR1,AR3`) to drive traffic at |
+
+Workload:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--rate` | `20` | per-replica request rate (req/s); aggregate offered load is `rate × len(targets)` |
+| `--duration` | `60` | trace duration (seconds) |
+| `--read-ratio` | `0.8` | fraction of requests that are reads (vs. writes); use `1.0` / `0.0` for read- or write-only |
+| `--path`, `--method` | `/api/books/1`, `GET` | read request path / method |
+| `--write-path`, `--write-method` | `/api/books/1`, `PUT` | write request path / method |
+| `--write-body`, `--write-content-type` | small JSON / `application/json` | write request body and `Content-Type` |
+| `--seed-path`, `--seed-body`, `--no-seed` | `/api/books`, JSON, off | one-shot seeding of the target item before traffic starts |
+| `--timeout` | `5` | per-request HTTP timeout (seconds) |
+| `--warmup` | `2` | wait between bpftrace start and traffic start (seconds) |
+
+Probe:
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--interval` | `5` | bpftrace snapshot interval (seconds) |
+| `--bpftrace-script` | sibling `inter_replica_bw.bt` | override probe script |
+| `--output` | auto | CSV path; meta sidecar lives next to it |
+
+## CLI flags — `plot_bw_graph.py`
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `csv` (positional) | (required) | path to a `trace_bw.py` CSV |
+| `--direction` | `out` | `out` (sender-side, counts each flow once), `in` (receiver-side), or `both` (double-count, sanity only) |
+| `--include-unknown` | off | keep rows whose `local_id` / `peer_id` is `unknown` |
+| `--unit` | `KB` | `B` / `KB` / `MB` for matrix and edge labels |
+| `--output` | sibling PNG | output image path |
+
+Vertices: ARs on an inner unit circle (round, blue); each
+`client-ARx` on an outer ring at the matching angle (square, orange).
+Directed edges, two arcs per pair, edge labels positioned along their
+own arc with a fixed data-coordinate offset before the arrowhead so
+labels never cover the arrow.
+
+## CLI flags — `plot_lat_graph.py`
+
+Latency is computed analytically from each replica's `(lat, lon)`:
+Haversine great-circle distance divided by `c × fiber_fraction`. This
+is a propagation-only lower bound — real internet RTT is typically
+1.5–2× higher.
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--config` | (required if no `--service`) | gigapaxos properties; reads `active.<id>.geolocation` |
+| `--service` | — | if set, queries the RC's placement endpoint and uses only the replicas hosting this service (and their geolocations) |
+| `--reconfigurator` | derived from `--config` | RC endpoint override, same shape as `trace_bw.py` |
+| `--unit` | `ms` | `ms` or `us` for labels and the printed matrix |
+| `--rtt` | off (one-way) | display 2× one-way |
+| `--fiber-fraction` | `0.667` | effective signal speed as a fraction of c |
+| `--layout` | `circle` | `circle` (matches `plot_bw_graph.py`) or `geo` (equirectangular projection of `(lon, lat)`) |
+| `--min-node-spacing` | `0.20` | (geo only) minimum distance in normalized data units between any two replicas after projection; tunable to trade ratio fidelity against label readability |
+| `--output` | `xdn-bw-trace/results/<service-or-config>-latency.png` | output image path; default lives next to the bandwidth PNGs in `results/` |
+
+`geo` mode forces equal lat/lon aspect (`set_aspect("equal",
+adjustable="datalim")`), so 1° lat renders the same length as 1° lon.
+Replicas closer than `--min-node-spacing` after projection are pushed
+apart along their connecting line by the smallest amount that prevents
+disk overlap, so geographic ratios remain close to the real ones.
+
+## Distributed deployment
+
+`bpftrace` only sees its host's kernel, so a single `trace_bw.py
+--mode local` invocation captures everything cleanly only when the AR
+JVMs and the driver share a host (loopback / single-machine). For a
+real distributed cluster, `trace_bw.py` exposes three split-mode entry
+points and `trace_bw_distributed.py` ties them together over SSH.
+
+### Modes
+
+`trace_bw.py --mode {local | probe | driver | aggregate}` (default `local`).
+
+| Mode | What it does | Where to run it | Outputs |
+|------|--------------|-----------------|---------|
+| `local` | drive workload **and** run bpftrace **and** resolve in one process — single-host all-in-one path. **Backward-compatible default.** | one host where every AR JVM lives | `<service>-<ts>.csv` (resolved) + `.meta.json` |
+| `probe` | run bpftrace only, dump raw events + a `pid_to_ar.json` sidecar | each AR host (one probe per host) | `<output>.csv` (raw, no `local_id`/`peer_id`) + `<output>.pid_to_ar.json` |
+| `driver` | drive HTTP workload only (no bpftrace) | any host that can reach all AR HTTP frontends | `<output>.meta.json` |
+| `aggregate` | union N raw probe CSVs + sidecars, run `resolve_rows`, write a single resolved CSV | the orchestrator (or anywhere the per-host CSVs are gathered) | `<output>.csv` (resolved) |
+
+The aggregator's resolution works because GigaPaxos uses long-lived
+TCP connections between replicas: AR-i's outbound ephemeral port shows
+up as `peer_port` in AR-j's probe, and as `local_port` in AR-i's probe.
+Unioning the events lets the existing `ephemeral_owner` cross-correlation
+in `resolve_rows` recover the `(i, j)` pair across hosts.
+
+### Orchestrator: `trace_bw_distributed.py`
+
+End-to-end multi-host run with SSH fan-out:
+
+```bash
+python3 xdn-bw-trace/trace_bw_distributed.py \
+    --config conf/gigapaxos.cloudlab.properties \
+    --service bookcatalog \
+    --ssh-key ~/.ssh/cloudlab \
+    --username fadhil \
+    --duration 60 --interval 5 --rate 50 --read-ratio 0.0
+```
+
+The orchestrator:
+
+1. Reads `--config` to enumerate AR hosts (or honors `--hosts host1,host2,…`).
+2. For each host, opens an SSH session and starts `trace_bw.py --mode probe`
+   under `sudo -n` (bpftrace needs `CAP_BPF`). Probes write raw CSVs +
+   sidecars into the remote `--tmpdir`.
+3. Sleeps `--probe-startup-buffer` seconds (default 3) so kprobes attach
+   before traffic begins.
+4. Locally runs `trace_bw.py --mode driver` to drive the HTTP workload
+   against every replica in the placement.
+5. Waits for all probes to finish.
+6. SCPs each per-host CSV + sidecar back to `xdn-bw-trace/results/`.
+7. Runs `trace_bw.py --mode aggregate` over all retrieved CSVs to write a
+   single resolved CSV, identical in shape to a `--mode local` output.
+8. Cleans up remote tmp files (skip with `--keep-remote-files`).
+
+Pre-flight on remote hosts:
+- `bpftrace` ≥ 0.21 installed (use `xdn-bw-trace/install_bpftrace.sh`).
+- `python3` + `requests`.
+- The xdn checkout at the same path as locally, or pass
+  `--remote-xdn-path /path/to/remote/xdn`.
+- `gigapaxos.properties` at the same path as `--config`, or pass
+  `--remote-config-path /path/to/remote/properties`.
+- Passwordless SSH from the orchestrator and passwordless `sudo` for
+  `bpftrace` on each AR host.
+
+### Manual split-mode invocation
+
+If you don't want SSH orchestration, you can run the modes by hand. For
+each AR host:
+
+```bash
+sudo python3 xdn-bw-trace/trace_bw.py \
+    --mode probe \
+    --config /path/to/gigapaxos.properties \
+    --service bookcatalog \
+    --duration 65 --interval 5 \
+    --output /tmp/probe-host-A.csv
+```
+
+On any host that can reach all AR frontends:
+
+```bash
+python3 xdn-bw-trace/trace_bw.py \
+    --mode driver \
+    --config /path/to/gigapaxos.properties \
+    --service bookcatalog \
+    --rate 50 --duration 60 --read-ratio 0.0 \
+    --output /tmp/driver.csv
+```
+
+Once all per-host probes finish and you've collected their CSVs +
+`.pid_to_ar.json` sidecars to the same directory:
+
+```bash
+python3 xdn-bw-trace/trace_bw.py \
+    --mode aggregate \
+    --config /path/to/gigapaxos.properties \
+    --service bookcatalog \
+    --inputs /tmp/probe-host-A.csv,/tmp/probe-host-B.csv,/tmp/probe-host-C.csv \
+    --output xdn-bw-trace/results/bookcatalog-distributed.csv
+```
+
+## Caveats
+
+- **Linux + root.** No macOS path.
+- **Wire bytes.** Counts include TCP/TLS framing and retransmits, not
+  just application payload. Fine for placement decisions; flag if
+  publishing numbers.
+- **Linearizable reads go through Paxos.** With the default
+  `linearizability` consistency, every GET also runs through consensus,
+  so the bandwidth graph reflects all traffic, not just writes.
+- **Latency graph is geodesic.** `plot_lat_graph.py` reports a
+  propagation lower bound (great-circle / fiber). Real RTT typically
+  exceeds it by 1.5–2× because of routing/queueing/serialization.
+- **`trace_bw.py` runs under sudo**, so the CSV / `.meta.json` and the
+  `results/` directory end up root-owned. The plot scripts run as your
+  user and will hit `PermissionError` when writing the PNG. Either run
+  the plot scripts with `sudo` too, or chown after each trace:
+  ```bash
+  sudo chown -R "$USER:$USER" xdn-bw-trace/results/
+  ```
+
+## Deferred follow-ons
+
+- SSH harness so a single driver invocation runs bpftrace on every AR
+  and merges the CSVs.
+- A `XdnBandwidthProfiler` Java worker (analog of
+  `XdnGeoDemandProfiler`) that reports bandwidth deltas to the
+  Reconfigurator and feeds `XdnReplicaPlacementProfile`.
+- Per-service attribution via per-service virtual ports (the
+  blackbox-per-port architecture).
+- Live RTT measurement to cross-validate the analytical latency graph.

--- a/xdn-bw-trace/_plotutil.py
+++ b/xdn-bw-trace/_plotutil.py
@@ -1,0 +1,158 @@
+"""Shared plotting helpers for plot_bw_graph.py and plot_lat_graph.py.
+
+Kept module-private (leading underscore) because these are internal
+implementation details of the two scripts; nothing else in the repo
+should import from here.
+"""
+
+import math
+
+import networkx as nx
+import numpy as np
+
+CLIENT_PREFIX = "client-"  # mirrors trace_bw.CLIENT_PREFIX + "-"
+
+
+# ----- arc3 / Bezier geometry ------------------------------------------------
+#
+# nx.draw_networkx_edges(connectionstyle="arc3,rad=R") draws each edge as a
+# quadratic Bezier; reproducing that exact curve here lets us place edge
+# labels along the same path the renderer uses.
+
+def _arc3_control_point(p0, p1, rad):
+    """Matplotlib's `arc3,rad=R` is a quadratic Bezier whose control point
+    is at `midpoint + rad * (dy, -dx)` (matplotlib/patches.py
+    ConnectionStyle.Arc3.connect): chord midpoint shifted by the
+    *clockwise* perpendicular to the chord, scaled by `rad`. Reproducing
+    that exactly here is what makes our label curve sit on the same arc
+    that nx.draw_networkx_edges is drawing — so each label lands on its
+    own edge instead of the opposite-direction edge's mirror.
+    """
+    chord = p1 - p0
+    if float(np.linalg.norm(chord)) == 0.0:
+        return p0.copy()
+    perp_cw = np.array([chord[1], -chord[0]])
+    return (p0 + p1) / 2.0 + rad * perp_cw
+
+
+def _bezier_point(p0, c, p1, t):
+    return (1.0 - t) ** 2 * p0 + 2.0 * (1.0 - t) * t * c + t ** 2 * p1
+
+
+def _bezier_tangent(p0, c, p1, t):
+    return 2.0 * (1.0 - t) * (c - p0) + 2.0 * t * (p1 - c)
+
+
+def _t_at_distance_from_end(p0, c, p1, distance):
+    """Find t in [0, 1] such that |B(t) - p1| ≈ `distance`.
+
+    For an arc3 quadratic Bezier the distance from the endpoint is
+    monotone in t over [0, 1], so a plain bisection converges fast.
+    Returns 0.0 if the requested distance exceeds the curve length
+    (i.e. the curve is shorter than the requested offset).
+    """
+    if distance <= 0.0:
+        return 1.0
+    if float(np.linalg.norm(p1 - p0)) <= distance:
+        return 0.0
+    lo, hi = 0.0, 1.0
+    for _ in range(40):
+        mid = (lo + hi) / 2.0
+        if float(np.linalg.norm(_bezier_point(p0, c, p1, mid) - p1)) > distance:
+            lo = mid
+        else:
+            hi = mid
+    return (lo + hi) / 2.0
+
+
+def draw_edge_labels_at_fixed_offset(ax, graph, pos, edge_labels,
+                                     rad, offset, **text_kwargs):
+    """Draw each edge's label so that the label's *destination-facing
+    edge* lands at a constant data-coordinate `offset` before the target
+    node, measured along the edge's curved path. The rest of the label
+    extends backward along the curve toward the source — which keeps the
+    arrowhead end clear regardless of label width or edge length.
+
+    Replaces `nx.draw_networkx_edge_labels(label_pos=…)`, which is
+    proportional to edge length and therefore renders inconsistently
+    across short and long edges.
+    """
+    bbox = text_kwargs.pop("bbox", None)
+    fontsize = text_kwargs.pop("fontsize", 8)
+    for (u, v), label in edge_labels.items():
+        p0 = np.asarray(pos[u], dtype=float)
+        p1 = np.asarray(pos[v], dtype=float)
+        c = _arc3_control_point(p0, p1, rad)
+        t = _t_at_distance_from_end(p0, c, p1, offset)
+        xy = _bezier_point(p0, c, p1, t)
+        tan = _bezier_tangent(p0, c, p1, t)
+        angle = math.degrees(math.atan2(float(tan[1]), float(tan[0])))
+        # Keep text upright on edges that would otherwise read upside
+        # down. The flag remembers whether we flipped, because that
+        # changes which side of the (rotated) text faces the destination.
+        flipped = False
+        if angle > 90.0:
+            angle -= 180.0
+            flipped = True
+        elif angle < -90.0:
+            angle += 180.0
+            flipped = True
+        # rotation_mode="anchor" anchors the alignment point first and
+        # then rotates around it, so the label's chosen edge stays on
+        # the curve at the anchor.
+        #
+        # No flip → text reads in the same direction as the edge tangent:
+        #   the right side of the unrotated text faces the destination,
+        #   so ha="right" parks the destination-facing edge at the
+        #   anchor and the body extends back toward the source.
+        # Flipped → text reads opposite to the edge tangent:
+        #   the LEFT side of the unrotated text faces the destination
+        #   instead, so ha="left" gives the same visual result.
+        ha = "left" if flipped else "right"
+        ax.text(float(xy[0]), float(xy[1]), label,
+                rotation=angle, rotation_mode="anchor",
+                ha=ha, va="center", fontsize=fontsize,
+                bbox=bbox, **text_kwargs)
+
+
+# ----- AR-on-circle layout ---------------------------------------------------
+
+def replica_client_layout(graph, inner_radius=1.0, outer_radius=1.7):
+    """Place AR vertices on a circle (inner ring) and each `client-<AR>`
+    vertex on the outer ring at the same angle as its AR. Any leftover
+    nodes (e.g. a bare 'client' fallback or 'unknown') are placed at the
+    origin. If there are no AR vertices, fall back to a plain circular
+    layout so this function stays a drop-in for `nx.circular_layout`.
+
+    For graphs with no client- prefixed nodes (e.g. the latency graph)
+    this simply puts every replica on the inner circle, which is the
+    desired behaviour there too.
+    """
+    pos = {}
+    nodes = list(graph.nodes)
+    ar_nodes = sorted(n for n in nodes if not n.startswith(CLIENT_PREFIX)
+                      and n != "client" and n != "unknown")
+    if not ar_nodes:
+        return nx.circular_layout(graph)
+
+    # Match nx.circular_layout's convention: first node at angle 0, then
+    # counterclockwise. This keeps AR ordering consistent with what readers
+    # already saw in earlier renders.
+    n_ar = len(ar_nodes)
+    for i, ar in enumerate(ar_nodes):
+        angle = 2.0 * math.pi * i / n_ar
+        pos[ar] = (inner_radius * math.cos(angle),
+                   inner_radius * math.sin(angle))
+
+    for n in nodes:
+        if n.startswith(CLIENT_PREFIX):
+            ar = n[len(CLIENT_PREFIX):]
+            if ar in pos:
+                cx, cy = pos[ar]
+                length = math.hypot(cx, cy) or 1.0
+                pos[n] = (cx * outer_radius / length,
+                          cy * outer_radius / length)
+                continue
+        if n not in pos:
+            pos[n] = (0.0, 0.0)
+    return pos

--- a/xdn-bw-trace/install_bpftrace.sh
+++ b/xdn-bw-trace/install_bpftrace.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# install_bpftrace.sh — install a recent enough bpftrace for inter_replica_bw.bt.
+#
+# The trace script uses builtins (e.g. `bswap`) that are only present in
+# bpftrace ≥ 0.21, so the apt/jammy package (0.14) is too old. This script
+# pulls the upstream static-bundle AppImage from
+# github.com/bpftrace/bpftrace/releases and installs it under
+# /opt/bpftrace-<version>, with a symlink at /usr/local/bin/bpftrace.
+#
+# Some hosts can't run the AppImage directly (the bundled FUSE auto-mount
+# fails when its packaged util-linux's `mount` isn't where the AppImage
+# expects it — that's what we hit on Ubuntu 22.04). On those hosts we
+# extract the AppImage with `--appimage-extract` and use the inner AppRun
+# instead. Both paths end up at the same /usr/local/bin/bpftrace symlink.
+#
+# Re-running the script is a no-op if the requested version is already
+# installed; pass `--force` to reinstall.
+#
+# Usage:
+#   xdn-bw-trace/install_bpftrace.sh                 # installs the pinned default
+#   xdn-bw-trace/install_bpftrace.sh --version v0.25.1
+#   BPFTRACE_VERSION=v0.25.1 xdn-bw-trace/install_bpftrace.sh
+#   xdn-bw-trace/install_bpftrace.sh --force         # reinstall
+
+set -euo pipefail
+
+DEFAULT_VERSION="v0.25.1"
+PREFIX_BASE="/opt"
+SYMLINK="/usr/local/bin/bpftrace"
+
+VERSION="${BPFTRACE_VERSION:-$DEFAULT_VERSION}"
+FORCE=0
+
+while (($#)); do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { echo "error: --version requires an argument" >&2; exit 2; }
+      VERSION="$2"; shift 2 ;;
+    --version=*)
+      VERSION="${1#--version=}"; shift ;;
+    --force)
+      FORCE=1; shift ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "error: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+# Normalize: accept "0.25.1" as well as "v0.25.1".
+[[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
+VERSION_NUM="${VERSION#v}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "error: bpftrace runs on Linux only (host: $(uname -s))" >&2
+  exit 1
+fi
+
+# Pick a sudo prefix: empty if we're already root, `sudo` otherwise.
+if [[ "$(id -u)" -eq 0 ]]; then
+  SUDO=""
+else
+  command -v sudo >/dev/null 2>&1 \
+    || { echo "error: not root and 'sudo' not found" >&2; exit 1; }
+  SUDO="sudo"
+fi
+
+PREFIX="${PREFIX_BASE}/bpftrace-${VERSION_NUM}"
+URL="https://github.com/bpftrace/bpftrace/releases/download/${VERSION}/bpftrace"
+
+# Probe: actually load a trivial bpftrace program. This forces the AppImage's
+# squashfs to mount (and thus exercises the FUSE auto-mount path) and goes
+# through the inner bpftrace binary, unlike `--version`/`--info` which the
+# AppImage shim answers without mounting. We need root because bpftrace's
+# CAP check fires before the mount. Returns 0 if the binary can run a script.
+probe_bpftrace() {
+  local bin="$1"
+  $SUDO "$bin" -e 'BEGIN { exit(); }' >/dev/null 2>&1
+}
+
+# Skip work if the right version is already installed AND it actually runs.
+# A bare AppImage on a FUSE-broken host will report the right --version but
+# blow up on real scripts, so we re-probe before declaring "nothing to do".
+if [[ "$FORCE" -eq 0 ]] && command -v bpftrace >/dev/null 2>&1; then
+  EXISTING="$(bpftrace --version 2>/dev/null | head -n1 | awk '{print $NF}' || true)"
+  if [[ "$EXISTING" == "$VERSION" ]] && probe_bpftrace "$(command -v bpftrace)"; then
+    echo "bpftrace $VERSION already installed at $(command -v bpftrace) — nothing to do."
+    echo "(pass --force to reinstall)"
+    exit 0
+  fi
+  if [[ "$EXISTING" == "$VERSION" ]]; then
+    echo "bpftrace $VERSION is on PATH but fails the probe — reinstalling."
+    FORCE=1
+  fi
+fi
+
+# If we already have an extracted install at $PREFIX that probes successfully,
+# just (re-)point the symlink at it. This avoids re-downloading 164MB on every
+# reinstall and tolerates a pre-existing /opt/bpftrace-<ver> from a previous
+# manual install.
+if [[ "$FORCE" -eq 0 && -x "${PREFIX}/AppRun" ]] \
+   && probe_bpftrace "${PREFIX}/AppRun"; then
+  echo "found working ${PREFIX}/AppRun — pointing ${SYMLINK} at it."
+  $SUDO ln -sf "${PREFIX}/AppRun" "$SYMLINK"
+  echo "installed: $(bpftrace --version 2>&1 | head -n1)  (via ${SYMLINK})"
+  exit 0
+fi
+
+# Each bpftrace AppImage run stacks a tmpfs onto its `mountroot` directory
+# and (on at least some kernels) doesn't tear it down on exit, so any path
+# we want to delete may have one or more lingering tmpfs mounts under it.
+# Try to unmount cleanly; -lf so a stuck mount still detaches.
+unmount_under() {
+  local root="$1"
+  [[ -d "$root" ]] || return 0
+  while read -r mp; do
+    [[ -n "$mp" ]] && $SUDO umount -lf "$mp" 2>/dev/null || true
+  done < <(mount | awk -v r="$root" '$3 ~ ("^" r) {print $3}' | sort -r)
+}
+
+safe_rm_rf() {
+  local target="$1"
+  unmount_under "$target"
+  $SUDO rm -rf "$target"
+}
+
+WORKDIR="$(mktemp -d)"
+# Extracted AppImages contain files owned by various build-side uids (root,
+# nixbld, etc.) so a user-mode rm -rf can fail. Use sudo for cleanup, and
+# unmount any tmpfs left behind by AppImage probes first.
+trap 'safe_rm_rf "$WORKDIR"' EXIT
+
+echo "downloading bpftrace ${VERSION} ..."
+curl -fL --retry 3 -o "${WORKDIR}/bpftrace" "$URL"
+chmod +x "${WORKDIR}/bpftrace"
+
+# First try running the AppImage directly. On hosts where the AppImage's
+# FUSE auto-mount works this is enough; we just install the binary.
+echo "checking AppImage runs as-is ..."
+if probe_bpftrace "${WORKDIR}/bpftrace"; then
+  echo "AppImage runs natively — installing single binary."
+  $SUDO install -m 0755 "${WORKDIR}/bpftrace" "$SYMLINK"
+else
+  echo "AppImage FUSE mount unavailable — falling back to --appimage-extract."
+  pushd "$WORKDIR" >/dev/null
+  ./bpftrace --appimage-extract >/dev/null
+  popd >/dev/null
+
+  if [[ ! -x "${WORKDIR}/squashfs-root/AppRun" ]]; then
+    echo "error: AppImage extracted but AppRun missing in ${WORKDIR}/squashfs-root" >&2
+    exit 1
+  fi
+
+  # Sanity: the extracted AppRun should actually run a script.
+  if ! probe_bpftrace "${WORKDIR}/squashfs-root/AppRun"; then
+    echo "error: extracted AppRun still fails to load a trivial bpftrace program" >&2
+    exit 1
+  fi
+
+  # Replace any existing /opt/bpftrace-<ver> dir if --force was set.
+  if [[ -d "$PREFIX" ]]; then
+    if [[ "$FORCE" -eq 1 ]]; then
+      safe_rm_rf "$PREFIX"
+    else
+      echo "error: $PREFIX already exists; pass --force to reinstall" >&2
+      exit 1
+    fi
+  fi
+  $SUDO mv "${WORKDIR}/squashfs-root" "$PREFIX"
+  $SUDO ln -sf "${PREFIX}/AppRun" "$SYMLINK"
+fi
+
+# Final verification — should be on PATH at the symlink.
+if ! INSTALLED="$(bpftrace --version 2>&1 | head -n1)"; then
+  echo "error: bpftrace not runnable after install" >&2
+  exit 1
+fi
+echo "installed: ${INSTALLED}  (via ${SYMLINK})"

--- a/xdn-bw-trace/inter_replica_bw.bt
+++ b/xdn-bw-trace/inter_replica_bw.bt
@@ -1,0 +1,107 @@
+// inter_replica_bw.bt
+//
+// Per-interval TCP byte counter for XDN bandwidth tracing. Captures both
+// inter-replica TCP flows (NIO listener ports) and client<->replica HTTP
+// flows (AR HTTP frontend ports). A flow is matched if either endpoint
+// sits in EITHER configured port range.
+//
+// Positional args:
+//   $1 = nio_low    (uint16)  AR NIO listener range low,  e.g. 2000
+//   $2 = nio_high   (uint16)  AR NIO listener range high, e.g. 2004
+//   $3 = http_low   (uint16)  AR HTTP frontend range low,  e.g. 2300
+//   $4 = http_high  (uint16)  AR HTTP frontend range high, e.g. 2304
+//   $5 = interval_s (uint32)  snapshot interval in seconds
+//
+// Stdout protocol (parsed by trace_bw.py):
+//   # trace start: ports=[<low>,<high>] interval=<sec>s
+//   SNAP
+//   @out[<pid>, <local_port>, <peer_ip>, <peer_port>]: <bytes>
+//   ...
+//   @in[<pid>, <local_port>, <peer_ip>, <peer_port>]: <bytes>
+//   ...
+//   END
+//
+// Events are keyed by the tuple (pid, local_port, peer_ip, peer_port). Both
+// kprobes fire in the JVM thread's user context (sendmsg via send()/write(),
+// cleanup_rbuf via the recv() path), so the kernel pid identifies the local
+// AR. trace_bw.py post-processes these tuples into a (local_id -> peer_id)
+// bandwidth matrix; ephemeral peer ports are resolved by cross-referencing
+// against rows where the same port appears as someone's local_port.
+//
+// `struct sock` is resolved from kernel BTF (/sys/kernel/btf/vmlinux);
+// no kernel-header #includes are needed on bpftrace 0.21+.
+
+BEGIN {
+    printf("# trace start: nio=[%d,%d] http=[%d,%d] interval=%ds\n",
+           $1, $2, $3, $4, $5);
+}
+
+// Java NIO (gigapaxos) opens IPv6 sockets even for 127.0.0.1 — peers appear
+// as ::ffff:127.0.0.1. We accept both AF_INET (2) and AF_INET6 (10) and
+// format the peer address with the family-appropriate ntop() call.
+kprobe:tcp_sendmsg {
+    $sk = (struct sock *)arg0;
+    $fam = $sk->__sk_common.skc_family;
+    if ($fam != 2 && $fam != 10) { return; }
+
+    $size = (uint64)arg2;
+    $dport = bswap((uint16)$sk->__sk_common.skc_dport);
+    $sport = (uint16)$sk->__sk_common.skc_num;
+
+    // Match if either endpoint sits in the AR NIO range (inter-replica
+    // Paxos/NIO traffic) OR in the AR HTTP frontend range (client<->AR
+    // HTTP traffic). This catches both directions of either kind of flow
+    // regardless of which side opened the connection.
+    if (($dport >= (uint16)$1 && $dport <= (uint16)$2) ||
+        ($sport >= (uint16)$1 && $sport <= (uint16)$2) ||
+        ($dport >= (uint16)$3 && $dport <= (uint16)$4) ||
+        ($sport >= (uint16)$3 && $sport <= (uint16)$4)) {
+        if ($fam == 2) {
+            @out[pid, $sport, ntop($sk->__sk_common.skc_daddr), $dport] = sum($size);
+        } else {
+            @out[pid, $sport, ntop($sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $dport] = sum($size);
+        }
+    }
+}
+
+kprobe:tcp_cleanup_rbuf {
+    $sk = (struct sock *)arg0;
+    $fam = $sk->__sk_common.skc_family;
+    if ($fam != 2 && $fam != 10) { return; }
+
+    $copied = (int64)arg1;
+    if ($copied <= 0) { return; }
+
+    $dport = bswap((uint16)$sk->__sk_common.skc_dport);
+    $sport = (uint16)$sk->__sk_common.skc_num;
+    if (($dport >= (uint16)$1 && $dport <= (uint16)$2) ||
+        ($sport >= (uint16)$1 && $sport <= (uint16)$2) ||
+        ($dport >= (uint16)$3 && $dport <= (uint16)$4) ||
+        ($sport >= (uint16)$3 && $sport <= (uint16)$4)) {
+        if ($fam == 2) {
+            @in[pid, $sport, ntop($sk->__sk_common.skc_daddr), $dport] = sum((uint64)$copied);
+        } else {
+            @in[pid, $sport, ntop($sk->__sk_common.skc_v6_daddr.in6_u.u6_addr8), $dport] = sum((uint64)$copied);
+        }
+    }
+}
+
+interval:s:$5 {
+    printf("SNAP\n");
+    print(@out);
+    print(@in);
+    printf("END\n");
+    clear(@out);
+    clear(@in);
+}
+
+// On SIGINT/SIGTERM, flush any partial interval as one last frame so
+// trace_bw.py captures the tail rather than losing it.
+END {
+    printf("SNAP\n");
+    print(@out);
+    print(@in);
+    printf("END\n");
+    clear(@out);
+    clear(@in);
+}

--- a/xdn-bw-trace/paxos-json-overhead.md
+++ b/xdn-bw-trace/paxos-json-overhead.md
@@ -1,0 +1,256 @@
+# JSON-encoded Paxos packets cost ~2× the wire bytes vs byteification
+
+GigaPaxos has two on-the-wire formats for `RequestPacket` / `AcceptPacket`
+/ `BatchedAcceptReply` / `BatchedCommit`: a packed byteified format and a
+JSON-string fallback. The byteified path is gated by `IntegerMap.allInt()`,
+which silently flips to `false` whenever a node name isn't a numeric
+string. With node IDs like `AR0..AR4` (the convention in
+`gigapaxos.xdn.local.properties` and several CloudLab configs), the JSON
+fallback runs for every Paxos message — roughly doubling inter-replica
+bandwidth.
+
+This was discovered investigating why leader→follower bandwidth was
+~8× higher than client↔replica bandwidth at small payloads.
+
+## Empirical evidence
+
+All runs: 100% PUT, 60 s @ rate=50 per replica, 3-replica placement
+(linearizable Paxos), identical config except for the active-replica
+naming. Three body shapes:
+
+- **1× (47 B)**: default `{"title":"trace_bw","author":"benchmark"}`
+- **10× pathological (473 B)**: `{"title":"X×440","author":"benchmark"}`
+  — long run of identical bytes, deflate collapses it to almost nothing
+- **10× entropy (473 B)**: same shape but `title` is random-looking,
+  url-safe-base64 padding — incompressible
+
+### Headline: 1× baseline (47 B body)
+
+| Flow                              | Named (`AR0..AR4`) | Numeric (`0..4`) | Δ      |
+|-----------------------------------|-------------------:|-----------------:|-------:|
+| Leader → follower (per write)     |             1063 B |        **487 B** | −54%   |
+| Follower → leader (per write)     |              411 B |            196 B | −52%   |
+| Client → leader (HTTP, per write) |              268 B |            268 B |  0%    |
+| Leader → client (HTTP, per write) |              181 B |            181 B |  0%    |
+| Leader-out total per write        |             2127 B |        **974 B** | **−54%** |
+| Ratio leader-out : client-in      |               8.0× |             3.6× |        |
+
+Client/HTTP framing is unchanged (the AR HTTP frontend doesn't depend on
+node-id encoding). The reduction is entirely on the Paxos NIO links.
+
+### Six-run cross-cut: leader → follower per-write bytes
+
+| Body         | Named (JSON)  | Numeric (byteified) | Savings |
+|--------------|--------------:|--------------------:|--------:|
+| 1× (47 B)    | 1063 B        | 487 B               | **−54%** |
+| 10× pathological (`X×440`) | 1056 B | 474 B          | **−55%** |
+| 10× entropy (random)       | 1833 B | 836 B          | **−54%** |
+
+The savings ratio is essentially flat across body sizes — the
+byteification optimization touches only the Paxos protocol envelope, not
+the body propagation path, and the same per-byte JSON-encoding tax
+applies to both metadata bytes (heavily, since they're rich in
+non-printables) and the QV body bytes (lightly, since deflated payloads
+are mostly printable when ISO-8859-1 viewed).
+
+CSVs preserved under `xdn-bw-trace/results/`:
+- `bookcatalog-writes-1x.csv` (named, JSON path)
+- `bookcatalog-writes-1x-numeric.csv` (numeric, byteified path)
+- plus `-10x`, `-10x-entropy`, `-10x-numeric`, `-10x-entropy-numeric`
+
+## Single AcceptPacket on the wire (named-IDs / JSON path)
+
+Captured live with `tcpdump` on `lo`, decoded with scapy:
+
+```
+total payload:                                     763 B
+  NIO frame header (length prefix):                  8 B   (1%)
+  JSON-encoded AcceptPacket:                       755 B
+    JSON envelope (Paxos protocol metadata):       471 B  (62%)
+      field names: B PT QV E type QID ET SNDR
+                   GC_S S QF V ID CA               ~50 B
+      values (ballot, slot, sender, paxosID,
+              clientAddress, ...)                  ~250 B
+      JSON syntax (braces/commas/colons/quotes/
+                   \u00XX escapes)                 ~170 B
+    QV (the application payload, JSON-escaped):    284 B  (37%)
+      XdnHttpRequestBatch wrapper (svc name,
+        uncompressed-len, compressed-len)           23 B
+      deflated XdnHttpRequest proto
+        (HTTP method + URI + headers + body)      ~255 B
+```
+
+## Single AcceptPacket on the wire (numeric-IDs / byteified path)
+
+Captured live on the same workload, same config except for the node IDs.
+Sums to exactly **392 bytes** — every field accounted for from the
+GigaPaxos struct definitions:
+
+| Range   | Layer                          | Bytes | Contents (live values) |
+|---------|--------------------------------|------:|------------------------|
+| 0–8     | NIO frame                      |   8   | preamble (`0x2b1eb469`) + payload-length (384) |
+| 8–32    | `PaxosPacket` header           |  24   | type=90 · sub_type=3 (ACCEPT) · version=0 · paxosID-len=11 · paxosID=`"bookcatalog"` |
+| 32–87   | `RequestPacket.SIZEOF_REQUEST_FIXED` | 55 | requestID(8) · stop(1) · clientAddr(6) · listenAddr(6) · entryReplica(4) · entryTime(8) · shouldReturnReqVal(1) · forwardCount(4) · broadcasted(1) · digest-len(4) · reqVal-len(4) · respVal-len(4) · batchSize(4) |
+| 87      | digest bytes                   |   0   | empty (`DIGEST_REQUESTS=false`) |
+| 87–370  | requestValue (XdnHttpRequestBatch) | 283 | svcname-len(4) · `"bookcatalog"`(11) · uncompressed-len(4) · compressed-len(4) · deflated XdnHttpRequest proto |
+| 370     | responseValue bytes            |   0   | empty for accepts |
+| 370     | batched-slots bytes            |   0   | singleton batch — already inlined in reqval |
+| 370–374 | `ProposalPacket.SIZEOF_PROPOSAL` | 4   | slot=2404 |
+| 374–388 | `PValuePacket.SIZEOF_PVALUE`   |  14   | ballot.num(4) · ballot.coord(4) · recovery(1) · medianCheckpointedSlot(4) · noCoalesce(1) |
+| 388–392 | `AcceptPacket.SIZEOF_ACCEPT`   |   4   | sender=0 (the numeric node id, on the wire as a raw int) |
+| **Total** |                              | **392** | |
+
+The 109 B of Paxos protocol fixed overhead (8 NIO + 24 PaxosPacket + 55
+RequestPacket + 4 Proposal + 14 PValue + 4 Accept) is what the JSON path
+inflates to 471 B (4.3×) — see the JSON breakdown above.
+
+## Per-write breakdown (numeric, 1× baseline → 487 B/write outbound)
+
+From the live capture: ~1.06 leader→follower packets per write,
+averaging 441 B/pkt. The single decoded AcceptPacket above is one
+sample.
+
+| Component                       | Bytes/write | Notes |
+|---------------------------------|------------:|-------|
+| 1 × AcceptPacket (avg)          | ~415        | 1.0 pkt/write × ~415 B avg |
+| ↳ Fixed Paxos protocol (NIO + headers) | 109  | 8 + 24 + 55 + 4 + 14 + 4 |
+| ↳ deflated XdnHttpRequestBatch  | ~283        | scales with body size |
+| residual: small commit/decision follow-ups, heartbeats, accept-replies merged into bidirectional flow | ~70 | empirical gap to 487 |
+| **Measured total**              | **487 B/write** |   |
+
+## Side-by-side per AcceptPacket: numeric vs named
+
+| Component                      | Numeric (byteified) | Named (JSON) | Inflation |
+|--------------------------------|--------------------:|-------------:|----------:|
+| NIO frame header               |         8 B         |        8 B   |     1.0×  |
+| **Paxos protocol metadata**    |       **109 B**     |    **471 B** |   **4.3×** |
+| ↳ as struct fields (numeric)   | type/sub_type/version/paxosID + RequestPacket(55) + Proposal(4) + PValue(14) + Accept(4) | | |
+| ↳ as JSON keys+values (named)  | | `"B":"0:AR1","PT":3,"E":65056,"type":90,"QID":...,"ET":...,"SNDR":65056,"GC_S":...,"S":...,"QF":true,"V":0,"ID":"bookcatalog","CA":"/127.0.0.1:2001"` | |
+| Application payload (QV / requestValue) | 283 B      |     284 B    |     1.0×  |
+| ↳ deflated XdnHttpRequest proto | 283 B verbatim     | 278 B (after `\u00XX` unescape) + ~6 B JSON-escape | |
+| **Total per AcceptPacket**     |       **392 B**     |    **763 B** |   **1.95×** |
+
+The ~2× wire savings is concentrated entirely in the Paxos protocol
+metadata. The application payload itself is virtually unchanged — JSON
+only adds the modest cost of escaping non-printable bytes inside the
+`"QV"` string.
+
+## The gating logic
+
+`paxospackets/RequestPacket.java:815-832`:
+
+```java
+protected byte[] toBytes(boolean instrument) {
+    ...
+    // check if we can use byteification at all; if not, use toString()
+    if (!((BYTEIFICATION && IntegerMap.allInt()) || instrument)) {
+        ...
+        return this.byteifiedSelf = this.toString().getBytes(CHARSET);
+    }
+    // else byteify
+    ...
+}
+```
+
+The same gate appears in `AcceptPacket.toBytes()`, `BatchedAcceptReply`,
+and `BatchedCommit`. `BYTEIFICATION` defaults to `true`
+(`PaxosConfig.java:644`). The flip happens in `IntegerMap.put()`
+(`paxosutil/IntegerMap.java:61-66`):
+
+```java
+public int put(NodeIDType node) {
+    int id = getID(node);
+    if (!node.toString().equals(Integer.valueOf(id).toString()))
+        allInteger = false;
+    ...
+}
+```
+
+`getID` hashes the node ID to an int (e.g. `"AR1"` → `65056`), then this
+check compares the stringified hash (`"65056"`) to the original name
+(`"AR1"`). They don't match, so `allInteger` flips to `false` once and
+never recovers. From that point every Paxos packet falls through to
+`toString().getBytes(CHARSET)` — which is the JSON encoding from
+`toJSONObject()`/`toJSONSmart()`.
+
+The code comment at `RequestPacket.java:797-813` is explicit about the
+cost:
+
+> The serialization overhead really matters most for `RequestPacket` and
+> `AcceptPacket`. ... byteification makes a non-trivial difference
+> (~2× over json-smart and >4× over org.json).
+
+Our measurement (`1063 / 487 = 2.18×`) lands in the predicted range.
+
+## The fix
+
+Use numeric strings for active-replica and reconfigurator IDs. The
+key after `active.` / `reconfigurator.` is the only thing that needs
+to change:
+
+```properties
+# Engages byteification:
+active.0=127.0.0.1:2000
+active.1=127.0.0.1:2001
+...
+reconfigurator.5=127.0.0.1:3000
+
+# Disables byteification (currently the default in our local configs):
+active.AR0=127.0.0.1:2000
+active.AR1=127.0.0.1:2001
+...
+reconfigurator.RC0=127.0.0.1:3000
+```
+
+Reference config: `conf/gigapaxos.xdn.local.numeric.properties`
+(numeric variant of `conf/gigapaxos.xdn.local.properties`,
+identical otherwise).
+
+## Caveats
+
+- **The wire-format compatibility is asymmetric.** A cluster running
+  with mixed naming (some nodes numeric, some named) emits packets in
+  whichever format the *sending* JVM's `IntegerMap.allInt()` returns
+  at send time. Mixed deployments should be tested before relying on
+  this — don't assume nodes negotiate the format.
+- **`xdn-cli` and any tooling that pretty-prints replica info** is
+  agnostic to whether IDs are numeric (e.g. `xdn service info` happily
+  shows `0`, `1`, `3` as the placement). Anything that hard-codes
+  `AR<N>` strings would need updating; a quick grep finds none in the
+  data plane, only the bandwidth tracer's *probe-attach* helper
+  (`build_pid_to_ar` in `trace_bw.py`), which already accepts any
+  token after `ReconfigurableNode`.
+- **The optimization is purely on the Paxos NIO channel.** Client-facing
+  HTTP, state diffs, and Docker manifests are untouched — this is not
+  a workload-shape change, just a serialization-path change.
+- **Savings ratio is constant across body sizes.** Across 1× (47 B),
+  10× pathological, and 10× entropy bodies the leader→follower
+  per-write reduction was 54%, 55%, 54%. Both the metadata envelope
+  and the body bytes inside `QV` get the same JSON-escape tax in the
+  named path, so the optimization scales with payload — there's no
+  body shape at which it stops paying off.
+
+## Reproducer
+
+```bash
+# Stop existing cluster + clean state
+sudo ./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.properties forceclear all
+sg docker -c "docker ps -aq --filter 'name=^c0\.e0\.' | xargs -r docker rm -f"
+sudo rm -rf /tmp/gigapaxos /tmp/xdn
+
+# Start with numeric IDs
+sg docker -c "./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.numeric.properties start all"
+
+# Deploy + trace
+export XDN_CONTROL_PLANE=localhost
+sg docker -c "xdn launch bookcatalog --image=fadhilkurnia/xdn-bookcatalog --state=/app/data/ --deterministic=true"
+sudo python3 xdn-bw-trace/trace_bw.py \
+    --config conf/gigapaxos.xdn.local.numeric.properties \
+    --service bookcatalog \
+    --duration 60 --interval 5 --rate 50 --read-ratio 0.0 \
+    --output xdn-bw-trace/results/bookcatalog-writes-1x-numeric.csv
+
+# Compare matrices
+python3 xdn-bw-trace/plot_bw_graph.py xdn-bw-trace/results/bookcatalog-writes-1x.csv
+python3 xdn-bw-trace/plot_bw_graph.py xdn-bw-trace/results/bookcatalog-writes-1x-numeric.csv
+```

--- a/xdn-bw-trace/plot_bw_graph.py
+++ b/xdn-bw-trace/plot_bw_graph.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""plot_bw_graph.py — turn a trace_bw.py CSV into a directed bandwidth graph.
+
+Reads the per-event CSV produced by `trace_bw.py` (columns
+`local_id, peer_id, direction, bytes, ...`), aggregates bytes per
+`(local_id, peer_id)` edge, and renders it as a NetworkX DiGraph with the
+replicas arranged on a circle. The aggregated adjacency matrix is also
+printed to stdout.
+
+Usage:
+    python3 xdn-bw-trace/plot_bw_graph.py xdn-bw-trace/results/<file>.csv
+    python3 xdn-bw-trace/plot_bw_graph.py <file>.csv --output graph.png
+
+The `out` direction is preferred for edge weights — it counts bytes once
+at the sender, avoiding the double-count that would happen if we summed
+both `out` (sender's tcp_sendmsg) and `in` (receiver's tcp_cleanup_rbuf)
+for the same flow.
+"""
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless render
+import matplotlib.pyplot as plt
+import networkx as nx
+
+from _plotutil import (
+    CLIENT_PREFIX, draw_edge_labels_at_fixed_offset, replica_client_layout,
+)
+
+
+def display_node_label(node):
+    """Per-node display text for `nx.draw_networkx_labels`. Client
+    vertices break onto two lines so 'client' and the AR id stack
+    vertically inside the orange node square."""
+    if node.startswith(CLIENT_PREFIX):
+        return f"client\n{node[len(CLIENT_PREFIX):]}"
+    return node
+
+
+def load_meta(csv_path):
+    """Return the workload-metadata dict that trace_bw.py writes
+    alongside each CSV, or `None` if it isn't there (older CSVs, or
+    user moved the file)."""
+    meta_path = csv_path.with_name(csv_path.stem + ".meta.json")
+    if not meta_path.exists():
+        return None
+    try:
+        with open(meta_path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"warning: failed to read {meta_path}: {e}", file=sys.stderr)
+        return None
+
+
+def _humanize_consistency(s):
+    """Match the Go CLI's display style for consistency model names.
+    `LINEARIZABILITY` -> `Linearizability`, `READ_YOUR_WRITES` ->
+    `ReadYourWrites`. Empty input passes through unchanged so callers
+    can safely chain it.
+    """
+    if not s:
+        return s
+    return "".join(p.capitalize() for p in s.split("_"))
+
+
+def format_workload_subtitle(meta):
+    """Two-line workload summary built from the trace_bw.py metadata.
+    Returns an empty string if `meta` is None so the caller can skip
+    the subtitle entirely. Split across two lines so it fits inside
+    the axes width without being clipped."""
+    if not meta:
+        return ""
+    rr = meta.get("read_ratio")
+    rate = meta.get("rate_per_replica_rps")
+    n_t = meta.get("num_targets")
+    dur = meta.get("duration_seconds")
+    info = meta.get("service_info") or {}
+    line1_parts = []
+    if "service" in meta:
+        line1_parts.append(f"service={meta['service']}")
+    if info.get("protocol"):
+        line1_parts.append(f"protocol={info['protocol']}")
+    if info.get("consistency"):
+        c = _humanize_consistency(info["consistency"])
+        rc = _humanize_consistency(info.get("requested_consistency", ""))
+        if rc and rc != c:
+            line1_parts.append(f"consistency={c} (requested: {rc})")
+        else:
+            line1_parts.append(f"consistency={c}")
+    if rr is not None:
+        line1_parts.append(f"r/w={rr:.0%}/{1.0 - rr:.0%}")
+    if rate is not None and n_t is not None:
+        line1_parts.append(f"rate={rate:g} req/s × {n_t} replicas")
+    if dur is not None:
+        line1_parts.append(f"duration={dur:g}s")
+
+    read = meta.get("read") or {}
+    write = meta.get("write") or {}
+    totals = meta.get("totals") or {}
+    line2_parts = []
+    if read.get("method") and read.get("path"):
+        line2_parts.append(f"read={read['method']} {read['path']}")
+    if write.get("method") and write.get("path"):
+        line2_parts.append(f"write={write['method']} {write['path']}")
+    if "reads" in totals and "writes" in totals:
+        line2_parts.append(
+            f"sent reads={totals['reads']} writes={totals['writes']}")
+
+    sep = "  ·  "
+    lines = []
+    if line1_parts:
+        lines.append(sep.join(line1_parts))
+    if line2_parts:
+        lines.append(sep.join(line2_parts))
+    return "\n".join(lines)
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("csv", help="path to a trace_bw.py CSV")
+    p.add_argument("--direction", choices=["out", "in", "both"], default="out",
+                   help="which event direction(s) to sum into edge weight. "
+                        "'out' (default) counts each flow once on the sender. "
+                        "'in' counts on the receiver. 'both' double-counts "
+                        "(useful only for sanity-checking symmetry).")
+    p.add_argument("--include-unknown", action="store_true",
+                   help="keep rows whose local_id or peer_id is 'unknown' "
+                        "(default: drop them).")
+    p.add_argument("--output",
+                   help="output image path. Default: <csv-stem>.png next to "
+                        "the CSV.")
+    p.add_argument("--unit", choices=["B", "KB", "MB"], default="KB",
+                   help="byte unit for edge labels and the printed matrix. "
+                        "Default: KB.")
+    return p.parse_args()
+
+
+def read_edges(csv_path, direction, include_unknown):
+    """Return a {(src, dst): bytes} dict aggregated from the CSV."""
+    edges = defaultdict(int)
+    nodes = set()
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        required = {"local_id", "peer_id", "direction", "bytes"}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            sys.exit(f"error: CSV is missing columns: {sorted(missing)}. "
+                     f"Did you regenerate it with the updated trace_bw.py?")
+        for row in reader:
+            if direction != "both" and row["direction"] != direction:
+                continue
+            src, dst = row["local_id"], row["peer_id"]
+            if not include_unknown and ("unknown" in (src, dst)):
+                continue
+            try:
+                nbytes = int(row["bytes"])
+            except (ValueError, TypeError):
+                continue
+            edges[(src, dst)] += nbytes
+            nodes.add(src)
+            nodes.add(dst)
+    return edges, nodes
+
+
+def fmt_bytes(n, unit):
+    if unit == "B":
+        return f"{n} B"
+    if unit == "KB":
+        return f"{n / 1024:.1f} KB"
+    return f"{n / (1024 * 1024):.2f} MB"
+
+
+def print_matrix(nodes, edges, unit):
+    """Print the adjacency matrix to stdout (rows = src, cols = dst)."""
+    sorted_nodes = sorted(nodes)
+    cell_strs = [
+        fmt_bytes(edges.get((s, d), 0), unit)
+        for s in sorted_nodes for d in sorted_nodes
+    ]
+    width = max(12,
+                max((len(n) for n in sorted_nodes), default=0) + 2,
+                max((len(c) for c in cell_strs), default=0) + 2)
+    print("src \\ dst".ljust(width)
+          + "".join(n.ljust(width) for n in sorted_nodes))
+    for src in sorted_nodes:
+        cells = [src.ljust(width)]
+        for dst in sorted_nodes:
+            v = edges.get((src, dst), 0)
+            cells.append(("-" if src == dst and v == 0
+                          else fmt_bytes(v, unit)).ljust(width))
+        print("".join(cells))
+
+
+def render_graph(nodes, edges, output_path, unit, meta=None):
+    """Draw the DiGraph with replicas on an inner circle, per-replica
+    `client-<AR>` vertices on an outer ring at the matching angle, and
+    edge labels in `unit`. If `meta` is provided (the sidecar workload
+    metadata from trace_bw.py), its summary is rendered as a subtitle
+    beneath the main title."""
+    g = nx.DiGraph()
+    sorted_nodes = sorted(nodes)
+    g.add_nodes_from(sorted_nodes)
+    for (src, dst), w in edges.items():
+        if src == dst:
+            continue  # no self-loops in this view
+        g.add_edge(src, dst, weight=w)
+
+    pos = replica_client_layout(g)
+
+    weights = [d["weight"] for _, _, d in g.edges(data=True)]
+    if not weights:
+        sys.exit("error: no edges to plot (every row was filtered out).")
+    max_w = max(weights)
+    # Map [0, max_w] -> [0.5, 5.0] line widths so small edges remain visible.
+    widths = [0.5 + 4.5 * (w / max_w) for w in weights]
+
+    ar_vs = [n for n in g.nodes
+             if not n.startswith(CLIENT_PREFIX) and n not in ("client",
+                                                              "unknown")]
+    client_vs = [n for n in g.nodes if n.startswith(CLIENT_PREFIX)]
+    other_vs = [n for n in g.nodes if n not in ar_vs and n not in client_vs]
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    nx.draw_networkx_nodes(g, pos, nodelist=ar_vs,
+                           node_color="#cfe8ff", edgecolors="#1f6fb2",
+                           node_size=1800, ax=ax)
+    if client_vs:
+        nx.draw_networkx_nodes(g, pos, nodelist=client_vs,
+                               node_color="#ffe2c2", edgecolors="#c2691f",
+                               node_shape="s", node_size=1500, ax=ax)
+    if other_vs:
+        nx.draw_networkx_nodes(g, pos, nodelist=other_vs,
+                               node_color="#dddddd", edgecolors="#666666",
+                               node_size=1200, ax=ax)
+    display_labels = {n: display_node_label(n) for n in g.nodes}
+    nx.draw_networkx_labels(g, pos, labels=display_labels,
+                            font_size=10, font_weight="bold", ax=ax)
+    edge_rad = 0.12
+    edge_curve = f"arc3,rad={edge_rad}"
+    nx.draw_networkx_edges(
+        g, pos, width=widths, edge_color="#1f6fb2",
+        arrows=True, arrowstyle="-|>", arrowsize=16,
+        connectionstyle=edge_curve,
+        node_size=1800, ax=ax,
+    )
+    edge_labels = {(u, v): fmt_bytes(d["weight"], unit)
+                   for u, v, d in g.edges(data=True)}
+    # Absolute offset (data coords) from the target node center to the
+    # label's destination-facing edge. Has to clear: node disk radius
+    # (~0.11 with node_size=1800 at this figsize/dpi) plus the
+    # arrowhead's length (~0.08), plus a little breathing room so the
+    # widest labels (e.g. "2966.6 KB" on the heaviest AR1->follower
+    # edges) don't graze the arrow tip.
+    draw_edge_labels_at_fixed_offset(
+        ax, g, pos, edge_labels,
+        rad=edge_rad, offset=0.28,
+        fontsize=8,
+        bbox={"boxstyle": "round,pad=0.1", "fc": "white",
+              "ec": "none", "alpha": 0.75},
+    )
+    main_title = (f"Inter-replica bandwidth — {output_path.name} "
+                  f"(edge weight = bytes, unit = {unit})")
+    subtitle = format_workload_subtitle(meta)
+    if subtitle:
+        # fig.suptitle = main heading at top of figure;
+        # ax.set_title = subheading directly above the axes.
+        fig.suptitle(main_title, fontsize=11, y=0.97)
+        ax.set_title(subtitle, fontsize=9, color="dimgray", pad=6)
+    else:
+        ax.set_title(main_title, fontsize=11)
+    ax.set_axis_off()
+    # A little padding so outer-ring labels aren't clipped.
+    ax.margins(0.15)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+
+
+def main():
+    args = parse_args()
+    csv_path = Path(args.csv)
+    if not csv_path.exists():
+        sys.exit(f"error: {csv_path} does not exist")
+
+    edges, nodes = read_edges(csv_path, args.direction, args.include_unknown)
+    if not nodes:
+        sys.exit("error: CSV produced no usable rows after filtering. "
+                 "Try --include-unknown or check --direction.")
+
+    print(f"# direction={args.direction}  nodes={len(nodes)}  "
+          f"edges={len(edges)}  unit={args.unit}")
+    print_matrix(nodes, edges, args.unit)
+
+    output_path = (Path(args.output) if args.output
+                   else csv_path.with_suffix(".png"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    meta = load_meta(csv_path)
+    render_graph(nodes, edges, output_path, args.unit, meta=meta)
+    print(f"# wrote {output_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xdn-bw-trace/plot_lat_graph.py
+++ b/xdn-bw-trace/plot_lat_graph.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""plot_lat_graph.py — render an inter-replica latency graph computed
+analytically from each replica's (lat, lon).
+
+Latency is the great-circle distance via the Haversine formula divided
+by an effective signal speed (default: c × 2/3, the typical refractive
+index of fiber). This is a propagation-only lower bound; real RTT on
+the public internet typically exceeds it by 1.5–2× because of routing
+and queueing.
+
+Usage:
+    # Plot every active.<id>.geolocation in the gigapaxos config:
+    python3 xdn-bw-trace/plot_lat_graph.py \\
+        --config conf/gigapaxos.cloudlab.properties
+
+    # Plot only the replicas hosting a service (queries the RC):
+    python3 xdn-bw-trace/plot_lat_graph.py \\
+        --config conf/gigapaxos.xdn.local.properties \\
+        --service bookcatalog
+
+    # Geographic layout (replicas placed at their actual (lon, lat)):
+    python3 xdn-bw-trace/plot_lat_graph.py --config <...> --layout geo
+"""
+
+import argparse
+import math
+import sys
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import networkx as nx
+import numpy as np
+
+from _plotutil import replica_client_layout
+from trace_bw import (
+    HTTP_PORT_OFFSET, fetch_service_placement, parse_properties,
+)
+
+EARTH_RADIUS_KM = 6371.0
+SPEED_OF_LIGHT_KMS = 299_792.0  # km/s
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--config",
+                   help="path to gigapaxos.properties. Used to read "
+                        "active.<id>.geolocation if --service is not given, "
+                        "and to derive the reconfigurator endpoint when "
+                        "--service is given without --reconfigurator.")
+    p.add_argument("--service",
+                   help="XDN service name. If set, replicas are taken from "
+                        "the reconfigurator's placement endpoint instead of "
+                        "from the config file (so only the replicas hosting "
+                        "this service appear in the graph).")
+    p.add_argument("--reconfigurator",
+                   help="reconfigurator HTTP endpoint as host[:port] "
+                        "(default: derive host from the first reconfigurator "
+                        "in --config, port = NIO port + 300).")
+    p.add_argument("--output",
+                   help="output PNG path. Default: "
+                        "xdn-bw-trace/results/<service-or-config>-latency.png "
+                        "(same dir plot_bw_graph.py writes to).")
+    p.add_argument("--unit", choices=["ms", "us"], default="ms",
+                   help="latency unit for labels and the printed matrix. "
+                        "Default: ms.")
+    p.add_argument("--rtt", action="store_true",
+                   help="show round-trip latency (2 × one-way). Default: "
+                        "one-way.")
+    p.add_argument("--fiber-fraction", type=float, default=2.0 / 3.0,
+                   help="effective signal speed as a fraction of c. Default: "
+                        "0.667 (typical fiber refractive index ≈ 1.47).")
+    p.add_argument("--layout", choices=["circle", "geo"], default="circle",
+                   help="vertex layout. 'circle' (default) matches "
+                        "plot_bw_graph.py; 'geo' places each replica at its "
+                        "(longitude, latitude) via equirectangular "
+                        "projection.")
+    p.add_argument("--min-node-spacing", type=float, default=0.20,
+                   help="(geo layout only) minimum distance, in normalized "
+                        "data units, between any two replicas after the "
+                        "projection. Replicas closer than this get pushed "
+                        "apart along their connecting line, just enough to "
+                        "stop their disks from overlapping. Smaller values "
+                        "preserve geographic ratios more faithfully but may "
+                        "leave dense clusters visually overlapping. "
+                        "Default: 0.20 (just past 2× the default node-disk "
+                        "radius).")
+    return p.parse_args()
+
+
+def haversine_km(lat1, lon1, lat2, lon2):
+    """Great-circle distance in km, Haversine formula."""
+    rlat1, rlat2 = math.radians(lat1), math.radians(lat2)
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (math.sin(dlat / 2) ** 2
+         + math.cos(rlat1) * math.cos(rlat2) * math.sin(dlon / 2) ** 2)
+    return EARTH_RADIUS_KM * 2.0 * math.asin(min(1.0, math.sqrt(a)))
+
+
+def latency_seconds(distance_km, fiber_fraction, rtt=False):
+    """Propagation latency in seconds for a given distance over fiber."""
+    if fiber_fraction <= 0.0:
+        return float("inf")
+    one_way = distance_km / (SPEED_OF_LIGHT_KMS * fiber_fraction)
+    return 2.0 * one_way if rtt else one_way
+
+
+def fmt_latency(seconds, unit):
+    if unit == "us":
+        return f"{seconds * 1e6:.1f} us"
+    return f"{seconds * 1000.0:.2f} ms"
+
+
+def load_replicas(args):
+    """Return [(id, lat, lon), ...] in deterministic order.
+
+    If --service is given, query the reconfigurator and use only the
+    replicas hosting that service. Otherwise read every
+    active.<id>.geolocation from --config.
+    """
+    if args.service:
+        rc_host, rc_http_port = _resolve_rc_endpoint(args)
+        nodes = fetch_service_placement(rc_host, rc_http_port, args.service)
+        out = []
+        skipped = []
+        for n in nodes:
+            geo = n.get("geolocation")
+            if geo is None:
+                skipped.append(n["id"])
+                continue
+            out.append((n["id"], geo[0], geo[1]))
+        if skipped:
+            print(f"warning: skipping {len(skipped)} replica(s) without "
+                  f"geolocation in placement: {skipped}", file=sys.stderr)
+        return out
+
+    if not args.config:
+        sys.exit("error: must pass --config (or --service to fetch from RC)")
+    _, _, geolocations = parse_properties(args.config)
+    if not geolocations:
+        sys.exit(f"error: no active.<id>.geolocation entries in {args.config}")
+    return [(name, lat, lon)
+            for name, (lat, lon) in sorted(geolocations.items())]
+
+
+def _resolve_rc_endpoint(args):
+    if args.reconfigurator:
+        endpoint = args.reconfigurator
+        if ":" in endpoint:
+            host, _, port_s = endpoint.rpartition(":")
+            try:
+                return host, int(port_s)
+            except ValueError:
+                sys.exit(f"error: invalid --reconfigurator '{endpoint}'")
+        return endpoint, 3000 + HTTP_PORT_OFFSET
+    if not args.config:
+        sys.exit("error: --service requires either --reconfigurator or "
+                 "--config (to derive the reconfigurator host).")
+    _, reconfigurators, _ = parse_properties(args.config)
+    if not reconfigurators:
+        sys.exit(f"error: no reconfigurator.<name>=host:port in "
+                 f"{args.config}; pass --reconfigurator host[:port]")
+    name = sorted(reconfigurators.keys())[0]
+    host, nio_port = reconfigurators[name]
+    return host, nio_port + HTTP_PORT_OFFSET
+
+
+def compute_latencies(replicas, fiber_fraction, rtt):
+    """{(id_i, id_j): seconds} for every i<j (undirected)."""
+    out = {}
+    for i in range(len(replicas)):
+        id_i, lat_i, lon_i = replicas[i]
+        for j in range(i + 1, len(replicas)):
+            id_j, lat_j, lon_j = replicas[j]
+            d_km = haversine_km(lat_i, lon_i, lat_j, lon_j)
+            out[(id_i, id_j)] = latency_seconds(d_km, fiber_fraction, rtt)
+    return out
+
+
+def geo_layout(replicas, min_distance=0.20, max_iter=80):
+    """Equirectangular projection (lon → x, lat → y), then rescale into
+    roughly [-1, 1] × [-1, 1] so the rest of the rendering pipeline (the
+    same offset, font sizes, and figure size as the circle layout) keeps
+    working without retuning.
+
+    Replicas that would overlap their disks after the projection get
+    iteratively pushed apart by `_spread_close_nodes` until every pair
+    is at least `min_distance` away. This is intentionally just barely
+    past 2× the node-disk radius (~0.16 in this frame at the default
+    node_size) so the visual distance ratios stay as close to the real
+    geographic ratios as possible — only pairs that would otherwise
+    fully overlap get nudged, and only by the minimum amount.
+
+    No latitude correction (would require cosine compression for high-
+    latitude bands); for a small handful of replicas this isn't worth it.
+    """
+    if not replicas:
+        return {}
+    lats = [r[1] for r in replicas]
+    lons = [r[2] for r in replicas]
+    lon_mid = (min(lons) + max(lons)) / 2.0
+    lat_mid = (min(lats) + max(lats)) / 2.0
+    span = max(max(lons) - min(lons), max(lats) - min(lats), 1e-6)
+    scale = 2.0 / span  # fit the bounding box of the replicas into [-1, 1]
+    raw = {r_id: ((lon - lon_mid) * scale, (lat - lat_mid) * scale)
+           for r_id, lat, lon in replicas}
+    return _spread_close_nodes(raw, min_distance=min_distance,
+                               max_iter=max_iter)
+
+
+def _spread_close_nodes(pos, min_distance, max_iter):
+    """Iteratively push apart any pair of nodes whose Euclidean distance
+    is below `min_distance`. Each pass nudges every violating pair half-
+    symmetrically along their connecting axis; for genuinely coincident
+    nodes, the push direction is derived deterministically from the
+    node-id pair so reruns produce the same layout. Converges in a
+    handful of iterations for the small graphs this script is designed
+    for; if `max_iter` is hit without convergence we still return the
+    current positions (better than throwing).
+    """
+    if len(pos) < 2:
+        return pos
+    keys = sorted(pos.keys())  # deterministic iteration order
+    p = {k: np.asarray(v, dtype=float).copy() for k, v in pos.items()}
+    for _ in range(max_iter):
+        moved = False
+        for i in range(len(keys)):
+            for j in range(i + 1, len(keys)):
+                a, b = keys[i], keys[j]
+                d_vec = p[b] - p[a]
+                d = float(np.linalg.norm(d_vec))
+                if d >= min_distance:
+                    continue
+                if d == 0.0:
+                    # Coincident — pick a stable, content-derived
+                    # direction so two identical inputs produce the same
+                    # output across runs.
+                    seed = (hash((a, b)) & 0xFFFF) / 0xFFFF
+                    angle = 2.0 * math.pi * seed
+                    unit = np.array([math.cos(angle), math.sin(angle)])
+                else:
+                    unit = d_vec / d
+                violation = min_distance - d
+                p[a] -= unit * violation / 2.0
+                p[b] += unit * violation / 2.0
+                moved = True
+        if not moved:
+            break
+    return {k: tuple(v) for k, v in p.items()}
+
+
+def print_matrix(replicas, latencies, unit):
+    """Symmetric latency matrix to stdout."""
+    ids = [r[0] for r in replicas]
+    cell_strs = [
+        fmt_latency(latencies.get(_undirected_key(a, b), 0.0), unit)
+        for a in ids for b in ids
+    ]
+    width = max(12,
+                max((len(i) for i in ids), default=0) + 2,
+                max((len(c) for c in cell_strs), default=0) + 2)
+    print("a \\ b".ljust(width)
+          + "".join(i.ljust(width) for i in ids))
+    for a in ids:
+        row = [a.ljust(width)]
+        for b in ids:
+            if a == b:
+                row.append("-".ljust(width))
+            else:
+                v = latencies.get(_undirected_key(a, b), 0.0)
+                row.append(fmt_latency(v, unit).ljust(width))
+        print("".join(row))
+
+
+def _undirected_key(a, b):
+    return (a, b) if a < b else (b, a)
+
+
+def render_graph(replicas, latencies, output_path, args):
+    """Undirected latency graph. Default circle layout matches the bw
+    graph; --layout geo places replicas at their (lon, lat)."""
+    g = nx.Graph()  # undirected
+    g.add_nodes_from(r[0] for r in replicas)
+    for (a, b), seconds in latencies.items():
+        if a == b:
+            continue
+        g.add_edge(a, b, weight=seconds)
+
+    if args.layout == "geo":
+        pos = geo_layout(replicas, min_distance=args.min_node_spacing)
+    else:
+        pos = replica_client_layout(g)
+
+    weights = [d["weight"] for _, _, d in g.edges(data=True)]
+    if not weights:
+        sys.exit("error: no edges to plot (need at least 2 replicas with "
+                 "geolocations).")
+    max_w = max(weights) or 1.0
+    widths = [0.5 + 4.5 * (w / max_w) for w in weights]
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    nx.draw_networkx_nodes(g, pos, node_color="#cfe8ff",
+                           edgecolors="#1f6fb2", node_size=1800, ax=ax)
+    nx.draw_networkx_labels(g, pos, font_size=10, font_weight="bold", ax=ax)
+
+    # Straight lines: latency is symmetric, so there's no need to fan
+    # out two arcs per pair. networkx's undirected drawer uses a
+    # LineCollection by default (no connectionstyle support); that's
+    # exactly what we want here.
+    edge_rad = 0.0
+    nx.draw_networkx_edges(
+        g, pos, width=widths, edge_color="#1f6fb2",
+        node_size=1800, ax=ax,
+    )
+    edge_labels = {(u, v): fmt_latency(d["weight"], args.unit)
+                   for u, v, d in g.edges(data=True)}
+    # Latency edges are undirected and drawn straight, so the midpoint
+    # is the natural place for the label. Plain networkx is fine here —
+    # we don't need the curve-aware fixed-offset drawer used by the bw
+    # graph (which exists specifically to handle two opposite-direction
+    # arcs per pair).
+    nx.draw_networkx_edge_labels(
+        g, pos, edge_labels=edge_labels, font_size=8,
+        label_pos=0.5,
+        rotate=True,
+        bbox={"boxstyle": "round,pad=0.1", "fc": "white",
+              "ec": "none", "alpha": 0.75},
+        ax=ax,
+    )
+
+    if args.layout == "geo":
+        # Force equal data aspect so 1° of latitude renders the same
+        # length as 1° of longitude — otherwise matplotlib auto-stretches
+        # the narrower axis to fill the figure, which makes a 0.5° lat
+        # gap look as big as a 30° lon gap. `adjustable="datalim"` keeps
+        # the axes box at the requested figure size and instead expands
+        # the data range in the narrower direction (so the replicas end
+        # up correctly proportioned but with whitespace above and below
+        # when the AR layout is wide-and-thin, e.g. our coast-to-coast
+        # cluster).
+        ax.set_aspect("equal", adjustable="datalim")
+        # A faint graticule helps orient the viewer; otherwise the axes
+        # are off and you're just looking at floating dots.
+        ax.grid(True, color="#d0d0d0", linestyle=":", linewidth=0.5)
+        # Restore tick labels in lat/lon (we projected to data coords,
+        # but it's easy to invert for tick text).
+        lats = [r[1] for r in replicas]
+        lons = [r[2] for r in replicas]
+        lon_mid = (min(lons) + max(lons)) / 2.0
+        lat_mid = (min(lats) + max(lats)) / 2.0
+        span = max(max(lons) - min(lons),
+                   max(lats) - min(lats), 1e-6)
+        scale = 2.0 / span
+
+        def x_to_lon(x):
+            return x / scale + lon_mid
+
+        def y_to_lat(y):
+            return y / scale + lat_mid
+
+        ax.xaxis.set_major_formatter(
+            plt.FuncFormatter(lambda x, _pos: f"{x_to_lon(x):.1f}°"))
+        ax.yaxis.set_major_formatter(
+            plt.FuncFormatter(lambda y, _pos: f"{y_to_lat(y):.1f}°"))
+        ax.set_xlabel("longitude")
+        ax.set_ylabel("latitude")
+    else:
+        ax.set_axis_off()
+    ax.margins(0.18)
+
+    main_title = (f"Inter-replica latency — {output_path.name} "
+                  f"({'RTT' if args.rtt else 'one-way'}, "
+                  f"fiber × {args.fiber_fraction:g})")
+    subtitle = format_lat_subtitle(replicas, args)
+    if subtitle:
+        fig.suptitle(main_title, fontsize=11, y=0.97)
+        ax.set_title(subtitle, fontsize=9, color="dimgray", pad=6)
+    else:
+        ax.set_title(main_title, fontsize=11)
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+
+
+def format_lat_subtitle(replicas, args):
+    locs = "  ·  ".join(
+        f"{r_id}=({lat:g}, {lon:g})" for r_id, lat, lon in replicas
+    )
+    v_eff = SPEED_OF_LIGHT_KMS * args.fiber_fraction
+    model = (f"model: c={SPEED_OF_LIGHT_KMS:.0f} km/s · "
+             f"fiber_fraction={args.fiber_fraction:g} · "
+             f"v_eff={v_eff:.0f} km/s · "
+             f"propagation lower bound (real RTT typically 1.5–2× higher)")
+    return locs + "\n" + model
+
+
+def main():
+    args = parse_args()
+    replicas = load_replicas(args)
+    if len(replicas) < 2:
+        sys.exit(f"error: need at least 2 replicas with geolocation; "
+                 f"got {len(replicas)}.")
+    latencies = compute_latencies(replicas, args.fiber_fraction, args.rtt)
+
+    print(f"# replicas={len(replicas)}  layout={args.layout}  "
+          f"unit={args.unit}  "
+          f"{'rtt' if args.rtt else 'one-way'}  "
+          f"fiber_fraction={args.fiber_fraction:g}")
+    print_matrix(replicas, latencies, args.unit)
+
+    if args.output:
+        out_path = Path(args.output)
+    else:
+        stem = args.service or (Path(args.config).stem if args.config
+                                else "latency")
+        out_path = (Path(__file__).resolve().parent / "results"
+                    / f"{stem}-latency.png")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    render_graph(replicas, latencies, out_path, args)
+    print(f"# wrote {out_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xdn-bw-trace/trace_bw.py
+++ b/xdn-bw-trace/trace_bw.py
@@ -1,0 +1,1410 @@
+#!/usr/bin/env python3
+"""trace_bw.py — drive HTTP traffic at one XDN service while bpftrace counts
+inter-replica TCP bytes, then write a per-interval CSV.
+
+Usage:
+    sudo python3 xdn-bw-trace/trace_bw.py \
+        --config conf/gigapaxos.xdn.local.properties \
+        --service bookcatalog \
+        --duration 30 --interval 5 --rate 20
+
+Pre-flight:
+  - Linux host with bpftrace installed (apt install bpftrace).
+  - XDN cluster running with the given properties file.
+  - Service deployed (e.g. xdn launch bookcatalog --image=... --state=... --deterministic=true).
+  - Run as root, or with passwordless sudo (bpftrace requires CAP_BPF).
+
+This first cut assumes a single service is hosted in the cluster, so the
+cluster-wide (peer_i, peer_j) byte matrix from bpftrace is itself the
+per-service bandwidth map (no attribution needed).
+"""
+
+import argparse
+import csv
+import json
+import os
+import random
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import requests
+
+# Reconfigurator HTTP port = NIO port + 300 (HTTP_PORT_OFFSET in
+# ReconfigurationConfig.java). Used to query the placement endpoint below.
+HTTP_PORT_OFFSET = 300
+
+# Endpoint served by HttpReconfigurator (see
+# src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java) and consumed
+# by `xdn service info` (xdn-cli/cmd/service.go). Returns
+#   {"DATA": {"NODES": [{"ID": "AR1",
+#                        "ADDRESS": "/127.0.0.1:2001",
+#                        "HTTP_ADDRESS": "/127.0.0.1:2301",
+#                        "ROLE": "leader|...|"}, ...]}, ...}
+PLACEMENT_PATH_FMT = "/api/v2/services/{service}/placement"
+
+DEFAULT_BPFTRACE_SCRIPT = Path(__file__).resolve().parent / "inter_replica_bw.bt"
+DEFAULT_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+HEADER_LINE_RE = re.compile(r"^# trace start:")
+# Matches lines like:  @out[14489, 52896, ::ffff:127.0.0.1, 2003]: 71
+MAP_LINE_RE = re.compile(
+    r"^@(out|in)\[\s*"
+    r"(\d+)\s*,\s*"                       # pid
+    r"(\d+)\s*,\s*"                       # local port
+    r"([0-9a-fA-F:.]+)\s*,\s*"            # peer ip
+    r"(\d+)\s*"                           # peer port
+    r"\]:\s*(\d+)\s*$"                    # bytes
+)
+
+# AR JVM cmdlines look like
+#   java ... edu.umass.cs.reconfiguration.ReconfigurableNode AR1
+# We pull the AR id by walking the null-separated cmdline once at startup.
+RECONF_NODE_CLASS = "edu.umass.cs.reconfiguration.ReconfigurableNode"
+
+
+def build_pid_to_ar():
+    """Scan /proc and return {pid: ar_id} for every running AR JVM.
+
+    Used to attribute each bpftrace event to a specific replica via the
+    `pid` builtin, without needing handshake-time hooks (i.e., bpftrace can
+    attach to an already-running cluster).
+    """
+    mapping = {}
+    proc = Path("/proc")
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            cmdline = (entry / "cmdline").read_bytes()
+        except (OSError, PermissionError):
+            continue
+        if not cmdline:
+            continue
+        parts = cmdline.split(b"\0")
+        for i, p in enumerate(parts):
+            if p.decode("utf-8", "replace") == RECONF_NODE_CLASS:
+                if i + 1 < len(parts):
+                    ar_id = parts[i + 1].decode("utf-8", "replace")
+                    if ar_id:
+                        mapping[int(entry.name)] = ar_id
+                break
+    return mapping
+
+
+def parse_properties(path):
+    """Parse a gigapaxos properties file.
+
+    Returns (actives, reconfigurators, geolocations) where:
+      actives        = {name: (host, nio_port)}
+      reconfigurators = {name: (host, port)}
+      geolocations   = {name: (lat, lon)}
+    """
+    actives = {}
+    reconfigurators = {}
+    geolocations = {}
+    with open(path) as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip('"')
+
+            if key.startswith("active.") and key.endswith(".geolocation"):
+                name = key[len("active."):-len(".geolocation")]
+                try:
+                    lat_s, lon_s = value.split(",", 1)
+                    geolocations[name] = (float(lat_s), float(lon_s))
+                except ValueError:
+                    pass
+            elif key.startswith("active."):
+                name = key[len("active."):]
+                if ":" in value:
+                    host, port_s = value.rsplit(":", 1)
+                    try:
+                        actives[name] = (host, int(port_s))
+                    except ValueError:
+                        pass
+            elif key.startswith("reconfigurator."):
+                name = key[len("reconfigurator."):]
+                if ":" in value:
+                    host, port_s = value.rsplit(":", 1)
+                    try:
+                        reconfigurators[name] = (host, int(port_s))
+                    except ValueError:
+                        pass
+    return actives, reconfigurators, geolocations
+
+
+def parse_java_inet_addr(s):
+    """Parse a Java InetSocketAddress.toString() value like '/127.0.0.1:2001'
+    or 'host/127.0.0.1:2001' into (host, port)."""
+    if s is None:
+        return None
+    addr = s.split("/", 1)[-1]  # drop the optional 'hostname/' prefix
+    if ":" not in addr:
+        return None
+    host, _, port_s = addr.rpartition(":")
+    try:
+        return host, int(port_s)
+    except ValueError:
+        return None
+
+
+def fetch_service_placement(rc_host, rc_http_port, service, timeout=5.0):
+    """GET /api/v2/services/<service>/placement on the Reconfigurator.
+
+    Returns a list of nodes preserving server-side order:
+        [{"id": "AR1",
+          "nio_host": "127.0.0.1", "nio_port": 2001,
+          "http_host": "127.0.0.1", "http_port": 2301,
+          "role": "leader" | "" | ...,
+          "geolocation": (lat, lon) | None}, ...]
+    """
+    url = f"http://{rc_host}:{rc_http_port}{PLACEMENT_PATH_FMT.format(service=service)}"
+    try:
+        resp = requests.get(url, timeout=timeout)
+    except requests.RequestException as e:
+        sys.exit(f"error: cannot reach reconfigurator at {url}: {e}")
+    if resp.status_code == 404:
+        sys.exit(f"error: service '{service}' not found on reconfigurator "
+                 f"({url}). Is it deployed?")
+    if resp.status_code != 200:
+        sys.exit(f"error: reconfigurator returned HTTP {resp.status_code} "
+                 f"for {url}: {resp.text[:200]}")
+    try:
+        body = resp.json()
+        raw_nodes = body["DATA"]["NODES"]
+    except (ValueError, KeyError, TypeError) as e:
+        sys.exit(f"error: unexpected placement response shape from {url}: {e}")
+
+    nodes = []
+    for n in raw_nodes:
+        nio = parse_java_inet_addr(n.get("ADDRESS"))
+        http = parse_java_inet_addr(n.get("HTTP_ADDRESS"))
+        if nio is None or http is None:
+            continue
+        geo = n.get("GEOLOCATION")
+        geolocation = None
+        if isinstance(geo, dict):
+            try:
+                geolocation = (float(geo["LATITUDE"]),
+                               float(geo["LONGITUDE"]))
+            except (KeyError, TypeError, ValueError):
+                geolocation = None
+        nodes.append({
+            "id": n.get("ID", ""),
+            "nio_host": nio[0], "nio_port": nio[1],
+            "http_host": http[0], "http_port": http[1],
+            "role": n.get("ROLE", "") or "",
+            "geolocation": geolocation,
+        })
+    if not nodes:
+        sys.exit(f"error: placement for '{service}' contained no usable nodes")
+    return nodes
+
+
+def fetch_replica_info(http_host, http_port, service, timeout=5.0):
+    """GET /api/v2/services/<service>/replica/info on an AR's HTTP
+    frontend. Returns service-wide metadata that the RC's placement
+    endpoint doesn't expose (protocol, consistency model, requested
+    consistency, deterministic flag). The AR HTTP frontend requires the
+    `XDN` header to route the request into the XDN-specific handler.
+
+    Best-effort: warns and returns an empty dict if the AR can't be
+    reached or the response is malformed, so the caller can still write
+    out a meta.json without this field.
+    """
+    url = (f"http://{http_host}:{http_port}"
+           f"/api/v2/services/{service}/replica/info")
+    headers = {"XDN": service}
+    try:
+        r = requests.get(url, headers=headers, timeout=timeout)
+    except requests.RequestException as e:
+        print(f"warning: replica/info fetch from {url} failed: {e}",
+              file=sys.stderr)
+        return {}
+    if r.status_code != 200:
+        print(f"warning: replica/info {url} returned HTTP {r.status_code}",
+              file=sys.stderr)
+        return {}
+    try:
+        body = r.json()
+    except ValueError as e:
+        print(f"warning: replica/info JSON parse failed for {url}: {e}",
+              file=sys.stderr)
+        return {}
+    return {
+        "protocol": body.get("protocol", "") or "",
+        "consistency": body.get("consistency", "") or "",
+        "requested_consistency": body.get("requestedConsistency", "") or "",
+        "deterministic": body.get("deterministic"),
+    }
+
+
+def select_targets(nodes, target_arg):
+    """Pick the set of replicas to drive HTTP traffic at.
+
+    `target_arg` may be `None` (drive every replica in the placement) or a
+    comma-separated allowlist of replica ids (e.g. "AR1,AR3"). All matched
+    nodes are returned in placement order; unknown ids are an error.
+    """
+    if not target_arg:
+        return list(nodes)
+    requested = [t.strip() for t in target_arg.split(",") if t.strip()]
+    by_id = {n["id"]: n for n in nodes}
+    missing = [t for t in requested if t not in by_id]
+    if missing:
+        sys.exit(f"error: --target value(s) {missing} not in placement "
+                 f"({[n['id'] for n in nodes]})")
+    seen = set()
+    out = []
+    for t in requested:
+        if t in seen:
+            continue
+        seen.add(t)
+        out.append(by_id[t])
+    return out
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    # Execution mode. Default is the legacy single-host "everything in one
+    # process" path. The other modes split the work across hosts so each AR
+    # can capture local-kernel events on the host it runs on. See
+    # `trace_bw_distributed.py` for the SSH orchestrator that ties them
+    # together.
+    p.add_argument("--mode",
+                   choices=["local", "probe", "driver", "aggregate"],
+                   default="local",
+                   help="local (default): drive workload AND run bpftrace "
+                        "AND resolve, all on this host. probe: only run "
+                        "bpftrace, write raw CSV + pid_to_ar.json sidecar "
+                        "(no workload, no resolution). driver: only drive "
+                        "the HTTP workload (no bpftrace). aggregate: merge "
+                        "per-host probe CSVs, run resolve_rows on the "
+                        "union, write a final resolved CSV.")
+    p.add_argument("--ar-id",
+                   help="probe mode only: the AR id this probe is capturing "
+                        "for. If omitted, all AR JVMs found in /proc on this "
+                        "host are included; supplying it constrains the "
+                        "pid_to_ar map to one entry, useful when several AR "
+                        "JVMs share a host but you only want one in the trace.")
+    p.add_argument("--inputs",
+                   help="aggregate mode only: comma-separated list of raw "
+                        "probe CSVs (e.g. 'host_a.csv,host_b.csv'). Each "
+                        "CSV must have a sibling '<basename>.pid_to_ar.json' "
+                        "written by probe mode.")
+    p.add_argument("--config", required=True,
+                   help="path to gigapaxos.properties (used to locate the "
+                        "reconfigurator host:port and, in aggregate mode, "
+                        "the host:port of each AR for peer_ip resolution).")
+    p.add_argument("--service", required=True,
+                   help="XDN service name (sent in the XDN: header).")
+    p.add_argument("--target",
+                   help="comma-separated allowlist of replica ids (e.g. "
+                        "'AR1,AR3') to drive traffic at. Each id must be in "
+                        "the placement. Default: drive every replica hosting "
+                        "the service, in parallel.")
+    p.add_argument("--reconfigurator",
+                   help="reconfigurator HTTP endpoint as host[:port] "
+                        "(default: derive host from the first reconfigurator "
+                        "in --config, port = NIO port + 300).")
+    # Read spec (--path / --method preserved as the "read request"). Defaults
+    # target a specific bookcatalog item so the response payload is the same
+    # constant book row on every read.
+    p.add_argument("--path", default="/api/books/1",
+                   help="HTTP path used for READ requests. Defaults to a "
+                        "specific book id so the response payload is "
+                        "constant. Override for non-bookcatalog services.")
+    p.add_argument("--method", default="GET",
+                   help="HTTP method for READ requests. Default: GET.")
+    # Read/write mix.
+    p.add_argument("--read-ratio", type=float, default=0.8,
+                   help="Fraction of requests that are reads (vs. writes). "
+                        "Default: 0.8 (80%% read / 20%% write). "
+                        "Use 1.0 for read-only, 0.0 for write-only.")
+    # Write spec.
+    p.add_argument("--write-path", default="/api/books/1",
+                   help="HTTP path used for WRITE requests. Default targets "
+                        "the same book id as --path, so writes mutate the "
+                        "row that reads observe.")
+    p.add_argument("--write-method", default="PUT",
+                   help="HTTP method for WRITE requests. Default: PUT.")
+    p.add_argument("--write-body",
+                   default='{"title":"trace_bw","author":"benchmark"}',
+                   help="Request body for WRITE requests (sent as bytes).")
+    p.add_argument("--write-content-type", default="application/json",
+                   help="Content-Type header for WRITE requests. "
+                        "Default: application/json.")
+    # Seeding the target book so reads/writes find it.
+    p.add_argument("--seed-path", default="/api/books",
+                   help="HTTP path used to create the target item if it does "
+                        "not exist before traffic starts. Default: "
+                        "/api/books (bookcatalog).")
+    p.add_argument("--seed-body",
+                   default='{"id":1,"title":"trace_bw","author":"benchmark"}',
+                   help="Request body posted to --seed-path during the "
+                        "seeding step.")
+    p.add_argument("--no-seed", action="store_true",
+                   help="Skip the seeding step. Use this when the target "
+                        "item is already present, or when the service has "
+                        "no create endpoint at --seed-path.")
+    p.add_argument("--rate", type=float, default=20.0,
+                   help="Per-replica HTTP request rate (req/s). Each replica "
+                        "is driven by its own client thread at this rate, so "
+                        "the total offered load is rate * len(targets). "
+                        "Default: 20.")
+    p.add_argument("--duration", type=float, default=60.0,
+                   help="Total trace duration in seconds. Default: 60")
+    p.add_argument("--interval", type=int, default=5,
+                   help="bpftrace snapshot interval in seconds. Default: 5")
+    p.add_argument("--warmup", type=float, default=2.0,
+                   help="Seconds between bpftrace start and HTTP traffic start. "
+                        "Default: 2")
+    p.add_argument("--output",
+                   help="CSV output path. Default: "
+                        "xdn-bw-trace/results/<service>-<unix-ts>.csv")
+    p.add_argument("--bpftrace-script", default=str(DEFAULT_BPFTRACE_SCRIPT),
+                   help="path to .bt script. Default: sibling inter_replica_bw.bt")
+    p.add_argument("--timeout", type=float, default=5.0,
+                   help="Per-request HTTP timeout in seconds. Default: 5")
+    return p.parse_args()
+
+
+class BpftraceReader(threading.Thread):
+    """Tail bpftrace stdout; parse SNAP / @out / @in / END frames into rows.
+
+    Frame model (one snapshot block emitted every interval, plus one on END):
+        SNAP
+        @out[<pid>, <local_port>, <peer_ip>, <peer_port>]: <bytes>
+        @in[<pid>, <local_port>, <peer_ip>, <peer_port>]: <bytes>
+        END
+
+    Each row's interval is [previous_snap_wall, current_snap_wall]. For the
+    very first snapshot we synthesize a start by subtracting `interval`.
+    """
+
+    def __init__(self, proc, on_header, interval_seconds):
+        super().__init__(daemon=True)
+        self.proc = proc
+        self.on_header = on_header
+        self.interval_seconds = interval_seconds
+        self.rows = []
+        self.lock = threading.Lock()
+        self.error = None
+        self._headed = False
+        self._prev_snap_wall = None
+        self._cur_snap_wall = None
+
+    def run(self):
+        try:
+            assert self.proc.stdout is not None
+            for line in self.proc.stdout:
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+                if HEADER_LINE_RE.match(line):
+                    if not self._headed:
+                        self._headed = True
+                        self.on_header()
+                    continue
+                if line.startswith("SNAP"):
+                    now = time.time()
+                    self._prev_snap_wall = self._cur_snap_wall
+                    self._cur_snap_wall = now
+                    continue
+                if line == "END":
+                    continue
+                m = MAP_LINE_RE.match(line)
+                if not m:
+                    # bpftrace also emits "Attaching N probes..." etc on stderr,
+                    # but tolerate any uninteresting stdout chatter here too.
+                    continue
+                direction = m.group(1)
+                pid = int(m.group(2))
+                local_port = int(m.group(3))
+                ip = m.group(4)
+                peer_port = int(m.group(5))
+                nbytes = int(m.group(6))
+
+                if self._cur_snap_wall is None:
+                    # Map output before any SNAP is unexpected; skip it.
+                    continue
+                end_ts = self._cur_snap_wall
+                if self._prev_snap_wall is not None:
+                    start_ts = self._prev_snap_wall
+                else:
+                    start_ts = end_ts - self.interval_seconds
+
+                with self.lock:
+                    self.rows.append({
+                        "interval_start_unix": int(start_ts),
+                        "interval_end_unix": int(end_ts),
+                        "direction": direction,
+                        "local_pid": pid,
+                        "local_port": local_port,
+                        "peer_ip": ip,
+                        "peer_port": peer_port,
+                        "bytes": nbytes,
+                    })
+        except Exception as e:
+            self.error = e
+
+    def snapshot_rows(self):
+        with self.lock:
+            return list(self.rows)
+
+
+CLIENT_PREFIX = "client"
+
+
+def _client_label(ar_id):
+    """Per-replica client vertex label (e.g. 'client-AR1'). Falls back to a
+    bare 'client' if the serving AR can't be determined."""
+    return f"{CLIENT_PREFIX}-{ar_id}" if ar_id else CLIENT_PREFIX
+
+
+def _strip_v4mapped(ip):
+    """Strip the IPv4-in-IPv6 prefix (`::ffff:`) that bpftrace emits for
+    AF_INET6 sockets with v4 addresses."""
+    if ip and ip.startswith("::ffff:"):
+        return ip[len("::ffff:"):]
+    return ip
+
+
+def resolve_rows(rows, pid_to_ar, nio_port_to_ar, http_port_to_ar,
+                  endpoint_to_ar=None):
+    """Annotate each event with `local_id` and `peer_id`.
+
+    Two flow categories are handled:
+      - Inter-replica (NIO): keyed off NIO listener ports. Cross-correlation
+        on ephemeral ports recovers the (i, j) pair on loopback.
+      - Client<->replica (HTTP): keyed off AR HTTP frontend listener ports.
+        The non-AR side is labeled as `client-<AR>` (one client vertex per
+        replica) so the resulting graph keeps each AR's request/response
+        traffic on its own pair of edges instead of collapsing every external
+        client into a single hub vertex.
+
+    `endpoint_to_ar` (optional) maps `(host, port)` → AR id for every
+    replica's NIO and HTTP listener. Keyed jointly so it stays injective in
+    every deployment shape (pure-distributed shared-port, loopback distinct-
+    port, mixed co-located). Resolution prefers this map; the legacy
+    port-only maps remain as a backstop for older callers that don't supply
+    it.
+
+    Resolution rules per row (in order; first match wins):
+      local_id =
+        pid_to_ar[pid]                                if pid is a known AR JVM
+        else nio_port_to_ar[local_port]               if local is a NIO listener
+        else http_port_to_ar[local_port]              if local is an HTTP listener
+        else ephemeral_owner[local_port]              if local is an AR ephemeral
+        else "client-<peer_ar>"                       if peer is an HTTP listener
+        else "unknown"
+      peer_id =
+        endpoint_to_ar[(peer_ip, peer_port)]          if peer is a known listener endpoint
+        else nio_port_to_ar[peer_port]                if peer is a NIO listener
+        else http_port_to_ar[peer_port]               if peer is an HTTP listener
+        else ephemeral_owner[peer_port]               if peer is an AR ephemeral
+        else "client-<local_ar>"                      if local is an HTTP listener
+        else "unknown"
+    """
+    endpoint_to_ar = endpoint_to_ar or {}
+    nio_listener_ports = set(nio_port_to_ar.keys())
+    http_listener_ports = set(http_port_to_ar.keys())
+    listener_ports = nio_listener_ports | http_listener_ports
+
+    def _ar_at_endpoint(ip, port):
+        """Resolve an (ip, port) listener endpoint to an AR id. Looks up the
+        joint key — returns None for ephemeral peers and for non-cluster IPs
+        (driver / external clients)."""
+        if not endpoint_to_ar:
+            return None
+        return endpoint_to_ar.get((_strip_v4mapped(ip), port))
+
+    # Pass 1: ephemeral_port -> ar_id (only when the local pid is known and
+    # the local port is *not* a well-known listener port).
+    ephemeral_owner = {}
+    for r in rows:
+        local = pid_to_ar.get(r["local_pid"])
+        if not local:
+            continue
+        lp = r["local_port"]
+        if lp in listener_ports:
+            continue
+        # Last writer wins on ephemeral reuse — vanishingly rare in short
+        # traces, and the alternative (silently dropping) is worse.
+        ephemeral_owner[lp] = local
+
+    # Pass 2: annotate.
+    for r in rows:
+        lp = r["local_port"]
+        pp = r["peer_port"]
+        local = pid_to_ar.get(r["local_pid"])
+        if not local:
+            local = (nio_port_to_ar.get(lp)
+                     or http_port_to_ar.get(lp)
+                     or ephemeral_owner.get(lp))
+        if not local and pp in http_listener_ports:
+            # Peer is the HTTP server; we are an external client of that AR.
+            # Prefer (peer_ip, peer_port) over port-only to disambiguate when
+            # every AR shares the same HTTP listener port across hosts.
+            peer_ar = (_ar_at_endpoint(r["peer_ip"], pp)
+                       or http_port_to_ar.get(pp))
+            local = _client_label(peer_ar)
+        r["local_id"] = local or "unknown"
+
+        peer = _ar_at_endpoint(r["peer_ip"], pp)
+        if not peer:
+            peer = (nio_port_to_ar.get(pp)
+                    or http_port_to_ar.get(pp)
+                    or ephemeral_owner.get(pp))
+        if not peer and lp in http_listener_ports:
+            # Local is the HTTP server; the peer is an external client of
+            # *this* AR. Use the already-resolved local_id so each AR's
+            # client-side vertex stays distinct.
+            peer = _client_label(local)
+        r["peer_id"] = peer or "unknown"
+    return rows
+
+
+def http_loop(base_url, headers, rate, duration, read_spec, write_spec,
+              read_ratio, timeout, rng=None):
+    """Drive a mixed read/write workload at `rate` req/s for `duration` s.
+
+    `base_url`     — http://host:port (no path).
+    `read_spec`    — {"method": ..., "path": ...}
+    `write_spec`   — {"method": ..., "path": ..., "body": str|None,
+                       "content_type": str|None}
+    `read_ratio`   — probability that each request is a read.
+
+    Returns a dict {sent, ok, failed, reads, writes}.
+    Pattern adapted from eval/geo_demand_smoke.py:125,139,145-148,167-170 —
+    rate-limited via sleep against a wall-clock schedule.
+    """
+    if rng is None:
+        rng = random.Random()
+    period = 1.0 / rate if rate > 0 else 0.0
+    sent = ok = failed = reads = writes = 0
+    write_body_bytes = (write_spec["body"].encode("utf-8")
+                        if write_spec.get("body") is not None else None)
+    write_extra_headers = dict(headers)
+    if write_spec.get("content_type"):
+        write_extra_headers["Content-Type"] = write_spec["content_type"]
+    session = requests.Session()
+    start = time.monotonic()
+    deadline = start + duration
+    i = 0
+    try:
+        while time.monotonic() < deadline:
+            is_read = rng.random() < read_ratio
+            if is_read:
+                spec = read_spec
+                req_headers = headers
+                req_body = None
+                reads += 1
+            else:
+                spec = write_spec
+                req_headers = write_extra_headers
+                req_body = write_body_bytes
+                writes += 1
+            url = base_url + spec["path"]
+            try:
+                resp = session.request(spec["method"], url,
+                                       headers=req_headers, data=req_body,
+                                       timeout=timeout)
+                sent += 1
+                if 200 <= resp.status_code < 500:
+                    ok += 1
+                else:
+                    failed += 1
+            except requests.RequestException:
+                sent += 1
+                failed += 1
+            i += 1
+            if period > 0:
+                target = start + i * period
+                sleep_for = target - time.monotonic()
+                if sleep_for > 0:
+                    time.sleep(sleep_for)
+    finally:
+        # Close pooled keep-alive sockets cleanly (FIN, not RST). Without
+        # this, abrupt teardown when the thread's deadline fires shows up
+        # on the AR side as "HttpActiveReplicaHandler Error: Connection
+        # reset" (HttpActiveReplica.java:1218).
+        session.close()
+    return {"sent": sent, "ok": ok, "failed": failed,
+            "reads": reads, "writes": writes}
+
+
+def seed_target_item(base_url, headers, args):
+    """Best-effort: ensure --path is reachable on the cluster before traffic
+    starts, by POSTing --seed-body to --seed-path if --path returns 404.
+
+    Replication is linearizable for bookcatalog so a single POST to any
+    replica is enough. Failures are logged and tolerated; we don't abort on
+    seeding errors because some workloads don't need it.
+    """
+    if args.no_seed:
+        return
+    probe_url = base_url + args.path
+    try:
+        r = requests.get(probe_url, headers=headers, timeout=args.timeout)
+    except requests.RequestException as e:
+        print(f"seed: probe {probe_url} failed: {e}; "
+              f"attempting POST anyway", file=sys.stderr)
+        r = None
+    if r is not None and 200 <= r.status_code < 300:
+        print(f"seed: target {args.path} already exists "
+              f"(HTTP {r.status_code} from {probe_url})", file=sys.stderr)
+        return
+
+    seed_url = base_url + args.seed_path
+    seed_headers = dict(headers)
+    if args.write_content_type:
+        seed_headers["Content-Type"] = args.write_content_type
+    try:
+        r = requests.post(seed_url,
+                          data=args.seed_body.encode("utf-8"),
+                          headers=seed_headers,
+                          timeout=args.timeout)
+    except requests.RequestException as e:
+        print(f"seed: warning, POST {seed_url} failed: {e}. "
+              f"Continuing anyway — pass --no-seed to silence this.",
+              file=sys.stderr)
+        return
+    if 200 <= r.status_code < 300:
+        print(f"seed: created target via POST {seed_url} "
+              f"(HTTP {r.status_code})", file=sys.stderr)
+    else:
+        print(f"seed: warning, POST {seed_url} returned HTTP "
+              f"{r.status_code}: {r.text[:200]}", file=sys.stderr)
+
+
+def _resolve_rc_endpoint(args):
+    """Return (rc_host, rc_http_port). Honors --reconfigurator if set,
+    otherwise derives from the first reconfigurator entry in --config."""
+    _actives, reconfigurators, _geolocations = parse_properties(args.config)
+    if args.reconfigurator:
+        endpoint = args.reconfigurator
+        if ":" in endpoint:
+            host, _, port_s = endpoint.rpartition(":")
+            try:
+                return host, int(port_s)
+            except ValueError:
+                sys.exit(f"error: invalid --reconfigurator '{endpoint}'")
+        return endpoint, 3000 + HTTP_PORT_OFFSET
+    if not reconfigurators:
+        sys.exit(f"error: no reconfigurator.<name>=host:port entries in "
+                 f"{args.config}; pass --reconfigurator host[:port]")
+    rc_name = sorted(reconfigurators.keys())[0]
+    rc_host, rc_nio_port = reconfigurators[rc_name]
+    return rc_host, rc_nio_port + HTTP_PORT_OFFSET
+
+
+def _build_port_maps(nodes):
+    """Compute the bpftrace port range + listener-endpoint → AR-id maps from
+    a placement node list. Shared by every mode that touches bpftrace output.
+
+    `endpoint_to_ar` is keyed on `(host, port)` so it remains injective in
+    every deployment shape: pure-distributed (each AR on its own host with a
+    shared port number), loopback (every AR on 127.0.0.1 with distinct
+    ports), and mixed (some hosts run multiple ARs on different ports).
+    Port-only or host-only maps collapse in two of those three cases; the
+    joint key collapses in none."""
+    nio_ports = sorted({n["nio_port"] for n in nodes})
+    http_ports = sorted({n["http_port"] for n in nodes})
+    endpoint_to_ar = {}
+    for n in nodes:
+        endpoint_to_ar[(n["nio_host"], n["nio_port"])] = n["id"]
+        endpoint_to_ar[(n["http_host"], n["http_port"])] = n["id"]
+    return {
+        "nio_low": min(nio_ports),
+        "nio_high": max(nio_ports),
+        "http_low": min(http_ports),
+        "http_high": max(http_ports),
+        "nio_port_to_ar": {n["nio_port"]: n["id"] for n in nodes},
+        "http_port_to_ar": {n["http_port"]: n["id"] for n in nodes},
+        "endpoint_to_ar": endpoint_to_ar,
+    }
+
+
+def _resolve_output_path(args):
+    """Default output path. Mirrors the rule used by local mode."""
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        return out_path
+    DEFAULT_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    return DEFAULT_RESULTS_DIR / f"{args.service}-{int(time.time())}.csv"
+
+
+def _launch_bpftrace(args, port_maps):
+    """Launch bpftrace, return (proc, reader, header_event). Common to local
+    and probe modes."""
+    script_path = str(Path(args.bpftrace_script).resolve())
+    bpf_cmd = [
+        "bpftrace", script_path,
+        str(port_maps["nio_low"]), str(port_maps["nio_high"]),
+        str(port_maps["http_low"]), str(port_maps["http_high"]),
+        str(args.interval),
+    ]
+    if os.geteuid() != 0:
+        bpf_cmd = ["sudo"] + bpf_cmd
+    print(f"launching: {' '.join(bpf_cmd)}", file=sys.stderr)
+    proc = subprocess.Popen(
+        bpf_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    header_event = threading.Event()
+    reader = BpftraceReader(
+        proc, on_header=header_event.set, interval_seconds=args.interval,
+    )
+    reader.start()
+    if not header_event.wait(timeout=15.0):
+        try:
+            stderr_data = proc.stderr.read() if proc.stderr else ""
+        except Exception:
+            stderr_data = ""
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        sys.exit("error: bpftrace did not emit '# trace start:' within 15s.\n"
+                 f"stderr:\n{stderr_data}")
+    return proc, reader
+
+
+def _stop_bpftrace(proc, reader, args):
+    """Send SIGINT, drain reader, return rows. Mirrors the local-mode
+    teardown sequence so probe mode behaves identically on the wire."""
+    final_wait = max(args.interval + 1, 2)
+    print(f"waiting {final_wait}s for final bpftrace snapshot ...",
+          file=sys.stderr)
+    time.sleep(final_wait)
+    print("stopping bpftrace ...", file=sys.stderr)
+    try:
+        proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    reader.join(timeout=5)
+    if reader.error:
+        print(f"warning: reader thread error: {reader.error}", file=sys.stderr)
+    return reader.snapshot_rows()
+
+
+# CSV column order used by local mode and aggregate mode (resolved output).
+RESOLVED_FIELDNAMES = [
+    "interval_start_unix", "interval_end_unix", "direction",
+    "local_id", "local_pid", "local_port",
+    "peer_id", "peer_ip", "peer_port",
+    "bytes",
+]
+# Probe mode emits the same columns but with local_id/peer_id left blank;
+# the aggregator fills them in from the union of pid_to_ar maps.
+RAW_FIELDNAMES = RESOLVED_FIELDNAMES
+
+
+def _write_rows(out_path, rows, fieldnames):
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({k: r.get(k, "") for k in fieldnames})
+
+
+# ---------------------------------------------------------------------------
+# probe mode: bpftrace only, no workload, no resolution. Writes raw CSV +
+# pid_to_ar.json sidecar so the aggregator can reconstruct the full picture.
+# ---------------------------------------------------------------------------
+
+def _run_probe(args):
+    rc_host, rc_http_port = _resolve_rc_endpoint(args)
+    print(f"reconfigurator: http://{rc_host}:{rc_http_port}", file=sys.stderr)
+    nodes = fetch_service_placement(rc_host, rc_http_port, args.service)
+    port_maps = _build_port_maps(nodes)
+    print(f"placement ({len(nodes)} replicas), bpftrace: "
+          f"nio=[{port_maps['nio_low']},{port_maps['nio_high']}] "
+          f"http=[{port_maps['http_low']},{port_maps['http_high']}] "
+          f"interval={args.interval}s duration={args.duration}s",
+          file=sys.stderr)
+
+    pid_to_ar = build_pid_to_ar()
+    placement_ids = {n["id"] for n in nodes}
+    if args.ar_id:
+        if args.ar_id not in placement_ids:
+            sys.exit(f"error: --ar-id '{args.ar_id}' not in placement "
+                     f"{sorted(placement_ids)}")
+        # Constrain the map to a single AR — useful when multiple AR JVMs
+        # share a host but only one is in scope for this probe run.
+        pid_to_ar = {pid: ar for pid, ar in pid_to_ar.items()
+                     if ar == args.ar_id}
+        if not pid_to_ar:
+            print(f"warning: no JVM with cmdline 'ReconfigurableNode "
+                  f"{args.ar_id}' found in /proc on this host", file=sys.stderr)
+    else:
+        pid_to_ar = {pid: ar for pid, ar in pid_to_ar.items()
+                     if ar in placement_ids}
+        if not pid_to_ar:
+            print("warning: no AR JVMs from this placement found in /proc on "
+                  "this host; aggregate mode will fall back to port-based "
+                  "resolution for events captured here", file=sys.stderr)
+
+    if pid_to_ar:
+        pid_str = ", ".join(f"{ar}=pid {pid}"
+                            for pid, ar in sorted(pid_to_ar.items(),
+                                                  key=lambda kv: kv[1]))
+        print(f"local AR pids: {pid_str}", file=sys.stderr)
+
+    out_path = _resolve_output_path(args)
+    pidmap_path = out_path.with_name(out_path.stem + ".pid_to_ar.json")
+
+    proc, reader = _launch_bpftrace(args, port_maps)
+
+    # Run for the full duration window. Unlike local mode, there's no
+    # in-process workload here — the orchestrator (or a separate driver
+    # invocation) drives traffic during this window.
+    print(f"probe running for {args.duration}s ...", file=sys.stderr)
+    time.sleep(args.duration)
+
+    rows = _stop_bpftrace(proc, reader, args)
+    _write_rows(out_path, rows, RAW_FIELDNAMES)
+    print(f"wrote {len(rows)} raw rows -> {out_path}", file=sys.stderr)
+
+    with open(pidmap_path, "w") as f:
+        json.dump({str(pid): ar for pid, ar in pid_to_ar.items()}, f, indent=2)
+    print(f"wrote pid_to_ar -> {pidmap_path}", file=sys.stderr)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# driver mode: only drive HTTP traffic. No bpftrace, no CSV. Writes a
+# meta.json with workload totals so the aggregator can stitch it in.
+# ---------------------------------------------------------------------------
+
+def _run_driver(args):
+    rc_host, rc_http_port = _resolve_rc_endpoint(args)
+    print(f"reconfigurator: http://{rc_host}:{rc_http_port}", file=sys.stderr)
+    nodes = fetch_service_placement(rc_host, rc_http_port, args.service)
+    targets = select_targets(nodes, args.target)
+
+    targets_str = ", ".join(
+        f"{n['id']}->http://{n['http_host']}:{n['http_port']}{args.path}"
+        for n in targets
+    )
+    print(f"targets ({len(targets)}, driven in parallel @ {args.rate} req/s "
+          f"each): {targets_str}", file=sys.stderr)
+
+    service_info = fetch_replica_info(
+        targets[0]["http_host"], targets[0]["http_port"], args.service,
+        timeout=args.timeout,
+    )
+    if service_info.get("protocol") or service_info.get("consistency"):
+        print(f"service info: protocol={service_info.get('protocol', '?')} "
+              f"consistency={service_info.get('consistency', '?')}",
+              file=sys.stderr)
+
+    if not 0.0 <= args.read_ratio <= 1.0:
+        sys.exit(f"error: --read-ratio must be in [0,1] (got {args.read_ratio})")
+
+    headers = {"XDN": args.service}
+    read_spec = {"method": args.method, "path": args.path}
+    write_spec = {"method": args.write_method, "path": args.write_path,
+                  "body": args.write_body,
+                  "content_type": args.write_content_type}
+
+    seed_base = (f"http://{targets[0]['http_host']}:"
+                 f"{targets[0]['http_port']}")
+    seed_target_item(seed_base, headers, args)
+
+    if args.warmup > 0:
+        time.sleep(args.warmup)
+
+    write_ratio = 1.0 - args.read_ratio
+    print(f"driving traffic in parallel: {len(targets)} replicas @ "
+          f"{args.rate} req/s each (total ~{args.rate * len(targets):g} req/s) "
+          f"for {args.duration}s, mix=read {args.read_ratio:.0%} "
+          f"({args.method} {args.path}) / write {write_ratio:.0%} "
+          f"({args.write_method} {args.write_path}) ...", file=sys.stderr)
+
+    results, errors, elapsed = _drive_workload_threads(
+        targets, headers, args, read_spec, write_spec,
+    )
+    total_sent = sum(r["sent"] for r in results.values())
+    total_ok = sum(r["ok"] for r in results.values())
+    total_failed = sum(r["failed"] for r in results.values())
+    total_reads = sum(r["reads"] for r in results.values())
+    total_writes = sum(r["writes"] for r in results.values())
+    per_replica = ", ".join(
+        f"{nid}: sent={results[nid]['sent']} ok={results[nid]['ok']} "
+        f"failed={results[nid]['failed']} "
+        f"r/w={results[nid]['reads']}/{results[nid]['writes']}"
+        for nid in (n["id"] for n in targets)
+    )
+    print(f"traffic done: sent={total_sent} ok={total_ok} "
+          f"failed={total_failed} reads={total_reads} writes={total_writes} "
+          f"elapsed={elapsed:.1f}s | per-replica: {per_replica}",
+          file=sys.stderr)
+    for nid, e in errors.items():
+        print(f"warning: client thread for {nid} crashed: {e}",
+              file=sys.stderr)
+
+    out_path = _resolve_output_path(args)
+    meta_path = out_path.with_name(out_path.stem + ".meta.json")
+    meta = _build_meta(args, service_info, nodes, targets, results,
+                       total_sent, total_ok, total_failed,
+                       total_reads, total_writes, elapsed)
+    try:
+        with open(meta_path, "w") as f:
+            json.dump(meta, f, indent=2)
+        print(f"wrote metadata -> {meta_path}", file=sys.stderr)
+    except OSError as e:
+        print(f"warning: could not write {meta_path}: {e}", file=sys.stderr)
+    return 0
+
+
+def _drive_workload_threads(targets, headers, args, read_spec, write_spec):
+    """One client thread per target replica. Returns (results, errors,
+    elapsed). Factored out so local + driver modes share the workload code."""
+    results = {}
+    errors = {}
+    threads = []
+    base_seed = int(time.time() * 1e6)
+
+    def worker(node, seed):
+        base = f"http://{node['http_host']}:{node['http_port']}"
+        try:
+            results[node["id"]] = http_loop(
+                base, headers, args.rate, args.duration,
+                read_spec, write_spec, args.read_ratio, args.timeout,
+                rng=random.Random(seed),
+            )
+        except Exception as e:
+            errors[node["id"]] = e
+            results[node["id"]] = {"sent": 0, "ok": 0, "failed": 0,
+                                   "reads": 0, "writes": 0}
+
+    t0 = time.monotonic()
+    for idx, n in enumerate(targets):
+        th = threading.Thread(target=worker, args=(n, base_seed + idx),
+                              daemon=True, name=f"client-{n['id']}")
+        th.start()
+        threads.append(th)
+    for th in threads:
+        th.join()
+    elapsed = time.monotonic() - t0
+    return results, errors, elapsed
+
+
+def _build_meta(args, service_info, nodes, targets, results,
+                 total_sent, total_ok, total_failed,
+                 total_reads, total_writes, elapsed):
+    return {
+        "service": args.service,
+        "service_info": service_info,
+        "rate_per_replica_rps": args.rate,
+        "duration_seconds": args.duration,
+        "interval_seconds": args.interval,
+        "warmup_seconds": args.warmup,
+        "num_targets": len(targets),
+        "target_ids": [n["id"] for n in targets],
+        "placement_ids": [n["id"] for n in nodes],
+        "read_ratio": args.read_ratio,
+        "read": {"method": args.method, "path": args.path},
+        "write": {"method": args.write_method, "path": args.write_path,
+                  "content_type": args.write_content_type},
+        "totals": {
+            "sent": total_sent, "ok": total_ok, "failed": total_failed,
+            "reads": total_reads, "writes": total_writes,
+            "elapsed_seconds": elapsed,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# aggregate mode: take N raw probe CSVs (each from a different host's
+# bpftrace), union their events, fold their pid_to_ar maps, and run
+# resolve_rows on the merged stream. Outputs a single resolved CSV.
+# ---------------------------------------------------------------------------
+
+def _run_aggregate(args):
+    if not args.inputs:
+        sys.exit("error: --inputs is required for aggregate mode "
+                 "(comma-separated list of probe CSVs)")
+    input_paths = [Path(p.strip()) for p in args.inputs.split(",") if p.strip()]
+    if not input_paths:
+        sys.exit("error: --inputs is empty")
+
+    rc_host, rc_http_port = _resolve_rc_endpoint(args)
+    print(f"reconfigurator: http://{rc_host}:{rc_http_port}", file=sys.stderr)
+    nodes = fetch_service_placement(rc_host, rc_http_port, args.service)
+    port_maps = _build_port_maps(nodes)
+
+    rows = []
+    pid_to_ar = {}
+    for csv_path in input_paths:
+        if not csv_path.exists():
+            sys.exit(f"error: input csv not found: {csv_path}")
+        pidmap_path = csv_path.with_name(csv_path.stem + ".pid_to_ar.json")
+        if pidmap_path.exists():
+            try:
+                with open(pidmap_path) as f:
+                    for pid_str, ar in json.load(f).items():
+                        pid_to_ar[int(pid_str)] = ar
+            except Exception as e:
+                print(f"warning: could not parse {pidmap_path}: {e}",
+                      file=sys.stderr)
+        else:
+            print(f"warning: missing sidecar {pidmap_path} — pid-based "
+                  f"resolution may be incomplete for events from this csv",
+                  file=sys.stderr)
+        rows_before = len(rows)
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            for r in reader:
+                # Coerce numeric fields to ints (csv loads as str).
+                try:
+                    r["interval_start_unix"] = int(r["interval_start_unix"])
+                    r["interval_end_unix"] = int(r["interval_end_unix"])
+                    r["local_pid"] = int(r["local_pid"])
+                    r["local_port"] = int(r["local_port"])
+                    r["peer_port"] = int(r["peer_port"])
+                    r["bytes"] = int(r["bytes"])
+                except (KeyError, ValueError) as e:
+                    print(f"warning: skipping malformed row in {csv_path}: {e}",
+                          file=sys.stderr)
+                    continue
+                rows.append(r)
+        print(f"loaded {csv_path.name}: {len(rows) - rows_before} rows "
+              f"(running total: {len(rows)})", file=sys.stderr)
+
+    print(f"merged {len(rows)} rows from {len(input_paths)} probe(s); "
+          f"pid_to_ar has {len(pid_to_ar)} entries", file=sys.stderr)
+
+    resolve_rows(rows, pid_to_ar, port_maps["nio_port_to_ar"],
+                  port_maps["http_port_to_ar"],
+                  endpoint_to_ar=port_maps["endpoint_to_ar"])
+    unresolved_local = sum(1 for r in rows if r["local_id"] == "unknown")
+    unresolved_peer = sum(1 for r in rows if r["peer_id"] == "unknown")
+    if unresolved_local or unresolved_peer:
+        print(f"warning: {unresolved_local}/{len(rows)} rows with unresolved "
+              f"local_id, {unresolved_peer}/{len(rows)} with unresolved peer_id",
+              file=sys.stderr)
+
+    out_path = _resolve_output_path(args)
+    _write_rows(out_path, rows, RESOLVED_FIELDNAMES)
+    print(f"wrote {len(rows)} resolved rows -> {out_path}", file=sys.stderr)
+    return 0
+
+
+def main():
+    args = parse_args()
+    if args.mode == "probe":
+        return _run_probe(args)
+    if args.mode == "driver":
+        return _run_driver(args)
+    if args.mode == "aggregate":
+        return _run_aggregate(args)
+    return _run_local(args)
+
+
+def _run_local(args):
+    _actives, reconfigurators, _geolocations = parse_properties(args.config)
+    if args.reconfigurator:
+        rc_endpoint = args.reconfigurator
+        if ":" in rc_endpoint:
+            rc_host, _, rc_port_s = rc_endpoint.rpartition(":")
+            try:
+                rc_http_port = int(rc_port_s)
+            except ValueError:
+                sys.exit(f"error: invalid --reconfigurator '{rc_endpoint}'")
+        else:
+            rc_host = rc_endpoint
+            rc_http_port = 3000 + HTTP_PORT_OFFSET
+    else:
+        if not reconfigurators:
+            sys.exit(f"error: no reconfigurator.<name>=host:port entries in "
+                     f"{args.config}; pass --reconfigurator host[:port]")
+        rc_name = sorted(reconfigurators.keys())[0]
+        rc_host, rc_nio_port = reconfigurators[rc_name]
+        rc_http_port = rc_nio_port + HTTP_PORT_OFFSET
+
+    print(f"reconfigurator: http://{rc_host}:{rc_http_port}", file=sys.stderr)
+    nodes = fetch_service_placement(rc_host, rc_http_port, args.service)
+    targets = select_targets(nodes, args.target)
+
+    nio_ports = sorted({n["nio_port"] for n in nodes})
+    nio_low, nio_high = min(nio_ports), max(nio_ports)
+    http_ports = sorted({n["http_port"] for n in nodes})
+    http_low, http_high = min(http_ports), max(http_ports)
+
+    placement_str = ", ".join(
+        f"{n['id']}@{n['nio_host']}:{n['nio_port']}"
+        + (f" ({n['role']})" if n["role"] else "")
+        for n in nodes
+    )
+    targets_str = ", ".join(
+        f"{n['id']}->http://{n['http_host']}:{n['http_port']}{args.path}"
+        for n in targets
+    )
+    print(f"placement ({len(nodes)} replicas): {placement_str}",
+          file=sys.stderr)
+    print(f"targets ({len(targets)}, driven in parallel @ {args.rate} req/s "
+          f"each): {targets_str}", file=sys.stderr)
+    print(f"bpftrace: nio=[{nio_low},{nio_high}] http=[{http_low},{http_high}] "
+          f"interval={args.interval}s duration={args.duration}s",
+          file=sys.stderr)
+
+    local_port_maps = _build_port_maps(nodes)
+    nio_port_to_ar = local_port_maps["nio_port_to_ar"]
+    http_port_to_ar = local_port_maps["http_port_to_ar"]
+    endpoint_to_ar = local_port_maps["endpoint_to_ar"]
+    pid_to_ar = build_pid_to_ar()
+
+    # Pull service-wide metadata (protocol + consistency model) from one
+    # of the targets. Requires the XDN header; same endpoint that
+    # `xdn service info` queries (xdn-cli/cmd/service.go:884).
+    service_info = fetch_replica_info(
+        targets[0]["http_host"], targets[0]["http_port"], args.service,
+        timeout=args.timeout,
+    )
+    if service_info.get("protocol") or service_info.get("consistency"):
+        print(f"service info: protocol={service_info.get('protocol', '?')} "
+              f"consistency={service_info.get('consistency', '?')}",
+              file=sys.stderr)
+    placement_ids = {n["id"] for n in nodes}
+    local_ar_pids = {pid: ar for pid, ar in pid_to_ar.items()
+                     if ar in placement_ids}
+    if local_ar_pids:
+        pid_str = ", ".join(f"{ar}=pid {pid}"
+                            for pid, ar in sorted(local_ar_pids.items(),
+                                                  key=lambda kv: kv[1]))
+        print(f"local AR pids: {pid_str}", file=sys.stderr)
+    else:
+        print("warning: no AR JVMs for this placement found in /proc; "
+              "local_id will fall back to port-based resolution",
+              file=sys.stderr)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        DEFAULT_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out_path = DEFAULT_RESULTS_DIR / f"{args.service}-{int(time.time())}.csv"
+
+    script_path = str(Path(args.bpftrace_script).resolve())
+    bpf_cmd = ["bpftrace", script_path,
+               str(nio_low), str(nio_high),
+               str(http_low), str(http_high),
+               str(args.interval)]
+    if os.geteuid() != 0:
+        bpf_cmd = ["sudo"] + bpf_cmd
+
+    print(f"launching: {' '.join(bpf_cmd)}", file=sys.stderr)
+    proc = subprocess.Popen(
+        bpf_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    header_event = threading.Event()
+    reader = BpftraceReader(proc, on_header=header_event.set,
+                            interval_seconds=args.interval)
+    reader.start()
+
+    if not header_event.wait(timeout=15.0):
+        try:
+            stderr_data = proc.stderr.read() if proc.stderr else ""
+        except Exception:
+            stderr_data = ""
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        sys.exit("error: bpftrace did not emit '# trace start:' within 15s.\n"
+                 f"stderr:\n{stderr_data}")
+
+    if not 0.0 <= args.read_ratio <= 1.0:
+        sys.exit(f"error: --read-ratio must be in [0,1] (got {args.read_ratio})")
+
+    headers = {"XDN": args.service}
+    read_spec = {"method": args.method, "path": args.path}
+    write_spec = {"method": args.write_method, "path": args.write_path,
+                  "body": args.write_body,
+                  "content_type": args.write_content_type}
+
+    # Seed the target item via the first target's HTTP frontend, before the
+    # warmup window. This way GETs and PUTs against --path see HTTP 200 from
+    # the first request, instead of a flood of 404s while replication
+    # propagates a write that didn't happen yet.
+    seed_base = (f"http://{targets[0]['http_host']}:"
+                 f"{targets[0]['http_port']}")
+    seed_target_item(seed_base, headers, args)
+
+    if args.warmup > 0:
+        time.sleep(args.warmup)
+
+    write_ratio = 1.0 - args.read_ratio
+    print(f"driving traffic in parallel: {len(targets)} replicas @ "
+          f"{args.rate} req/s each (total ~{args.rate * len(targets):g} req/s) "
+          f"for {args.duration}s, mix=read {args.read_ratio:.0%} "
+          f"({args.method} {args.path}) / write {write_ratio:.0%} "
+          f"({args.write_method} {args.write_path}) ...",
+          file=sys.stderr)
+
+    # One client thread per target replica. Threads start back-to-back; the
+    # tiny startup skew (sub-millisecond on a single host) is negligible
+    # against `--duration` and `--warmup`. Each thread gets its own RNG so
+    # the read/write mix is independent across replicas.
+    results = {}
+    errors = {}
+    threads = []
+    base_seed = int(time.time() * 1e6)
+
+    def worker(node, seed):
+        base = f"http://{node['http_host']}:{node['http_port']}"
+        try:
+            results[node["id"]] = http_loop(
+                base, headers, args.rate, args.duration,
+                read_spec, write_spec, args.read_ratio, args.timeout,
+                rng=random.Random(seed),
+            )
+        except Exception as e:
+            errors[node["id"]] = e
+            results[node["id"]] = {"sent": 0, "ok": 0, "failed": 0,
+                                   "reads": 0, "writes": 0}
+
+    t0 = time.monotonic()
+    for idx, n in enumerate(targets):
+        th = threading.Thread(target=worker, args=(n, base_seed + idx),
+                              daemon=True, name=f"client-{n['id']}")
+        th.start()
+        threads.append(th)
+    for th in threads:
+        th.join()
+    elapsed = time.monotonic() - t0
+
+    total_sent = sum(r["sent"] for r in results.values())
+    total_ok = sum(r["ok"] for r in results.values())
+    total_failed = sum(r["failed"] for r in results.values())
+    total_reads = sum(r["reads"] for r in results.values())
+    total_writes = sum(r["writes"] for r in results.values())
+    per_replica = ", ".join(
+        f"{nid}: sent={results[nid]['sent']} ok={results[nid]['ok']} "
+        f"failed={results[nid]['failed']} "
+        f"r/w={results[nid]['reads']}/{results[nid]['writes']}"
+        for nid in (n["id"] for n in targets)
+    )
+    print(f"traffic done: sent={total_sent} ok={total_ok} "
+          f"failed={total_failed} reads={total_reads} writes={total_writes} "
+          f"elapsed={elapsed:.1f}s | per-replica: {per_replica}",
+          file=sys.stderr)
+    for nid, e in errors.items():
+        print(f"warning: client thread for {nid} crashed: {e}",
+              file=sys.stderr)
+
+    # Give bpftrace one more interval tick so the last full window is captured
+    # before we ask it to flush via SIGINT.
+    final_wait = max(args.interval + 1, 2)
+    print(f"waiting {final_wait}s for final bpftrace snapshot ...",
+          file=sys.stderr)
+    time.sleep(final_wait)
+
+    print("stopping bpftrace ...", file=sys.stderr)
+    try:
+        proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    # Allow reader thread to drain any final lines.
+    reader.join(timeout=5)
+
+    rows = reader.snapshot_rows()
+    if reader.error:
+        print(f"warning: reader thread error: {reader.error}", file=sys.stderr)
+
+    resolve_rows(rows, pid_to_ar, nio_port_to_ar, http_port_to_ar,
+                  endpoint_to_ar=endpoint_to_ar)
+
+    unresolved_local = sum(1 for r in rows if r["local_id"] == "unknown")
+    unresolved_peer = sum(1 for r in rows if r["peer_id"] == "unknown")
+    if unresolved_local or unresolved_peer:
+        print(f"warning: {unresolved_local}/{len(rows)} rows with unresolved "
+              f"local_id, {unresolved_peer}/{len(rows)} with unresolved peer_id",
+              file=sys.stderr)
+
+    fieldnames = [
+        "interval_start_unix", "interval_end_unix", "direction",
+        "local_id", "local_pid", "local_port",
+        "peer_id", "peer_ip", "peer_port",
+        "bytes",
+    ]
+    with open(out_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow({k: r.get(k, "") for k in fieldnames})
+    print(f"wrote {len(rows)} rows -> {out_path}", file=sys.stderr)
+
+    # Sidecar metadata so plot_bw_graph.py can render a workload subtitle
+    # without needing CLI flags repeated. Co-located so `--output` users
+    # get the meta in the same directory.
+    meta_path = out_path.with_name(out_path.stem + ".meta.json")
+    meta = {
+        "service": args.service,
+        "service_info": service_info,
+        "rate_per_replica_rps": args.rate,
+        "duration_seconds": args.duration,
+        "interval_seconds": args.interval,
+        "warmup_seconds": args.warmup,
+        "num_targets": len(targets),
+        "target_ids": [n["id"] for n in targets],
+        "placement_ids": [n["id"] for n in nodes],
+        "read_ratio": args.read_ratio,
+        "read": {"method": args.method, "path": args.path},
+        "write": {"method": args.write_method, "path": args.write_path,
+                  "content_type": args.write_content_type},
+        "totals": {
+            "sent": total_sent, "ok": total_ok, "failed": total_failed,
+            "reads": total_reads, "writes": total_writes,
+            "elapsed_seconds": elapsed,
+        },
+    }
+    try:
+        with open(meta_path, "w") as f:
+            json.dump(meta, f, indent=2)
+        print(f"wrote metadata -> {meta_path}", file=sys.stderr)
+    except OSError as e:
+        print(f"warning: could not write {meta_path}: {e}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xdn-bw-trace/trace_bw_distributed.py
+++ b/xdn-bw-trace/trace_bw_distributed.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""trace_bw_distributed.py — orchestrate a multi-host bandwidth trace.
+
+Splits the work across hosts:
+  - One bpftrace probe per AR host, started over SSH. Each probe captures
+    its own kernel's events and writes a raw CSV + pid_to_ar.json sidecar
+    on the remote host.
+  - One driver instance (run locally on the orchestrator) that drives
+    the HTTP workload at every replica.
+  - After both finish, per-host CSVs are SCP'd back and the local
+    aggregator stitches them into a single resolved CSV.
+
+This is the "Option A" architecture sketched in xdn-bw-trace/README.md's
+"Distributed deployment" section. The single-host `trace_bw.py --mode local`
+path is unchanged and still works for loopback testing.
+
+Usage:
+    python3 xdn-bw-trace/trace_bw_distributed.py \\
+        --config conf/gigapaxos.cloudlab.properties \\
+        --service bookcatalog \\
+        --ssh-key ~/.ssh/cloudlab \\
+        --username fadhil \\
+        --duration 60 --interval 5 --rate 50 --read-ratio 0.0
+
+Required:
+  --config        gigapaxos properties file (used for RC discovery and
+                  AR host enumeration on both the orchestrator and remote
+                  side; the orchestrator copies it to each host first).
+  --service       XDN service name.
+  --ssh-key       SSH private key for connecting to AR hosts.
+  --username      remote SSH user.
+
+Optional:
+  --remote-xdn-path   absolute path to the xdn checkout on remote hosts
+                      (default: same as local). Must contain
+                      xdn-bw-trace/trace_bw.py and inter_replica_bw.bt.
+  --hosts             comma-separated allowlist of AR hosts. Default:
+                      every distinct host found in active.* entries of
+                      --config.
+  --output            final aggregated CSV path. Default:
+                      xdn-bw-trace/results/<service>-<ts>.csv
+  --tmpdir            remote tmpdir for per-host CSV outputs. Default:
+                      /tmp/xdn-bw-trace
+  --rate, --duration, --interval, --warmup, --read-ratio, --path,
+  --method, --write-path, --write-method, --write-body,
+  --write-content-type, --seed-path, --seed-body, --no-seed, --timeout
+                      passed through to both the remote probe and the
+                      local driver.
+"""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Reuse trace_bw.py helpers for parsing the gigapaxos config.
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+import trace_bw  # noqa: E402
+
+DEFAULT_REMOTE_TMPDIR = "/tmp/xdn-bw-trace"
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--config", required=True,
+                   help="gigapaxos.properties path (must exist on the "
+                        "orchestrator and at the same path on remote hosts, "
+                        "or pass --remote-config-path).")
+    p.add_argument("--service", required=True)
+    p.add_argument("--ssh-key", required=True,
+                   help="SSH private key used to reach AR hosts.")
+    p.add_argument("--username", required=True,
+                   help="Remote SSH user.")
+    p.add_argument("--remote-xdn-path",
+                   help="Absolute path to the xdn checkout on each remote "
+                        "host. Default: same as local checkout. Must contain "
+                        "xdn-bw-trace/trace_bw.py + inter_replica_bw.bt.")
+    p.add_argument("--remote-config-path",
+                   help="Absolute path to gigapaxos.properties on remote "
+                        "hosts. Default: same as --config.")
+    p.add_argument("--hosts",
+                   help="Comma-separated allowlist of remote AR hosts. "
+                        "Default: every distinct host in active.* entries "
+                        "of --config.")
+    p.add_argument("--output",
+                   help="Aggregated CSV output path. Default: "
+                        "xdn-bw-trace/results/<service>-<unix-ts>.csv")
+    p.add_argument("--tmpdir", default=DEFAULT_REMOTE_TMPDIR,
+                   help=f"Remote tmpdir for per-host outputs. Default: "
+                        f"{DEFAULT_REMOTE_TMPDIR}")
+    p.add_argument("--reconfigurator",
+                   help="RC HTTP endpoint as host[:port] (default: derive "
+                        "from --config).")
+
+    # Workload knobs — passed through to driver and probe.
+    p.add_argument("--rate", type=float, default=20.0)
+    p.add_argument("--duration", type=float, default=60.0)
+    p.add_argument("--interval", type=int, default=5)
+    p.add_argument("--warmup", type=float, default=2.0)
+    p.add_argument("--read-ratio", type=float, default=0.8)
+    p.add_argument("--path", default="/api/books/1")
+    p.add_argument("--method", default="GET")
+    p.add_argument("--write-path", default="/api/books/1")
+    p.add_argument("--write-method", default="PUT")
+    p.add_argument("--write-body",
+                   default='{"title":"trace_bw","author":"benchmark"}')
+    p.add_argument("--write-content-type", default="application/json")
+    p.add_argument("--seed-path", default="/api/books")
+    p.add_argument("--seed-body",
+                   default='{"id":1,"title":"trace_bw","author":"benchmark"}')
+    p.add_argument("--no-seed", action="store_true")
+    p.add_argument("--timeout", type=float, default=5.0)
+    p.add_argument("--target",
+                   help="Comma-separated allowlist of replica ids the driver "
+                        "should drive traffic at. Default: every replica in "
+                        "the placement.")
+
+    # Pre-flight knobs.
+    p.add_argument("--probe-startup-buffer", type=float, default=3.0,
+                   help="Seconds to wait between starting probes and the "
+                        "driver, so kprobes are attached before traffic. "
+                        "Default: 3.")
+    p.add_argument("--keep-remote-files", action="store_true",
+                   help="Skip remote tmpdir cleanup at end (useful for "
+                        "debugging).")
+    return p.parse_args()
+
+
+def discover_ar_hosts(config_path):
+    """Return sorted unique hosts from active.* entries in the properties."""
+    actives, _, _ = trace_bw.parse_properties(config_path)
+    hosts = sorted({host for (host, _port) in actives.values()})
+    if not hosts:
+        sys.exit(f"error: no active.<id>=host:port entries in {config_path}")
+    return hosts
+
+
+def ssh_cmd(ssh_key, username, host, remote_cmd, capture=False):
+    """Return a subprocess.Popen for `ssh`. Auto-StrictHostKeyChecking=no
+    + BatchMode=yes for unattended runs (no password prompts)."""
+    args = [
+        "ssh",
+        "-i", ssh_key,
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=10",
+        f"{username}@{host}",
+        remote_cmd,
+    ]
+    if capture:
+        return subprocess.Popen(args, stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE, text=True)
+    return subprocess.Popen(args, text=True)
+
+
+def scp_pull(ssh_key, username, host, remote_path, local_path):
+    """Run `scp host:remote_path local_path`. Blocks until done; returns
+    (returncode, stderr)."""
+    cmd = [
+        "scp",
+        "-i", ssh_key,
+        "-o", "StrictHostKeyChecking=no",
+        "-o", "UserKnownHostsFile=/dev/null",
+        "-o", "BatchMode=yes",
+        "-o", "ConnectTimeout=10",
+        f"{username}@{host}:{remote_path}",
+        str(local_path),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    return proc.returncode, proc.stderr
+
+
+def quote_remote(s):
+    """Shell-quote a string for embedding in a remote ssh command."""
+    return shlex.quote(s)
+
+
+def _build_probe_cmd(args, remote_xdn_path, remote_config_path, remote_csv,
+                       host_idx):
+    """Construct the bash command run on each remote host: cd to the xdn
+    checkout, run trace_bw.py in probe mode under sudo (bpftrace needs root)."""
+    # Compose the probe args. We don't pass --ar-id because each host's
+    # trace_bw probe will scan /proc and pick up exactly the AR JVM(s) that
+    # belong to this placement; the sidecar pid_to_ar.json captures who's
+    # who. (In practice each AR host has exactly one AR JVM.)
+    probe_args = [
+        "python3", f"{remote_xdn_path}/xdn-bw-trace/trace_bw.py",
+        "--mode", "probe",
+        "--config", remote_config_path,
+        "--service", args.service,
+        "--duration", str(args.duration + args.warmup + args.probe_startup_buffer),
+        "--interval", str(args.interval),
+        "--output", remote_csv,
+    ]
+    if args.reconfigurator:
+        probe_args += ["--reconfigurator", args.reconfigurator]
+    # Note: probes don't drive traffic, so workload args (rate, paths, etc.)
+    # are not needed here. Probes only need port-range info derived from
+    # the placement, which they fetch from the RC themselves.
+    cmd = (
+        f"mkdir -p {quote_remote(args.tmpdir)} && "
+        f"cd {quote_remote(remote_xdn_path)} && "
+        f"sudo -n " + " ".join(quote_remote(a) for a in probe_args)
+    )
+    return cmd
+
+
+def _build_driver_cmd(args, local_xdn_path, local_config_path, driver_csv):
+    """Local driver: trace_bw.py --mode driver. Pass through workload knobs."""
+    driver_args = [
+        "python3", str(Path(local_xdn_path) / "xdn-bw-trace" / "trace_bw.py"),
+        "--mode", "driver",
+        "--config", str(local_config_path),
+        "--service", args.service,
+        "--rate", str(args.rate),
+        "--duration", str(args.duration),
+        "--interval", str(args.interval),
+        "--warmup", str(args.warmup),
+        "--read-ratio", str(args.read_ratio),
+        "--path", args.path, "--method", args.method,
+        "--write-path", args.write_path, "--write-method", args.write_method,
+        "--write-body", args.write_body,
+        "--write-content-type", args.write_content_type,
+        "--seed-path", args.seed_path, "--seed-body", args.seed_body,
+        "--timeout", str(args.timeout),
+        "--output", str(driver_csv),
+    ]
+    if args.no_seed:
+        driver_args.append("--no-seed")
+    if args.target:
+        driver_args += ["--target", args.target]
+    if args.reconfigurator:
+        driver_args += ["--reconfigurator", args.reconfigurator]
+    return driver_args
+
+
+def main():
+    args = parse_args()
+
+    local_xdn_path = SCRIPT_DIR.parent  # repo root
+    remote_xdn_path = args.remote_xdn_path or str(local_xdn_path)
+    local_config_path = Path(args.config).resolve()
+    remote_config_path = args.remote_config_path or str(local_config_path)
+
+    # Discover hosts.
+    if args.hosts:
+        hosts = [h.strip() for h in args.hosts.split(",") if h.strip()]
+    else:
+        hosts = discover_ar_hosts(args.config)
+    if not hosts:
+        sys.exit("error: no remote AR hosts to probe")
+    print(f"orchestrator: probing {len(hosts)} hosts: {', '.join(hosts)}",
+          file=sys.stderr)
+    print(f"  remote xdn path: {remote_xdn_path}", file=sys.stderr)
+    print(f"  remote config:   {remote_config_path}", file=sys.stderr)
+    print(f"  remote tmpdir:   {args.tmpdir}", file=sys.stderr)
+
+    ts = int(time.time())
+    final_out = Path(args.output) if args.output else (
+        SCRIPT_DIR / "results" / f"{args.service}-{ts}.csv"
+    )
+    final_out.parent.mkdir(parents=True, exist_ok=True)
+
+    # Per-host probe outputs (named by host so SCP back doesn't collide).
+    remote_csvs = {h: f"{args.tmpdir}/{args.service}-{ts}-{_safe(h)}.csv"
+                   for h in hosts}
+
+    # Phase 1: launch probes on every remote host (in parallel).
+    print(f"\n=== launching {len(hosts)} remote probes ===", file=sys.stderr)
+    probe_procs = {}
+    for h in hosts:
+        cmd = _build_probe_cmd(args, remote_xdn_path, remote_config_path,
+                                remote_csvs[h], host_idx=hosts.index(h))
+        print(f"[{h}] ssh: {cmd}", file=sys.stderr)
+        probe_procs[h] = ssh_cmd(args.ssh_key, args.username, h, cmd,
+                                  capture=True)
+
+    # Wait for probes to attach kprobes before driving traffic.
+    print(f"\n=== sleeping {args.probe_startup_buffer}s for kprobe attach ===",
+          file=sys.stderr)
+    time.sleep(args.probe_startup_buffer)
+
+    # Phase 2: drive workload locally.
+    driver_csv = final_out.with_name(final_out.stem + ".driver.csv")
+    print(f"\n=== driving workload locally ({args.duration}s) ===",
+          file=sys.stderr)
+    driver_proc = subprocess.run(
+        _build_driver_cmd(args, local_xdn_path, local_config_path, driver_csv),
+        text=True,
+    )
+    if driver_proc.returncode != 0:
+        print(f"warning: driver exited with code {driver_proc.returncode}",
+              file=sys.stderr)
+
+    # Phase 3: wait for all probes to finish.
+    print(f"\n=== waiting for {len(hosts)} probes to finish ===",
+          file=sys.stderr)
+    for h, proc in probe_procs.items():
+        try:
+            stdout, stderr = proc.communicate(timeout=args.duration + 60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            print(f"[{h}] timed out, killed", file=sys.stderr)
+        if proc.returncode != 0:
+            print(f"[{h}] probe exited rc={proc.returncode}", file=sys.stderr)
+            if stderr:
+                print(f"[{h}] stderr (last 500B):\n  "
+                      + (stderr[-500:].replace("\n", "\n  ")), file=sys.stderr)
+        else:
+            print(f"[{h}] probe ok", file=sys.stderr)
+
+    # Phase 4: pull per-host CSVs + sidecars back.
+    print(f"\n=== fetching per-host CSVs back ===", file=sys.stderr)
+    local_csvs = []
+    for h in hosts:
+        for suffix in (".csv", ".pid_to_ar.json"):
+            remote = remote_csvs[h].replace(".csv", suffix)
+            local = final_out.parent / f"{args.service}-{ts}-{_safe(h)}{suffix}"
+            rc, stderr = scp_pull(args.ssh_key, args.username, h,
+                                   remote, local)
+            if rc != 0:
+                print(f"[{h}] scp {suffix} FAILED: {stderr.strip()}",
+                      file=sys.stderr)
+            else:
+                print(f"[{h}] pulled {local}", file=sys.stderr)
+                if suffix == ".csv":
+                    local_csvs.append(local)
+
+    if not local_csvs:
+        sys.exit("error: no per-host CSVs were retrieved; cannot aggregate")
+
+    # Phase 5: aggregate.
+    print(f"\n=== aggregating {len(local_csvs)} per-host CSVs ===",
+          file=sys.stderr)
+    agg_args = [
+        "python3", str(SCRIPT_DIR / "trace_bw.py"),
+        "--mode", "aggregate",
+        "--config", str(local_config_path),
+        "--service", args.service,
+        "--inputs", ",".join(str(p) for p in local_csvs),
+        "--output", str(final_out),
+    ]
+    if args.reconfigurator:
+        agg_args += ["--reconfigurator", args.reconfigurator]
+    rc = subprocess.run(agg_args, text=True).returncode
+    if rc != 0:
+        sys.exit(f"error: aggregator exited with rc={rc}")
+
+    print(f"\n=== distributed trace complete ===", file=sys.stderr)
+    print(f"final csv: {final_out}", file=sys.stderr)
+    if driver_csv.exists() or driver_csv.with_name(driver_csv.stem + ".meta.json").exists():
+        print(f"driver meta: {driver_csv.with_name(driver_csv.stem + '.meta.json')}",
+              file=sys.stderr)
+
+    # Phase 6: optional remote cleanup.
+    if not args.keep_remote_files:
+        print(f"\n=== cleaning up remote tmp files ===", file=sys.stderr)
+        for h in hosts:
+            cleanup = (
+                f"rm -f {quote_remote(remote_csvs[h])} "
+                f"{quote_remote(remote_csvs[h].replace('.csv', '.pid_to_ar.json'))}"
+            )
+            ssh_cmd(args.ssh_key, args.username, h, cleanup).wait()
+    else:
+        print(f"\n=== --keep-remote-files: leaving remote tmp files alone ===",
+              file=sys.stderr)
+    return 0
+
+
+def _safe(s):
+    """Convert a hostname to a filename-safe form."""
+    return re.sub(r"[^A-Za-z0-9._-]", "_", s)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xdn-bw-trace/trace_bw_todo_app.py
+++ b/xdn-bw-trace/trace_bw_todo_app.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""trace_bw_todo_app.py — trace_bw.py with todo-app defaults preset.
+
+Wraps trace_bw.py with read/write/seed flags appropriate for the
+`fadhilkurnia/xdn-todo` (services/todo-rs) and `fadhilkurnia/xdn-todo-go`
+(services/todo-go) services. The read targets a specific item so the
+response payload size stays constant per request — same approach as
+trace_bw.py's bookcatalog defaults.
+
+Pre-set defaults (override any on the command line as usual):
+
+    --path                /api/todo/tasks/trace_bw
+    --method              GET
+    --write-path          /api/todo/tasks
+    --write-method        POST
+    --write-body          {"item":"trace_bw"}
+    --write-content-type  application/json
+    --seed-path           /api/todo/tasks
+    --seed-body           {"item":"trace_bw"}
+
+The seeding step probes GET /api/todo/tasks/trace_bw on the first
+target. If it returns 404 (item not yet present), the driver POSTs the
+seed body to /api/todo/tasks, which creates the task with counter=1.
+Subsequent GETs on /api/todo/tasks/trace_bw then return 200 with a
+constant-sized JSON body.
+
+Usage:
+    sudo python3 xdn-bw-trace/trace_bw_todo_app.py \\
+        --config conf/gigapaxos.xdn.local.properties \\
+        --service todo-eventual \\
+        --duration 30 --interval 5 --rate 20
+
+All other trace_bw.py flags (--rate, --duration, --interval, --read-ratio,
+--target, --reconfigurator, --warmup, --output, --bpftrace-script,
+--timeout, --no-seed) work unchanged.
+"""
+
+import sys
+
+import trace_bw
+
+# Defaults to inject if the caller did not already pass these flags.
+TODO_DEFAULTS = [
+    ("--path", "/api/todo/tasks/trace_bw"),
+    ("--method", "GET"),
+    ("--write-path", "/api/todo/tasks"),
+    ("--write-method", "POST"),
+    ("--write-body", '{"item":"trace_bw"}'),
+    ("--write-content-type", "application/json"),
+    ("--seed-path", "/api/todo/tasks"),
+    ("--seed-body", '{"item":"trace_bw"}'),
+]
+
+
+def _has_flag(argv, flag):
+    """True if argv already contains `flag` as `--flag value` or `--flag=value`."""
+    eq_form = flag + "="
+    for arg in argv:
+        if arg == flag or arg.startswith(eq_form):
+            return True
+    return False
+
+
+def main():
+    for flag, value in TODO_DEFAULTS:
+        if not _has_flag(sys.argv, flag):
+            sys.argv.extend([flag, value])
+    return trace_bw.main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xdn-cli/examples/todo-causal.yaml
+++ b/xdn-cli/examples/todo-causal.yaml
@@ -1,0 +1,21 @@
+---
+name: "todo-causal"
+image: "fadhilkurnia/xdn-todo"
+state: /app/data/
+port: 80
+consistency: causal
+deterministic: true
+num_replicas: 5
+environments:
+  - ENABLE_WAL: "true"
+
+requests:
+  - path_prefix: "/"
+    methods: "GET,OPTIONS,HEAD"
+    behavior: read_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: write_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: monotonic

--- a/xdn-cli/examples/todo-eventual.yaml
+++ b/xdn-cli/examples/todo-eventual.yaml
@@ -1,0 +1,21 @@
+---
+name: "todo-eventual"
+image: "fadhilkurnia/xdn-todo"
+state: /app/data/
+port: 80
+consistency: eventual
+deterministic: true
+num_replicas: 5
+environments:
+  - ENABLE_WAL: "true"
+
+requests:
+  - path_prefix: "/"
+    methods: "GET,OPTIONS,HEAD"
+    behavior: read_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: write_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: monotonic

--- a/xdn-cli/examples/todo-linearizability.yaml
+++ b/xdn-cli/examples/todo-linearizability.yaml
@@ -1,0 +1,21 @@
+---
+name: "todo-linearizability"
+image: "fadhilkurnia/xdn-todo"
+state: /app/data/
+port: 80
+consistency: linearizability
+deterministic: true
+num_replicas: 5
+environments:
+  - ENABLE_WAL: "true"
+
+requests:
+  - path_prefix: "/"
+    methods: "GET,OPTIONS,HEAD"
+    behavior: read_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: write_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: monotonic

--- a/xdn-cli/examples/todo-pram.yaml
+++ b/xdn-cli/examples/todo-pram.yaml
@@ -1,0 +1,21 @@
+---
+name: "todo-pram"
+image: "fadhilkurnia/xdn-todo"
+state: /app/data/
+port: 80
+consistency: pram
+deterministic: true
+num_replicas: 5
+environments:
+  - ENABLE_WAL: "true"
+
+requests:
+  - path_prefix: "/"
+    methods: "GET,OPTIONS,HEAD"
+    behavior: read_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: write_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: monotonic

--- a/xdn-cli/examples/todo-sequential.yaml
+++ b/xdn-cli/examples/todo-sequential.yaml
@@ -1,0 +1,18 @@
+---
+name: "todo-sequential"
+image: "fadhilkurnia/xdn-todo"
+state: /app/data/
+port: 80
+consistency: sequential
+deterministic: true
+num_replicas: 5
+environments:
+  - ENABLE_WAL: "true"
+
+requests:
+  - path_prefix: "/"
+    methods: "GET,OPTIONS,HEAD"
+    behavior: read_only
+  - path_prefix: "/"
+    methods: "POST,DELETE"
+    behavior: write_only


### PR DESCRIPTION
## Summary

Adds `xdn-bw-trace/`, a bpftrace-based toolkit for measuring inter-replica and
client⇄replica TCP bandwidth (and latency) across XDN consistency protocols,
plus the supporting wire-format fix, CI changes, and eval configs needed to drive it.

This is a cleaned-up, squashed re-homing of the `worktree-bw-trace` work onto current
`main`. The geolocation/geo-demand commits that branch carried (PRs #36/#38/#39) are
already merged, so they are intentionally absent here.

## Commits

1. **strip execution response from default request wire form** — `XdnHttpRequest/Batch.toBytes()`
   now defaults to `toBytes(false)`, omitting the locally-computed `httpResponse` from the wire.
   Inter-replica write-after forwarding (causal/pram/lazy) and paxos propose no longer ship a
   stale sender response, so the per-coordinator `clearHttpResponse()` guards are removed and
   `XdnGigapaxosApp`'s response-must-be-null assertion holds on re-execution. Only PB's
   primary→entry `ResponsePacket` path opts in via `toBytes(true)`. Also quiets
   `AwReplicaCoordinator` instrumentation (`System.err` → `FINE`).
2. **add xdn-bw-trace** — bpftrace probes (`inter_replica_bw.bt`) aggregating TCP bytes per
   `(pid, local_port, peer)`, topology-aware workload drivers (`trace_bw.py`,
   `trace_bw_distributed.py`), and plotting scripts for directed-bandwidth and
   Haversine/fiber-speed latency graphs. Documented in `CLAUDE.md`.
3. **ci: build host binaries from source** — `build_xdn_cli.sh` and `build_xdn_fuselog.sh` now
   compile their host binaries and install the `/usr/local/bin` symlinks themselves; CI builds
   via these scripts (adding Go, Rust, and `libzstd-dev` setup) rather than symlinking gitignored
   prebuilt binaries.
4. **add multi-protocol eval configs and todo example services** — 5-way and numeric-id cluster
   configs, a debug logging profile, a 5th local AR (AR4), and per-consistency-model `todo`
   service descriptors.

## Testing

- `ant jar` — builds clean.
- CI (Docker/FUSE matrix) will exercise the reworked build/CI flow on this PR.

## Notes

Linux only for the tracer itself (requires `bpftrace` ≥ 0.21 and `CAP_BPF`).