### PR TITLE
Add AWS terraform infrastructure and AMI builders

### DIFF
--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -1,0 +1,15 @@
+# Terraform state (may contain secrets; never commit)
+*.tfstate
+*.tfstate.*
+.terraform/
+*.tfvars
+*.tfvars.json
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Note: .terraform.lock.hcl and last-built-amis.txt ARE committed on purpose
+# (provider version pinning; AMI build history).

--- a/aws/.terraform.lock.hcl
+++ b/aws/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,52 @@
+# XDN on AWS
+
+Terraform infrastructure and AMI builders for deploying XDN to EC2.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `main.tf` | VPC (dual-stack), subnets, security group, EC2 instances, RC Elastic IP, Route53 delegation of `xdnapp.com` to coredns |
+| `create_rc_ami.sh` | Build an AMI for the Reconfigurator (RC) + coredns nameserver |
+| `create_ar_ami.sh` | Build an AMI for the ActiveReplica (AR) edge node |
+| `ami_common.sh` | Shared AWS plumbing sourced by the two builders (not run directly) |
+
+## Prerequisites
+
+- AWS CLI configured (`aws sts get-caller-identity` works), region `us-east-1`
+- An EC2 key pair `xdn-aws-key` with the private key at `~/.ssh/xdn-aws-key`
+- Terraform `>= 1.x` with the AWS provider
+
+## Build AMIs
+
+Each script launches a temporary builder, compiles XDN, snapshots an AMI, then
+terminates the builder. The new AMI id is printed and appended to
+`last-built-amis.txt`.
+
+```bash
+./create_rc_ami.sh
+./create_ar_ami.sh
+```
+
+Common overrides (see `ami_common.sh` for all): `AWS_REGION`, `REPO_BRANCH`,
+`BUILDER_INSTANCE_TYPE`, `BUILDER_VOLUME_SIZE`, `SUBNET_ID`.
+
+The AMIs are config-free: systemd units (`xdn-rc`, `xdn-dns`, `xdn-ar`) stay
+inert until launch-time `user_data` writes `/opt/xdn/conf/gigapaxos.properties`
+(and `node-id` / `Corefile`).
+
+## Deploy infrastructure
+
+Plug the AMI ids into `main.tf`, then:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Notes
+
+- Terraform state is git-ignored; do not commit `*.tfstate` (may contain secrets).
+- The RC needs a stable IP (`aws_eip.rc`) because it serves DNS for `xdnapp.com`.
+- Builders default to a 30 GB root volume; the base AMI's ~8 GB is too small.

--- a/aws/ami_common.sh
+++ b/aws/ami_common.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# ami_common.sh - shared AWS plumbing for the XDN AMI builders.
+#
+# This file is sourced by create_rc_ami.sh and create_ar_ami.sh. It owns the
+# generic "launch a builder, provision it, snapshot an AMI, terminate" flow.
+# Each role-specific entrypoint sets a few variables and defines
+# emit_provision_script() (the bash to run on the builder), then calls
+# run_ami_build.
+#
+# Nothing here is XDN-role-specific except the shared provisioning emitter
+# (emit_common_provision), which both roles reuse.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configurable knobs (override via environment before running the entrypoint).
+# ---------------------------------------------------------------------------
+AWS_REGION="${AWS_REGION:-us-east-1}"
+BASE_AMI="${BASE_AMI:-}"                       # empty -> resolve latest Ubuntu 24.04 amd64
+BUILDER_INSTANCE_TYPE="${BUILDER_INSTANCE_TYPE:-t3.large}"
+BUILDER_VOLUME_SIZE="${BUILDER_VOLUME_SIZE:-30}"   # GB, gp3 (8GB default is too small)
+KEY_NAME="${KEY_NAME:-xdn-aws-key}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/xdn-aws-key}"
+SUBNET_ID="${SUBNET_ID:-}"                     # empty -> first public subnet in default VPC
+REPO_URL="${REPO_URL:-https://github.com/fadhilkurnia/xdn.git}"
+REPO_BRANCH="${REPO_BRANCH:-main}"
+GO_VERSION="${GO_VERSION:-1.23.2}"             # satisfies coredns (go.mod) AND xdn-cli
+SSH_USER="${SSH_USER:-ubuntu}"
+
+# State populated during the run (used by teardown).
+BUILDER_ID=""
+BUILDER_SG_ID=""
+BUILDER_IP=""
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*" >&2; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[err]\033[0m %s\n' "$*" >&2; exit 1; }
+
+aws_ec2() { aws ec2 --region "$AWS_REGION" "$@"; }
+
+# ---------------------------------------------------------------------------
+# preflight - verify local tooling and credentials.
+# ---------------------------------------------------------------------------
+preflight() {
+  log "Preflight checks"
+  for bin in aws ssh; do
+    command -v "$bin" >/dev/null 2>&1 || die "'$bin' not found in PATH"
+  done
+  aws sts get-caller-identity >/dev/null 2>&1 \
+    || die "AWS credentials not configured (aws sts get-caller-identity failed)"
+  [[ -f "$SSH_KEY_PATH" ]] || die "SSH private key not found: $SSH_KEY_PATH"
+  aws_ec2 describe-key-pairs --key-names "$KEY_NAME" >/dev/null 2>&1 \
+    || die "EC2 key pair '$KEY_NAME' not found in $AWS_REGION"
+}
+
+# ---------------------------------------------------------------------------
+# resolve_base_ami - latest Ubuntu 24.04 amd64 via Canonical's public SSM param.
+# ---------------------------------------------------------------------------
+resolve_base_ami() {
+  if [[ -n "$BASE_AMI" ]]; then
+    log "Using provided base AMI: $BASE_AMI"
+    return
+  fi
+  log "Resolving latest Ubuntu 24.04 amd64 AMI via SSM"
+  BASE_AMI=$(aws ssm get-parameter --region "$AWS_REGION" \
+    --name /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id \
+    --query 'Parameter.Value' --output text)
+  [[ "$BASE_AMI" == ami-* ]] || die "Failed to resolve base AMI (got: '$BASE_AMI')"
+  log "Base AMI: $BASE_AMI"
+}
+
+# ---------------------------------------------------------------------------
+# resolve_subnet - pick a public subnet in the default VPC if none was given.
+# ---------------------------------------------------------------------------
+resolve_subnet() {
+  if [[ -n "$SUBNET_ID" ]]; then
+    log "Using provided subnet: $SUBNET_ID"
+    return
+  fi
+  log "Resolving a public subnet in the default VPC"
+  local vpc_id
+  vpc_id=$(aws_ec2 describe-vpcs --filters Name=isDefault,Values=true \
+    --query 'Vpcs[0].VpcId' --output text)
+  [[ "$vpc_id" == vpc-* ]] || die "No default VPC found; set SUBNET_ID explicitly"
+  SUBNET_ID=$(aws_ec2 describe-subnets \
+    --filters "Name=vpc-id,Values=$vpc_id" "Name=map-public-ip-on-launch,Values=true" \
+    --query 'Subnets[0].SubnetId' --output text)
+  [[ "$SUBNET_ID" == subnet-* ]] \
+    || die "No public subnet in default VPC; set SUBNET_ID explicitly"
+  VPC_ID="$vpc_id"
+  log "Subnet: $SUBNET_ID (vpc $VPC_ID)"
+}
+
+# ---------------------------------------------------------------------------
+# create_builder_sg - temp SG allowing SSH only from this machine's public IP.
+# ---------------------------------------------------------------------------
+create_builder_sg() {
+  log "Creating temporary security group for the builder"
+  local my_ip vpc_arg
+  my_ip=$(curl -s --max-time 10 https://checkip.amazonaws.com || true)
+  [[ -n "$my_ip" ]] || die "Could not determine this machine's public IP for SSH ingress"
+  # Place the SG in the same VPC as the subnet.
+  local vpc_id="${VPC_ID:-}"
+  if [[ -z "$vpc_id" ]]; then
+    vpc_id=$(aws_ec2 describe-subnets --subnet-ids "$SUBNET_ID" \
+      --query 'Subnets[0].VpcId' --output text)
+  fi
+  vpc_arg=(--vpc-id "$vpc_id")
+  BUILDER_SG_ID=$(aws_ec2 create-security-group \
+    --group-name "xdn-ami-builder-${ROLE}-$$" \
+    --description "Temporary SG for XDN ${ROLE} AMI builder" \
+    "${vpc_arg[@]}" --query 'GroupId' --output text)
+  aws_ec2 authorize-security-group-ingress --group-id "$BUILDER_SG_ID" \
+    --protocol tcp --port 22 --cidr "${my_ip}/32" >/dev/null
+  log "Security group: $BUILDER_SG_ID (SSH from ${my_ip}/32)"
+}
+
+# ---------------------------------------------------------------------------
+# launch_builder - run a builder instance with an enlarged gp3 root volume.
+# ---------------------------------------------------------------------------
+launch_builder() {
+  log "Launching builder ($BUILDER_INSTANCE_TYPE, ${BUILDER_VOLUME_SIZE}GB gp3)"
+  local bdm
+  bdm="[{\"DeviceName\":\"/dev/sda1\",\"Ebs\":{\"VolumeSize\":${BUILDER_VOLUME_SIZE},\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]"
+  BUILDER_ID=$(aws_ec2 run-instances \
+    --image-id "$BASE_AMI" \
+    --instance-type "$BUILDER_INSTANCE_TYPE" \
+    --key-name "$KEY_NAME" \
+    --security-group-ids "$BUILDER_SG_ID" \
+    --subnet-id "$SUBNET_ID" \
+    --associate-public-ip-address \
+    --block-device-mappings "$bdm" \
+    --tag-specifications \
+      "ResourceType=instance,Tags=[{Key=Name,Value=xdn-ami-builder-${ROLE}}]" \
+    --query 'Instances[0].InstanceId' --output text)
+  [[ "$BUILDER_ID" == i-* ]] || die "Failed to launch builder instance"
+  log "Builder instance: $BUILDER_ID"
+}
+
+# ---------------------------------------------------------------------------
+# wait_ssh - wait for running state, then for SSH to actually answer.
+# ---------------------------------------------------------------------------
+wait_ssh() {
+  log "Waiting for instance to enter running state"
+  aws_ec2 wait instance-running --instance-ids "$BUILDER_ID"
+  BUILDER_IP=$(aws_ec2 describe-instances --instance-ids "$BUILDER_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+  [[ -n "$BUILDER_IP" && "$BUILDER_IP" != "None" ]] || die "Builder has no public IP"
+  log "Builder public IP: $BUILDER_IP"
+  log "Waiting for SSH to respond"
+  for _ in $(seq 1 60); do
+    if ssh -i "$SSH_KEY_PATH" -o BatchMode=yes -o ConnectTimeout=5 \
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        "${SSH_USER}@${BUILDER_IP}" true 2>/dev/null; then
+      log "SSH is up"
+      return
+    fi
+    sleep 5
+  done
+  die "SSH did not come up within ~5 minutes"
+}
+
+# ssh_remote <cmd...> - run an interactive-ish command on the builder.
+ssh_remote() {
+  ssh -i "$SSH_KEY_PATH" -o BatchMode=yes -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null "${SSH_USER}@${BUILDER_IP}" "$@"
+}
+
+# run_remote_script - pipe the composed provisioning script to the builder and
+# execute it with strict bash. Streams remote output to this terminal.
+run_remote_script() {
+  log "Provisioning the builder (this takes several minutes)"
+  emit_provision_script | ssh_remote "cat > /tmp/provision.sh && bash /tmp/provision.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Shared provisioning emitters (printed locally, executed on the builder).
+# GO_VERSION/REPO_URL/REPO_BRANCH are interpolated here so the remote script
+# carries literal values; \$HOME etc. stay literal for remote expansion.
+# ---------------------------------------------------------------------------
+emit_header() {
+  cat <<EOF
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export PATH="\$HOME/.cargo/bin:/usr/local/go/bin:\$PATH"
+echo ">> provisioning XDN ${ROLE} builder"
+EOF
+}
+
+emit_common_provision() {
+  cat <<EOF
+# --- base dependencies (Java + Ant + Git) ---
+sudo apt-get update
+sudo apt-get install -y openjdk-21-jdk ant git rsync wget curl
+
+# --- Go ${GO_VERSION} (NOT 1.22.4 from bin/xdnd; coredns needs 1.23+) ---
+wget -q "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
+rm -f "go${GO_VERSION}.linux-amd64.tar.gz"
+
+# --- clone source and build the jars ---
+rm -rf "\$HOME/xdn"
+git clone --depth 1 --branch "${REPO_BRANCH}" "${REPO_URL}" "\$HOME/xdn"
+cd "\$HOME/xdn" && ./bin/build_xdn_jar.sh
+
+# --- staging layout shared by both roles ---
+sudo mkdir -p /opt/xdn/jars /opt/xdn/conf /opt/xdn/bin /opt/xdn/geo
+sudo cp "\$HOME"/xdn/jars/*.jar /opt/xdn/jars/
+sudo cp "\$HOME"/xdn/conf/keyStore.jks "\$HOME"/xdn/conf/trustStore.jks \\
+        "\$HOME"/xdn/conf/logging.properties "\$HOME"/xdn/conf/log4j.properties \\
+        /opt/xdn/conf/
+EOF
+}
+
+# emit_prestage_helper - reboot-safe /tmp staging (geo DB + state dirs).
+emit_prestage_helper() {
+  cat <<'EOF'
+# --- boot helper: recreate volatile /tmp dirs and stage the geo DB ---
+sudo tee /opt/xdn/bin/xdn-prestage.sh >/dev/null <<'PRESTAGE'
+#!/usr/bin/env bash
+set -e
+mkdir -p /tmp/geo /tmp/gigapaxos /tmp/xdn
+if [ -f /opt/xdn/geo/geolocation_city_data.mmdb ] \
+   && [ ! -f /tmp/geo/geolocation_city_data.mmdb ]; then
+  cp /opt/xdn/geo/geolocation_city_data.mmdb /tmp/geo/
+fi
+PRESTAGE
+sudo chmod +x /opt/xdn/bin/xdn-prestage.sh
+EOF
+}
+
+# emit_finalize <unit-names> - reload + enable units (kept inert by
+# ConditionPathExists until launch-time config arrives).
+emit_finalize() {
+  local units="$1"
+  cat <<EOF
+sudo systemctl daemon-reload
+sudo systemctl enable ${units}
+echo ">> provisioning complete for ${ROLE}"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# common_cleanup - shrink + de-identify the image before snapshotting.
+# ---------------------------------------------------------------------------
+common_cleanup() {
+  log "Cleaning up the builder before imaging"
+  ssh_remote 'bash -s' <<'EOF'
+set -e
+# stop anything we may have started; ignore if not present
+sudo systemctl stop xdn-rc xdn-dns xdn-ar 2>/dev/null || true
+# drop the source clone and build caches
+rm -rf "$HOME/xdn" "$HOME/go" "$HOME/.cargo" "$HOME/.rustup" 2>/dev/null || true
+go clean -cache -modcache 2>/dev/null || true
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/* /tmp/provision.sh
+sudo find /var/log -type f -exec truncate -s0 {} + 2>/dev/null || true
+# fresh identity for every instance launched from this AMI
+sudo truncate -s0 /etc/machine-id
+sudo rm -f /var/lib/dbus/machine-id
+sudo rm -f /etc/ssh/ssh_host_*
+sudo rm -f "$HOME/.bash_history"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# bake_image - stop the builder, create the AMI, wait for availability.
+# ---------------------------------------------------------------------------
+bake_image() {
+  local ami_name="$1"
+  common_cleanup
+  log "Stopping builder before snapshot"
+  aws_ec2 stop-instances --instance-ids "$BUILDER_ID" >/dev/null
+  aws_ec2 wait instance-stopped --instance-ids "$BUILDER_ID"
+  log "Creating AMI: $ami_name"
+  AMI_ID=$(aws_ec2 create-image --instance-id "$BUILDER_ID" \
+    --name "$ami_name" \
+    --description "XDN ${ROLE} node ($REPO_BRANCH)" \
+    --query 'ImageId' --output text)
+  [[ "$AMI_ID" == ami-* ]] || die "create-image failed"
+  log "Waiting for AMI $AMI_ID to become available"
+  aws_ec2 wait image-available --image-ids "$AMI_ID"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s\t%s\t%s\n' "$ami_name" "$AMI_ID" "$AWS_REGION" \
+    >> "$script_dir/last-built-amis.txt"
+  log "AMI ready: $AMI_ID"
+}
+
+# ---------------------------------------------------------------------------
+# teardown - terminate builder + delete temp SG. Idempotent; wired to traps.
+# ---------------------------------------------------------------------------
+teardown() {
+  local rc=$?
+  trap - EXIT ERR INT TERM
+  if [[ -n "$BUILDER_ID" ]]; then
+    log "Terminating builder $BUILDER_ID"
+    aws_ec2 terminate-instances --instance-ids "$BUILDER_ID" >/dev/null 2>&1 || true
+    aws_ec2 wait instance-terminated --instance-ids "$BUILDER_ID" 2>/dev/null || true
+  fi
+  if [[ -n "$BUILDER_SG_ID" ]]; then
+    log "Deleting security group $BUILDER_SG_ID"
+    # brief retry: ENI detachment can lag instance termination
+    for _ in $(seq 1 12); do
+      if aws_ec2 delete-security-group --group-id "$BUILDER_SG_ID" 2>/dev/null; then
+        break
+      fi
+      sleep 5
+    done
+  fi
+  if [[ $rc -ne 0 ]]; then
+    warn "Build failed (exit $rc); cleaned up builder resources."
+  fi
+  exit $rc
+}
+
+# ---------------------------------------------------------------------------
+# run_ami_build - top-level orchestration used by both entrypoints.
+# Requires: ROLE, AMI_NAME_PREFIX set, emit_provision_script() defined.
+# ---------------------------------------------------------------------------
+run_ami_build() {
+  : "${ROLE:?ROLE must be set by the entrypoint}"
+  : "${AMI_NAME_PREFIX:?AMI_NAME_PREFIX must be set by the entrypoint}"
+  local stamp ami_name
+  stamp="$(date -u +%Y%m%d-%H%M%S)"   # captured once; stable for this run
+  ami_name="${AMI_NAME_PREFIX}-${stamp}"
+
+  preflight
+  resolve_base_ami
+  resolve_subnet
+  trap teardown EXIT ERR INT TERM
+  create_builder_sg
+  launch_builder
+  wait_ssh
+  run_remote_script
+  bake_image "$ami_name"
+
+  log "Done. ${ROLE^^} AMI: $AMI_ID  (name: $ami_name, region: $AWS_REGION)"
+  log "Plug this id into aws/main.tf for the ${ROLE^^} instance(s)."
+}

--- a/aws/ar-userdata.tftpl
+++ b/aws/ar-userdata.tftpl
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Launch-time bootstrap for an XDN ActiveReplica (AR) node.
+# Writes the per-deployment config + this node's unique id, then starts the
+# baked, ConditionPathExists-gated xdn-ar unit.
+set -euo pipefail
+
+install -d -m 0755 /opt/xdn/conf
+
+cat > /opt/xdn/conf/gigapaxos.properties <<'PROPS'
+${gigapaxos_properties}
+PROPS
+
+# node id + JVM opts. JAVA_TOOL_OPTIONS forces the IPv4 stack: gigapaxos
+# RequestPacket.toBytes assumes 4-byte (IPv4) addresses, but on this dual-stack
+# VPC the wildcard bind fallback (the public EIP is not bindable) would be IPv6
+# (16 bytes), breaking Paxos packet serialization (AssertionError "N != M").
+# The xdn-ar unit reads this file via EnvironmentFile, so the JVM picks it up.
+cat > /opt/xdn/conf/node-id <<'NODEID'
+NODE_ID=${node_id}
+JAVA_TOOL_OPTIONS=-Djava.net.preferIPv4Stack=true
+NODEID
+
+systemctl daemon-reload
+systemctl start xdn-ar

--- a/aws/create_ar_ami.sh
+++ b/aws/create_ar_ami.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# create_ar_ami.sh - build an AWS AMI for the XDN ActiveReplica (AR) node.
+#
+# The AR role is heavy: Java 21 + gigapaxos jars + the xdn CLI + the FUSE
+# recorders (fuselog/fuserust, C++/Rust) + Docker. The resulting AMI is
+# config-free; per-deployment values (node IPs, unique node id AR0/AR1/...) are
+# injected later via Terraform user_data. The baked systemd unit stays inert
+# until that config lands.
+#
+# Usage:   ./create_ar_ami.sh
+# Tunables: see ami_common.sh (AWS_REGION, BUILDER_INSTANCE_TYPE, REPO_BRANCH, ...).
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=ami_common.sh
+source ./ami_common.sh
+
+ROLE="ar"
+AMI_NAME_PREFIX="${AMI_NAME_PREFIX:-xdn-ar}"
+
+# emit_provision_script - full bash run on the builder for the AR role.
+emit_provision_script() {
+  emit_header
+  emit_common_provision
+
+  # --- AR-specific deps: FUSE/zstd toolchain, Docker CE, Rust ---
+  cat <<'EOF'
+# build toolchain for the FUSE recorders (bin/xdnd:428)
+sudo apt-get install -y build-essential pkg-config libfuse3-dev libzstd-dev
+
+# Docker CE (bin/xdnd:440-452)
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo groupadd -f docker
+
+# Rust toolchain (bin/xdnd:466)
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+export PATH="$HOME/.cargo/bin:/usr/local/go/bin:$PATH"
+
+# --- build and stage AR artifacts ---
+cd "$HOME/xdn"
+./bin/build_xdn_cli.sh
+./bin/build_xdn_fuselog.sh
+
+# the xdn CLI is required
+sudo cp bin/xdn /opt/xdn/bin/
+sudo ln -sf /opt/xdn/bin/xdn /usr/local/bin/xdn
+
+# Stage whichever FUSE recorder binaries this branch actually produced. The
+# 'main' branch ships only the C++ fuselog; 'fadhil-optimized' also ships the
+# Rust fuserust. The default recorder (FUSELOG) needs only the C++ pair.
+for b in fuselog fuselog-apply fuserust fuserust-apply; do
+  if [ -f "bin/$b" ]; then
+    sudo cp "bin/$b" /opt/xdn/bin/
+    sudo ln -sf "/opt/xdn/bin/$b" "/usr/local/bin/$b"
+    echo "  staged $b"
+  else
+    echo "  note: bin/$b not produced by this branch; skipping"
+  fi
+done
+
+# allow non-root mounts to expose files to other users (bin/xdnd:539)
+sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+EOF
+
+  emit_prestage_helper
+  emit_ar_unit
+  emit_finalize "xdn-ar.service"
+}
+
+# emit_ar_unit - install the AR systemd unit. Runs as root for Docker access
+# (matches the `sudo java` invocation in bin/gpServer.sh). Gated on both the
+# config and a node id, since AR ids must be unique per instance (AR0/AR1/...)
+# and are written by launch-time user_data.
+emit_ar_unit() {
+  cat <<'EOF'
+sudo tee /etc/systemd/system/xdn-ar.service >/dev/null <<'UNIT'
+[Unit]
+Description=XDN ActiveReplica (edge server)
+After=network-online.target docker.service
+Wants=network-online.target
+Requires=docker.service
+ConditionPathExists=/opt/xdn/conf/gigapaxos.properties
+ConditionPathExists=/opt/xdn/conf/node-id
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/xdn
+EnvironmentFile=/opt/xdn/conf/node-id
+ExecStartPre=/opt/xdn/bin/xdn-prestage.sh
+ExecStart=/usr/bin/java -ea \
+  -Djavax.net.ssl.keyStore=/opt/xdn/conf/keyStore.jks -Djavax.net.ssl.keyStorePassword=qwerty \
+  -Djavax.net.ssl.trustStore=/opt/xdn/conf/trustStore.jks -Djavax.net.ssl.trustStorePassword=qwerty \
+  -Djava.util.logging.config.file=/opt/xdn/conf/logging.properties \
+  -Dlog4j.configuration=/opt/xdn/conf/log4j.properties \
+  -DgigapaxosConfig=/opt/xdn/conf/gigapaxos.properties \
+  -Djdk.httpclient.allowRestrictedHeaders=connection,content-length,host \
+  -cp /opt/xdn/jars/* \
+  edu.umass.cs.reconfiguration.ReconfigurableNode ${NODE_ID}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+EOF
+}
+
+run_ami_build

--- a/aws/create_rc_ami.sh
+++ b/aws/create_rc_ami.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# create_rc_ami.sh - build an AWS AMI for the XDN Reconfigurator (RC) node,
+# which also hosts the coredns (xdn-dns) nameserver.
+#
+# The RC role is lean: Java 21 + gigapaxos jars + the coredns binary + the geo
+# DB. No Docker, Rust, or FUSE. The resulting AMI is config-free; per-deployment
+# values (node IPs, Corefile with the RC EIP) are injected later via Terraform
+# user_data. Baked systemd units stay inert until that config lands.
+#
+# Usage:   ./create_rc_ami.sh
+# Tunables: see ami_common.sh (AWS_REGION, BUILDER_INSTANCE_TYPE, REPO_BRANCH, ...).
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=ami_common.sh
+source ./ami_common.sh
+
+ROLE="rc"
+AMI_NAME_PREFIX="${AMI_NAME_PREFIX:-xdn-rc}"
+
+# emit_provision_script - full bash run on the builder for the RC role.
+emit_provision_script() {
+  emit_header
+  emit_common_provision
+
+  # --- RC needs the docker CLI (not the daemon): the reconfigurator validates a
+  #     new service's image at CREATE time by shelling out to
+  #     `docker image inspect` / `docker manifest inspect`
+  #     (XdnServiceInitialStateValidator). Without it, every CREATE fails and
+  #     services land with 0 replicas. Quoted heredoc so $(...) stays literal. ---
+  cat <<'EOF'
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce-cli
+EOF
+
+  # --- RC-specific: build coredns and stage the nameserver assets ---
+  cat <<EOF
+# coredns: the upstream Makefile drives the build, so install 'make' (absent on
+# the base AMI). Then write the .go-version the Makefile expects (it is missing
+# in this vendored copy) so GOTOOLCHAIN resolves, and build the static binary.
+sudo apt-get install -y make
+cd "\$HOME/xdn/xdn-dns"
+echo "${GO_VERSION}" > .go-version
+make coredns
+sudo cp "\$HOME/xdn/xdn-dns/coredns" /opt/xdn/coredns
+sudo cp "\$HOME/xdn/xdn-dns/geolocation_city_data.mmdb" /opt/xdn/geo/
+
+# Baked default node id (numeric; the RC is node 0). user_data may overwrite
+# /opt/xdn/conf/node-id at launch.
+echo 'NODE_ID=0' | sudo tee /opt/xdn/conf/node-id >/dev/null
+
+# Free port 53 for coredns: disable systemd-resolved's stub listener and keep
+# local name resolution working via the real resolver.
+sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/' /etc/systemd/resolved.conf
+sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+EOF
+
+  emit_prestage_helper
+  emit_rc_units
+  emit_finalize "xdn-rc.service xdn-dns.service"
+}
+
+# emit_rc_units - install the RC + DNS systemd units. Both run as root (so
+# coredns can bind :53 without extra capabilities). ConditionPathExists keeps
+# them inert until launch-time config exists.
+emit_rc_units() {
+  cat <<'EOF'
+# --- xdn-rc.service (Reconfigurator) ---
+sudo tee /etc/systemd/system/xdn-rc.service >/dev/null <<'UNIT'
+[Unit]
+Description=XDN Reconfigurator (control plane)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/opt/xdn/conf/gigapaxos.properties
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/xdn
+EnvironmentFile=/opt/xdn/conf/node-id
+ExecStartPre=/opt/xdn/bin/xdn-prestage.sh
+ExecStart=/usr/bin/java -ea \
+  -Djavax.net.ssl.keyStore=/opt/xdn/conf/keyStore.jks -Djavax.net.ssl.keyStorePassword=qwerty \
+  -Djavax.net.ssl.trustStore=/opt/xdn/conf/trustStore.jks -Djavax.net.ssl.trustStorePassword=qwerty \
+  -Djava.util.logging.config.file=/opt/xdn/conf/logging.properties \
+  -Dlog4j.configuration=/opt/xdn/conf/log4j.properties \
+  -DgigapaxosConfig=/opt/xdn/conf/gigapaxos.properties \
+  -Djdk.httpclient.allowRestrictedHeaders=connection,content-length,host \
+  -cp /opt/xdn/jars/* \
+  edu.umass.cs.reconfiguration.ReconfigurableNode ${NODE_ID}
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+# --- xdn-dns.service (coredns nameserver) ---
+sudo tee /etc/systemd/system/xdn-dns.service >/dev/null <<'UNIT'
+[Unit]
+Description=XDN coredns nameserver
+After=xdn-rc.service network-online.target
+Wants=network-online.target
+ConditionPathExists=/opt/xdn/conf/Corefile
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/xdn
+ExecStartPre=/opt/xdn/bin/xdn-prestage.sh
+ExecStart=/opt/xdn/coredns -conf /opt/xdn/conf/Corefile
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+EOF
+}
+
+run_ami_build

--- a/aws/last-built-amis.txt
+++ b/aws/last-built-amis.txt
@@ -1,0 +1,2 @@
+xdn-ar-20260529-025247	ami-049eaacc453e1f0ae	us-east-1
+xdn-rc-20260529-044253	ami-0af90e71c86a6ac6b	us-east-1

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,0 +1,359 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+# 1. Fetch available zones (filtering out the older zone 'e')
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "zone-name"
+    values = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]
+  }
+}
+
+# 2. Create a Custom VPC with IPv6 Enabled
+resource "aws_vpc" "ipv6_vpc" {
+  cidr_block                       = "10.0.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags = { Name = "VPC-DualStack" }
+}
+
+# 3. Create an Internet Gateway (Handles both IPv4 and IPv6 traffic)
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.ipv6_vpc.id
+  tags   = { Name = "VPC-IGW" }
+}
+
+# 4. Create 4 separate subnets (one for each zone, enabling BOTH IPv4 and IPv6)
+resource "aws_subnet" "ipv6_subnets" {
+  count             = 4
+  vpc_id            = aws_vpc.ipv6_vpc.id
+  cidr_block        = "10.0.${count.index + 1}.0/24"
+  availability_zone = element(data.aws_availability_zones.available.names, count.index)
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.ipv6_vpc.ipv6_cidr_block, 8, count.index + 1)
+
+  # Enabling both ensures your Mac can connect over standard IPv4
+  map_public_ip_on_launch         = true
+  assign_ipv6_address_on_creation = true
+
+  tags = {
+    Name = "Subnet-${element(data.aws_availability_zones.available.names, count.index)}"
+  }
+}
+
+# 5. Route Table (Routes both IPv4 and IPv6 out to the internet)
+resource "aws_route_table" "routes" {
+  vpc_id = aws_vpc.ipv6_vpc.id
+
+  # Route for IPv4 traffic
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  # Route for IPv6 traffic
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.igw.id
+  }
+
+  tags = { Name = "VPC-Routes" }
+}
+
+# 6. Link the route table to all 4 subnets
+resource "aws_route_table_association" "a" {
+  count          = 4
+  subnet_id      = aws_subnet.ipv6_subnets[count.index].id
+  route_table_id = aws_route_table.routes.id
+}
+
+# 7. Security Group (Allows incoming SSH via IPv4/IPv6, and open internal traffic)
+resource "aws_security_group" "allow_ssh_ipv6" {
+  name        = "allow_ssh_dualstack"
+  description = "Allow SSH traffic and internal communication"
+  vpc_id      = aws_vpc.ipv6_vpc.id
+
+  # Rule A: Allow SSH from standard IPv4 internet
+  ingress {
+    description = "SSH via IPv4"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Rule B: Allow SSH from IPv6 internet
+  ingress {
+    description      = "SSH via IPv6"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  # Rule B2: Allow DNS queries to coredns on the RC (UDP + TCP)
+  ingress {
+    description      = "DNS via UDP"
+    from_port        = 53
+    to_port          = 53
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "DNS via TCP"
+    from_port        = 53
+    to_port          = 53
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  # Rule B3: AR data-plane HTTP frontend (clients reach services on :80)
+  ingress {
+    description      = "HTTP service traffic to ActiveReplicas"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  # Rule B4: RC control-plane API (xdn-cli contacts cp.xdnapp.com:3300)
+  ingress {
+    description      = "XDN control-plane API on the RC"
+    from_port        = 3300
+    to_port          = 3300
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  # Rule B5: intra-cluster traffic over PUBLIC IPs. Because gigapaxos.properties
+  #          advertises the nodes' EIPs, consensus (e.g. :2000, :3000) flows
+  #          node->node via public IPs. Allow all ports ONLY from the cluster's
+  #          own EIPs -- this keeps :2000/:3000 off the open internet (they are
+  #          NOT in any 0.0.0.0/0 rule) while letting members reach each other.
+  ingress {
+    description = "Intra-cluster consensus over public IPs (RC + AR EIPs only)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = concat(["${aws_eip.rc.public_ip}/32"], [for e in aws_eip.ar : "${e.public_ip}/32"])
+  }
+
+  # Rule C: Allow all 4 servers to talk to each other on any port (private path)
+  ingress {
+    description = "Allow all internal VPC traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self        = true
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+# 8. Link your existing local public key.
+#    This key pair was imported into state (it was created out-of-band to build
+#    the AMIs). The AWS API does not return public_key material on import, so a
+#    naive plan would force-replace the key pair; ignore_changes avoids that
+#    churn since the key material is stable.
+resource "aws_key_pair" "deployer" {
+  key_name   = "xdn-aws-key"
+  public_key = file("~/.ssh/xdn-aws-key.pub")
+
+  lifecycle {
+    ignore_changes = [public_key]
+  }
+}
+
+# 9. Per-role AMIs (built from the 'main' branch by create_rc_ami.sh /
+#    create_ar_ami.sh; see last-built-amis.txt). Override on the CLI if rebuilt.
+variable "rc_ami" {
+  description = "AMI for the Reconfigurator (RC) + coredns node (includes docker-ce-cli for CREATE-time image validation)."
+  type        = string
+  default     = "ami-0af90e71c86a6ac6b"
+}
+
+variable "ar_ami" {
+  description = "AMI for the ActiveReplica (AR) edge nodes."
+  type        = string
+  default     = "ami-049eaacc453e1f0ae"
+}
+
+variable "ar_count" {
+  description = "Number of ActiveReplica nodes (uses subnets 2..N)."
+  type        = number
+  default     = 3
+}
+
+# Static private IPs make the full cluster view known at plan time, so the
+# user_data templates can reference every node without resource cycles.
+locals {
+  rc_private_ip  = "10.0.1.10" # in subnet[0] = 10.0.1.0/24
+  ar_private_ips = [for i in range(var.ar_count) : "10.0.${i + 2}.10"]
+
+  # gigapaxos cluster config shared by every node. Numeric node ids: RC=0, ARs=1..N.
+  # Nodes advertise their PUBLIC Elastic IPs so that coredns returns
+  # client-reachable addresses for <service>.xdnapp.com (and geo-routing works on
+  # real geolocated IPs). Consequence: consensus traffic flows node->node over
+  # public IPs; ports 2000/3000 are therefore restricted to the cluster's own
+  # EIPs in the security group (Rule B5) and never exposed to the open internet.
+  gigapaxos_properties = join("\n", concat([
+    "APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp",
+    "REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator",
+    "INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator",
+    "GIGAPAXOS_DATA_DIR=/tmp/gigapaxos",
+    "NIO_MAX_PAYLOAD_SIZE=134217728",
+    # AR data-plane HTTP frontend on port 80 (the RC ignores these flags; the
+    # frontend is gated off for reconfigurators in ActiveReplica.java).
+    "ENABLE_ACTIVE_REPLICA_HTTP=true",
+    "ENABLE_ACTIVE_REPLICA_HTTP_PORT_80=true",
+    # RC control-plane API on :3300, which xdn-cli + coredns depend on
+    # (default true; set explicitly for clarity).
+    "ENABLE_RECONFIGURATOR_HTTP=true",
+    "reconfigurator.0=${aws_eip.rc.public_ip}:3000",
+    ], [
+    for i in range(var.ar_count) : "active.${i + 1}=${aws_eip.ar[i].public_ip}:2000"
+  ]))
+}
+
+# 9a. Reconfigurator (control plane) + coredns nameserver. Single node, subnet[0].
+resource "aws_instance" "rc" {
+  ami                    = var.rc_ami
+  instance_type          = "t3.large"
+  subnet_id              = aws_subnet.ipv6_subnets[0].id
+  private_ip             = local.rc_private_ip
+  vpc_security_group_ids = [aws_security_group.allow_ssh_ipv6.id]
+  key_name               = aws_key_pair.deployer.key_name
+
+  # Bootstrap: drop the gated config so the baked xdn-rc + xdn-dns units start.
+  # Replace the instance when the config changes, so cloud-init re-runs with the
+  # new gigapaxos.properties (an in-place user_data update would NOT re-run it).
+  user_data_replace_on_change = true
+  user_data = templatefile("${path.module}/rc-userdata.tftpl", {
+    gigapaxos_properties = local.gigapaxos_properties
+    rc_eip               = aws_eip.rc.public_ip
+  })
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+  }
+
+  tags = { Name = "xdn-rc" }
+}
+
+# 9b. ActiveReplica edge nodes, one per remaining subnet (subnet[i+1]).
+resource "aws_instance" "ar" {
+  count                  = var.ar_count
+  ami                    = var.ar_ami
+  instance_type          = "t3.large"
+  subnet_id              = aws_subnet.ipv6_subnets[count.index + 1].id
+  private_ip             = local.ar_private_ips[count.index]
+  vpc_security_group_ids = [aws_security_group.allow_ssh_ipv6.id]
+  key_name               = aws_key_pair.deployer.key_name
+
+  # Bootstrap: drop config + a unique numeric node id (1..N) so the baked
+  # xdn-ar unit starts. The RC is node 0; ARs continue from 1.
+  # Replace on config change so cloud-init re-runs with the new properties.
+  user_data_replace_on_change = true
+  user_data = templatefile("${path.module}/ar-userdata.tftpl", {
+    gigapaxos_properties = local.gigapaxos_properties
+    node_id              = count.index + 1
+  })
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+  }
+
+  tags = { Name = "xdn-ar-${count.index}" }
+}
+
+# 10. Stable public IP for the RC (a nameserver must not change IP on stop/start).
+#     Allocated standalone and associated separately so the RC's user_data can
+#     reference aws_eip.rc.public_ip without creating a dependency cycle.
+resource "aws_eip" "rc" {
+  domain = "vpc"
+  tags   = { Name = "xdn-rc-eip" }
+}
+
+resource "aws_eip_association" "rc" {
+  instance_id   = aws_instance.rc.id
+  allocation_id = aws_eip.rc.id
+}
+
+# 10b. Stable public IPs for the ARs. Required now that gigapaxos.properties
+#      advertises public addresses: coredns returns these to clients, so they
+#      must be stable (ephemeral IPs change on stop/start and would break DNS).
+#      Allocated standalone (no instance) so the AR user_data can reference them
+#      without a dependency cycle.
+resource "aws_eip" "ar" {
+  count  = var.ar_count
+  domain = "vpc"
+  tags   = { Name = "xdn-ar-eip-${count.index}" }
+}
+
+resource "aws_eip_association" "ar" {
+  count         = var.ar_count
+  instance_id   = aws_instance.ar[count.index].id
+  allocation_id = aws_eip.ar[count.index].id
+}
+
+# 11. Delegate the xdnapp.com zone to coredns on the RC.
+#     coredns is authoritative for the whole zone and self-serves its own
+#     ns1/ns2 glue (see xdn-dns/plugin/xdn/xdn.go). Both nameservers point to
+#     the single RC EIP (no DNS redundancy, acceptable for a research cluster).
+#     NOTE: the Route53 Domains API only operates in us-east-1 (matches our provider).
+resource "aws_route53domains_registered_domain" "xdnapp" {
+  domain_name = "xdnapp.com"
+
+  name_server {
+    name     = "ns1.xdnapp.com"
+    glue_ips = [aws_eip.rc.public_ip]
+  }
+
+  name_server {
+    name     = "ns2.xdnapp.com"
+    glue_ips = [aws_eip.rc.public_ip]
+  }
+}
+
+# 12. Outputs
+output "rc_elastic_ip" {
+  value       = aws_eip.rc.public_ip
+  description = "RC address for everything (SSH, XDN_CONTROL_PLANE :3300, and the xdnapp.com authoritative NS). The instance's auto-assigned public IP is released once this EIP attaches, so always use this."
+}
+
+output "ar_public_ips" {
+  value       = aws_eip.ar[*].public_ip
+  description = "Elastic IPs of the ActiveReplica nodes (also what coredns returns for service names)."
+}
+
+output "cluster_node_addresses" {
+  value = merge(
+    { "0" = "${aws_eip.rc.public_ip} (RC)" },
+    { for i in range(var.ar_count) : tostring(i + 1) => "${aws_eip.ar[i].public_ip} (AR)" },
+  )
+  description = "Numeric node id -> PUBLIC address advertised in gigapaxos.properties (node 0 is the RC)."
+}

--- a/aws/rc-userdata.tftpl
+++ b/aws/rc-userdata.tftpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Launch-time bootstrap for the XDN Reconfigurator (RC) + coredns node.
+# Writes the per-deployment config that the baked, ConditionPathExists-gated
+# systemd units wait for, then starts them.
+set -euo pipefail
+
+install -d -m 0755 /opt/xdn/conf
+
+cat > /opt/xdn/conf/gigapaxos.properties <<'PROPS'
+${gigapaxos_properties}
+PROPS
+
+# node id + JVM opts (RC = node 0). JAVA_TOOL_OPTIONS forces the IPv4 stack:
+# gigapaxos RequestPacket.toBytes assumes 4-byte (IPv4) addresses, but on this
+# dual-stack VPC the wildcard bind fallback (the public EIP is not bindable)
+# would be IPv6 (16 bytes), breaking Paxos packet serialization. The xdn-rc unit
+# reads this file via EnvironmentFile, so the JVM picks it up.
+cat > /opt/xdn/conf/node-id <<'NODEID'
+NODE_ID=0
+JAVA_TOOL_OPTIONS=-Djava.net.preferIPv4Stack=true
+NODEID
+
+cat > /opt/xdn/conf/Corefile <<'COREFILE'
+xdnapp.com {
+    xdn cp.xdnapp.com ${rc_eip}
+    errors
+    log
+}
+. {
+    forward . 1.1.1.1
+}
+COREFILE
+
+systemctl daemon-reload
+systemctl start xdn-rc xdn-dns


### PR DESCRIPTION
## Summary

Adds `aws/` — Terraform infrastructure and AMI builders for deploying XDN to EC2.
Self-contained deployment tooling; **no changes to platform source code**.

## Contents

- `main.tf` — dual-stack VPC, subnets, security group, EC2 instances, RC Elastic IP,
  and Route53 delegation of `xdnapp.com` to coredns.
- `create_rc_ami.sh` / `create_ar_ami.sh` — build AMIs for the Reconfigurator (+coredns)
  and ActiveReplica edge node; each launches a temporary builder, compiles XDN, snapshots
  an AMI, and terminates the builder.
- `ami_common.sh` — shared AWS plumbing sourced by the two builders.
- `*-userdata.tftpl` — launch-time `user_data` templates; AMIs are config-free until
  `user_data` writes `gigapaxos.properties` / `node-id` / `Corefile`.
- `README.md`, `.terraform.lock.hcl` (provider pinning), `last-built-amis.txt` (build history).

## Notes

- Terraform state and `*.tfvars` are gitignored (state may contain secrets); verified no
  credentials/keys are committed.
- Prereqs: AWS CLI configured for `us-east-1`, an EC2 key pair `xdn-aws-key`, Terraform ≥ 1.x.