### PR TITLE
Cluster-mode services: stateful self-clustering apps over Docker Swarm

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -127,6 +127,7 @@ jobs:
           - XdnPerReplicaRequestTest
           - XdnSetCoordinatorNodeTest
           - XdnTaggedImageLaunchTest
+          - XdnClusterLaunchTest
 
     steps:
     - uses: actions/checkout@v4
@@ -148,6 +149,14 @@ jobs:
         docker run --rm hello-world
         docker pull fadhilkurnia/xdn-bookcatalog
         docker pull fadhilkurnia/xdn-randstate
+
+    - name: 🐝 Initialize Docker swarm (for cluster overlay networking)
+      # Required by XdnClusterLaunchTest, harmless for the others. Single-node swarm; we
+      # don't run anything as a swarm service, only use the overlay network.
+      run: |
+        if ! docker info --format '{{.Swarm.LocalNodeState}}' | grep -q active; then
+          docker swarm init
+        fi
 
     - name: 🔄 Set up Rsync
       uses: GuillaumeFalourd/setup-rsync@v1.2

--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -128,6 +128,7 @@ jobs:
           - XdnSetCoordinatorNodeTest
           - XdnTaggedImageLaunchTest
           - XdnClusterLaunchTest
+          - XdnWordPressClusterTest
 
     steps:
     - uses: actions/checkout@v4
@@ -151,8 +152,9 @@ jobs:
         docker pull fadhilkurnia/xdn-randstate
 
     - name: 🐝 Initialize Docker swarm (for cluster overlay networking)
-      # Required by XdnClusterLaunchTest, harmless for the others. Single-node swarm; we
-      # don't run anything as a swarm service, only use the overlay network.
+      # Required by the cluster tests (XdnClusterLaunchTest, XdnWordPressClusterTest), harmless
+      # for the others. Single-node swarm; we don't run anything as a swarm service, only use the
+      # overlay network.
       run: |
         if ! docker info --format '{{.Swarm.LocalNodeState}}' | grep -q active; then
           docker swarm init

--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -6,7 +6,8 @@ name: "XDN test workflow"
 #                           non-Xdn unit tests via `ant xdn-regular-unit-tests`
 #                           plus the Xdn*Test classes that don't use
 #                           XdnTestCluster (XdnHttpRequestTest,
-#                           XdnHttpRequestBatchTest, XdnGeoDemandProfilerTest).
+#                           XdnHttpRequestBatchTest, XdnGeoDemandProfilerTest,
+#                           XdnPortAllocatorTest).
 #
 #   - xdn-integration     — Matrix, one entry per Xdn*Test class that drives
 #                           XdnTestCluster. Each entry runs on its own runner
@@ -80,6 +81,7 @@ jobs:
         bin/run_xdn_tests.sh XdnHttpRequestTest
         bin/run_xdn_tests.sh XdnHttpRequestBatchTest
         bin/run_xdn_tests.sh XdnGeoDemandProfilerTest
+        bin/run_xdn_tests.sh XdnPortAllocatorTest
 
     - name: 📝 Reporting the test results ...
       uses: dorny/test-reporter@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ ant jar                          # Compile and create JAR files (gigapaxos + nio
 ./bin/build_xdn_fuselog.sh       # Build both C++ (fuselog, fuselog-apply) and Rust (fuserust, fuserust-apply)
 ./bin/build_xdn_fuselog.sh cpp   # C++ only
 ./bin/build_xdn_fuselog.sh rust  # Rust only
+./bin/build_xdn_fuselog.sh test  # Build and run C++ GoogleTest unit tests (needs libgtest-dev)
+./bin/build_xdn_fuselog.sh bench # Build and run the compute_diff microbenchmark
 ```
 
 > **Note**: compiled binaries in `bin/` (`xdn-darwin-arm64`, `xdn-linux-amd64`,
@@ -73,6 +75,23 @@ XDN scripted tests (`run_xdn_tests.sh`) run each test method in a
 **separate JVM** because each test that calls 
 `XdnTestCluster.start()`/`.close()` needs full resource cleanup. 
 Test output goes to `out/junit5-test-output/`.
+
+**fuselog tests (`xdn-fs/test/`, Linux only):** layered correctness harnesses
+for the FUSE state-diff recorder, all driven by Python scripts that build on
+the C++ `fuselog`/`fuselog-apply` binaries:
+- **L1** — C++ GoogleTest unit tests (`build_xdn_fuselog.sh test`); pure C++,
+  no FUSE mount.
+- **L3** — `fuzz_differential.py`: random fs ops on a live mount vs. a plain-dir
+  POSIX oracle, replay the statediff, assert `tree(A) == tree(B) == tree(C)`.
+  Seed is printed at startup; reproduce a failure with `--seed N`.
+- **L4** — `fuzz_concurrent.py` (disjoint subtrees) / `fuzz_concurrent_overlap.py`
+  (shared path pool; ~5% known flake rate from a fid-reuse race).
+- **L5** — `fuzz_db.py --db {sqlite,postgres,mysql,mariadb,mongodb}`: run a real
+  DB on the mount, SIGKILL it, replay onto a fresh dir, assert committed
+  transactions round-trip. Docker-based DBs need `sudo docker` and
+  `user_allow_other` in `/etc/fuse.conf`.
+Failure artifacts land in `/tmp/fuselog-fuzz-fail-<seed>/`. See
+`xdn-fs/test/README.md` for details.
 
 **Test infrastructure:** `XdnTestCluster` provisions a local cluster 
 (1 RC + 3 AR on loopback) for integration tests. 
@@ -143,7 +162,8 @@ Use the `bin/xdnd` shell script (driver-machine orchestrator) for multi-host dep
 - `docker/` — Container management (`DockerComposeManager`)
 - `recorder/` — State diff strategies (`AbstractStateDiffRecorder` and four implementations)
 - `request/` — HTTP request parsing (`XdnRequestParser`, `XdnHttpRequest`, `XdnHttpRequestBatch`) and internal request types (`XdnGetReplicaInfoRequest`, `XdnStopRequest`, `XDNHttpForwardRequest`, `XDNStatediffApplyRequest`)
-- `service/` — Service metadata (`ServiceProperty`, `ServiceComponent`, `ConsistencyModel`, `ServiceInstance`, `RequestMatcher`)
+- `service/` — Service metadata (`ServiceProperty`, `ServiceComponent`, `ConsistencyModel`, `DeploymentMode`, `ServiceInstance`, `RequestMatcher`)
+- `cluster/` — Self-clustering ("StatefulSet-style") services: `StatefulClusterReplicaCoordinator`, `ClusterTopology`, `ClusterTopologyAware`, `SwarmOverlayManager` (see "Cluster-mode services" below)
 - `utils/` — Shell execution helpers, hosts file editing
 - `interfaces/behavior/` — Request behavior abstractions (commutative, key-commutative, etc.)
 - `proto/` — Protocol buffer classes
@@ -202,6 +222,79 @@ Supported via `ConsistencyModel`: linearizability (default), sequential, causal,
 eventual, pram, and client-centric variants. 
 Each maps to a coordinator in the corresponding protocol package.
 
+### Cluster-mode services (`xdn cluster launch`)
+A second deployment shape alongside the regular blackbox-replicated services:
+the container handles its own coordination/consensus, and XDN only provides
+placement, stable identity, peer-discovery networking, and request routing.
+Analogous to a Kubernetes StatefulSet. Selected via `"mode":"cluster"` in the
+`xdn:init:<JSON>` initial state (`DeploymentMode.CLUSTER`).
+
+**Coordinator.** `StatefulClusterReplicaCoordinator` (in
+`edu.umass.cs.xdn.cluster`) is a **pass-through** coordinator —
+`coordinateRequest` just calls `app.execute` on the local replica's container.
+No Paxos, no broadcast. Selected as the very first branch in
+`XdnReplicaCoordinator.inferCoordinatorByProperties` (before any
+determinism/consistency checks, since both are meaningless for cluster mode).
+
+**Identity.** Replicas get deterministic ordinals 0..N-1 by sorting the
+`Set<NodeIDType> nodes` lexicographically. The coordinator pushes a
+`ClusterTopology` (ordinal, size, phase) to `XdnGigapaxosApp` via the
+`ClusterTopologyAware` interface before `restore()`. Each container is started
+with `--hostname=replica-<ordinal> --network-alias=replica-<ordinal>` on a
+swarm-wide overlay (`xdn-cluster-<svc>`), so peers find each other clusterwide
+by name through Docker's embedded DNS.
+
+**Env contract** injected into every cluster container:
+`XDN_CLUSTER_ORDINAL`, `XDN_CLUSTER_SIZE`, `XDN_CLUSTER_SELF`,
+`XDN_CLUSTER_PEERS`, `XDN_CLUSTER_PEER_PORT`, `XDN_CLUSTER_PHASE`
+(`bootstrap` at epoch 0; `join` reserved for the not-yet-wired
+reconfiguration path).
+
+**Single-image vs. multi-component.** A cluster service can be one image
+(e.g. etcd alone) or multiple components in a pod-style group (e.g.
+bookcatalog frontend + a local rqlite sidecar per replica). For multi-
+component, the **stateful** component is the cluster member (attached to the
+overlay); the other components are **sidecars** started with `--network=
+container:<cluster-member-name>` so they share its network namespace and
+reach the cluster member at `127.0.0.1:<peer-port>`. The entry component's
+port gets published to the host on the cluster member's `docker run` so
+XDN's HTTP frontend can route to whichever sidecar is the entry.
+
+**Docker Swarm overlay is required.** `bin/xdnd dist-init` now bootstraps a
+swarm across all configured XDN hosts (all nodes join as managers).
+`SwarmOverlayManager.ensureOverlay()` creates `xdn-cluster-<svc>` on-demand
+(`-d overlay --attachable`); the call is idempotent and races between ARs
+are treated as success.
+
+**Statediff is bypassed** for cluster services — they handle their own
+replication, so XDN-side state-tar capture is a no-op and FUSE/rsync are
+skipped.
+
+**Reference images** under `services/`:
+- `services/etcd-cluster/` — single-image cluster (etcd), entrypoint maps
+  `XDN_CLUSTER_*` → etcd's `--initial-cluster`, `--initial-cluster-state`, etc.
+- `services/rqlite-cluster/` — single-image cluster (rqlite), same pattern.
+- `services/bookcatalog-rqlite-cluster.yaml` — multi-component spec:
+  `bookcatalog` (entry, talks to `127.0.0.1:4001`) + `rqlite` (stateful,
+  cluster member on the overlay).
+
+**Reconfiguration is deferred** (Component 6 in the design plan). The
+`xdn:final:` cluster path in `XdnGigapaxosApp.createServiceInstance` throws
+`UnsupportedOperationException`; cluster placements are effectively pinned
+at epoch 0. The design intent is that image-specific add/remove-replica
+hooks ship in the per-service YAML (e.g. `etcdctl member add` commands),
+*not* as Java adapter classes — see the deleted-but-documented adapter
+scaffolding history in commits `37b23c4f` → `79c90ace`.
+
+**Helper script.** `bin/xdn-cluster-up.sh` brings up XDN across the
+configured CloudLab hosts (1 RC + 3 ARs by default) and optionally launches
+a demo cluster service:
+```bash
+bin/xdn-cluster-up.sh                  # just start XDN
+bin/xdn-cluster-up.sh --launch-etcd
+bin/xdn-cluster-up.sh --launch-bookcat
+```
+
 ### Node Geolocation
 Each node's `(lat, lon)` can be set in the gigapaxos properties file (see
 `conf/gigapaxos.xdnlat.template.properties`) and is parsed via
@@ -219,7 +312,12 @@ end-to-end pipeline is exercised by `eval/geo_demand_smoke.py` (driven by
 the `geo-demand-smoke.yml` CI job).
 
 ### `xdn-cli` subcommands (`xdn-cli/cmd/`)
-Cobra-based CLI. Top-level verbs include `launch`, `status`, `check`, and the `service` command group. `service` covers: `info`, `destroy`, `move` (relocate a service to new replica hosts; drives synchronous paxos leader change), `leader` (inspect/set the paxos leader). `launch` accepts `--num-replicas`, `--min-replicas`, `--max-replicas` in addition to `--image`, `--state`, `--deterministic`, etc. Mutating subcommands prompt for yes/no confirmation on stdin.
+Cobra-based CLI. Top-level verbs include `launch`, `status`, `check`, and two command groups: `service` and `cluster`.
+- `launch` — deploy a regular blackbox-replicated service. Flags: `--image`, `--state`, `--deterministic`, `--consistency`, `--num-replicas`, `--min-replicas`, `--max-replicas`, `--env`, `--port`, `--methods`, `-f file.yaml`.
+- `service` — `info`, `destroy`, `move` (relocate; drives synchronous paxos leader change), `leader` (inspect/set the paxos leader).
+- `cluster launch` — deploy a self-clustering service (`mode:cluster`). Flag-based for single-image (`--image --port --peer-port --state --num-replicas --env`) or `-f spec.yaml` for multi-component clusters. See "Cluster-mode services" above.
+
+Mutating subcommands prompt for yes/no confirmation on stdin. The shared CREATE-request HTTP plumbing lives in `sendCreateRequest()` in `launch.go` and is reused by `cluster.go`.
 
 ### XDN-internal URL params
 URL query parameters prefixed with `_xdn` (e.g. `_xdnsvc`) are consumed at the XDN/proxy layer and must be stripped from the request URI before it is forwarded to the containerized service. `_xdnsvc` provides the service name directly as a URL param and is used as a developer-experience alternative to setting the `XDN:` header.
@@ -236,6 +334,7 @@ Per-service inter-replica + client⇄replica TCP bandwidth tracer built on bpftr
 - `conf/gigapaxos.xdn.3way.properties`, `conf/gigapaxos.xdn.3way.cloudlab.properties` — 3-way replication variants (local + cloudlab)
 - `conf/gigapaxos.xdn.tpcc-java-pb.cloudlab.properties`, `conf/gigapaxos.xdn.wordpress-pb.cloudlab.properties` — App-specific primary-backup eval configs
 - `conf/gigapaxos.xdnlat.template.properties` — Template showing the `(lat, lon)` syntax for node geolocation
+- `conf/gigapaxos.xdn.cluster-launch.cloudlab.properties` — 4-host CloudLab config used by `bin/xdn-cluster-up.sh` (1 RC + 3 ARs, numeric node IDs)
 - `testing.properties` — Test configuration (nodes, load, batch settings)
 
 Key config properties: `APPLICATION`, `REPLICA_COORDINATOR_CLASS`, `XDN_PB_STATEDIFF_RECORDER_TYPE`, `HTTP_AR_FRONTEND_BATCH_ENABLED`, `NIO_MAX_PAYLOAD_SIZE` (default 128MB).
@@ -243,9 +342,17 @@ Key config properties: `APPLICATION`, `REPLICA_COORDINATOR_CLASS`, `XDN_PB_STATE
 ### Cluster Orchestration (`bin/xdnd`)
 For multi-machine/CloudLab deployments, `bin/xdnd` drives remote setup and lifecycle over SSH: `xdnd init-driver` on the driver machine, then `xdnd dist-init -config=... -ssh-key=... -username=...` to initialize remotes, and `xdnd start-all ...` to start xdn instances fleet-wide. `xdnd dist-init-observability` is the optional observability bootstrap.
 
+`xdnd dist-init` also bootstraps a Docker swarm across the hosts (all as managers) — required by cluster-mode services for the cross-host attachable overlay networks. `init_docker_swarm()` is idempotent.
+
+For the cluster-launch demo specifically, `bin/xdn-cluster-up.sh` is a thinner helper that just starts ReconfigurableNode procs on the 4 configured hosts and optionally launches a demo service; it skips the dependency-install + image-build steps and assumes the hosts are already prepped.
+
+### Conventions used by this codebase
+- **Numeric GigaPaxos node IDs.** Configs use `reconfigurator.0=…`, `active.1=…`, `active.2=…`, `active.3=…` — *not* `RC0`/`AR0`/etc. String IDs cause `RequestPacket` to fall back to JSON-encoded packets (~2× wire bytes for Paxos-class protocols). The legacy assertion `requestPacket.getEntryReplica() > 0` at `PaxosInstanceStateMachine.java:1791` is **relaxed to `>= 0`** in this branch because node 0 (the reconfigurator under our numeric scheme) is a legitimate entry replica — see commit `64f00890`.
+
 ## CI Workflows (`.github/workflows/`)
 - **ant-build-test.yml**: Parallelized XDN test suite on push/PR to master/main. Two job groups: (1) **unit-tests** — JDK-only (no Docker/FUSE/rsync), runs `ant xdn-regular-unit-tests` plus the Xdn*Test classes that don't drive `XdnTestCluster` (`XdnHttpRequestTest`, `XdnHttpRequestBatchTest`, `XdnGeoDemandProfilerTest`). (2) **xdn-integration** — matrix with one entry per `XdnTestCluster`-using class (`XdnEventualConsistencyBatchingTest`, `XdnGetReplicaInfoTest`, `XdnMultiServiceTest`, `XdnPerReplicaRequestTest`, `XdnSetCoordinatorNodeTest`, `XdnTaggedImageLaunchTest`), each on its own runner with full Docker/FUSE/rsync setup. Per-runner isolation is mandatory because `XdnTestCluster.java:44-49` hardcodes loopback ports (RC :3000, AR :2000-2002, proxy :2300-2302) and `/tmp/{gigapaxos,xdn}` — two clusters can't coexist on one host.
 - **gigapaxos-correctness.yml**: Parallel matrix of four GigaPaxos correctness tests — `RequestPacketTest`, `E2ELatencyAwareRedirectorTest`, `ant test` (TESTReconfigurationClient end-to-end), and `TESTPaxosMain` (single-JVM multi-node Paxos with `assertRSMInvariant` enabled on every request). JDK-only, no Docker/FUSE/rsync — each job finishes in under a minute and they run concurrently.
+- **fuselog-tests.yml**: layered fuselog correctness suite (L1 GoogleTest unit, L3 differential, L4 concurrent disjoint/overlap, L5 SQLite + Docker DB matrix). Path-filtered — runs only when `xdn-fs/**`, `bin/build_xdn_fuselog.sh`, or the workflow itself changes. Each job builds fuselog independently; an `all-fuselog-tests` aggregator gates branch protection.
 - **xdn-cli-ci.yml**: gofmt check + CLI binary build on changes to `xdn-cli/`
 - **google-java-format.yml**: Formatting check on XDN Java file changes
 - **geo-demand-smoke.yml**: End-to-end smoke test for demand-driven replica reconfiguration — boots a local cluster from `conf/gigapaxos.xdn.local.geodemand.properties`, drives biased traffic via `eval/geo_demand_smoke.py`, and asserts the active set advances past `epoch=0` and contains the expected us-east-1 nodes (including leader)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,9 +274,16 @@ skipped.
 - `services/etcd-cluster/` — single-image cluster (etcd), entrypoint maps
   `XDN_CLUSTER_*` → etcd's `--initial-cluster`, `--initial-cluster-state`, etc.
 - `services/rqlite-cluster/` — single-image cluster (rqlite), same pattern.
+- `services/mysql-cluster/` — self-clustering MySQL via Group Replication;
+  the entrypoint maps `XDN_CLUSTER_*` onto GR (server_id, group seeds, bootstrap
+  on ordinal 0). Unlike etcd/rqlite, MySQL has no one-flag clustering, so the
+  entrypoint clears init GTIDs and wires the recovery channel itself.
 - `services/bookcatalog-rqlite-cluster.yaml` — multi-component spec:
   `bookcatalog` (entry, talks to `127.0.0.1:4001`) + `rqlite` (stateful,
   cluster member on the overlay).
+- `services/wordpress-mysql-cluster.yaml` — multi-component spec exercising the
+  sidecar-netns path: `wordpress` (entry) + `mysql` (stateful GR member). Covered
+  by `XdnWordPressClusterTest`.
 
 **Reconfiguration is deferred** (Component 6 in the design plan). The
 `xdn:final:` cluster path in `XdnGigapaxosApp.createServiceInstance` throws

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,10 +239,37 @@ determinism/consistency checks, since both are meaningless for cluster mode).
 **Identity.** Replicas get deterministic ordinals 0..N-1 by sorting the
 `Set<NodeIDType> nodes` lexicographically. The coordinator pushes a
 `ClusterTopology` (ordinal, size, phase) to `XdnGigapaxosApp` via the
-`ClusterTopologyAware` interface before `restore()`. Each container is started
-with `--hostname=replica-<ordinal> --network-alias=replica-<ordinal>` on a
-swarm-wide overlay (`xdn-cluster-<svc>`), so peers find each other clusterwide
-by name through Docker's embedded DNS.
+`ClusterTopologyAware` interface before `restore()`. Each container gets
+`--hostname=replica-<ordinal>` and joins a swarm-wide overlay
+(`xdn-cluster-<svc>`) under the alias `replica-<ordinal>`, so peers find each
+other clusterwide by name through Docker's embedded DNS.
+
+**Dual-homed networking.** Cluster containers are **created on the default
+bridge** (with the entry port `--publish`ed there) and then attached to the
+overlay via `docker network connect --alias replica-<ordinal>` **before**
+`docker start` (create → connect → start, so peer DNS resolves from the
+process's first instruction). Rationale: Docker Desktop (macOS) cannot route
+published ports of a `docker run` container attached only to an overlay — the
+classic publish path needs a bridge interface and the ingress routing mesh
+only serves swarm services — so bridge carries host→container forwarding
+(`127.0.0.1:<allocatedHttpPort>`) while the overlay carries cross-host peer
+traffic. On Linux both paths worked pre-dual-homing; dual-homing makes macOS
+local dev work too and changes nothing semantically on Linux.
+
+After start, the AR gates on the entry port actually answering HTTP (any
+status) before registering the service — a TCP accept is not enough, because
+Docker Desktop's port forwarder accepts on a published port even when nothing
+is bound inside, and a request forwarded into such a half-open port hangs the
+serial batch pipeline. If the port stays dead for 30s the AR restarts the
+container (then sidecars) once to re-program the forward — a known
+Docker Desktop flake where a freshly published port never gets wired; both
+the gate and the restart are no-ops on Linux. Two further Docker Desktop
+gotchas encoded in `startClusterContainer`: the bind-mount source dir is
+pre-created with Java NIO before `docker create` (the daemon caches a failed
+bind-source lookup, so a later mkdir cannot heal it — only a fresh path
+lookup or daemon restart can), and `docker create` validates bind sources
+eagerly while Linux dockerd would auto-create them as root (breaking
+`--user`).
 
 **Env contract** injected into every cluster container:
 `XDN_CLUSTER_ORDINAL`, `XDN_CLUSTER_SIZE`, `XDN_CLUSTER_SELF`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,22 +239,30 @@ determinism/consistency checks, since both are meaningless for cluster mode).
 **Identity.** Replicas get deterministic ordinals 0..N-1 by sorting the
 `Set<NodeIDType> nodes` lexicographically. The coordinator pushes a
 `ClusterTopology` (ordinal, size, phase) to `XdnGigapaxosApp` via the
-`ClusterTopologyAware` interface before `restore()`. Each container gets
-`--hostname=replica-<ordinal>` and joins a swarm-wide overlay
-(`xdn-cluster-<svc>`) under the alias `replica-<ordinal>`, so peers find each
-other clusterwide by name through Docker's embedded DNS.
+`ClusterTopologyAware` interface before `restore()`. Each container joins a
+swarm-wide overlay (`xdn-cluster-<svc>`) under the alias
+`replica-<ordinal>`, so peers find each other clusterwide by name through
+Docker's embedded DNS (the container's `--hostname` is its container name —
+see "Dual-homed networking" for why the alias must stay out of
+`/etc/hosts`).
 
 **Dual-homed networking.** Cluster containers are **created on the default
-bridge** (with the entry port `--publish`ed there) and then attached to the
-overlay via `docker network connect --alias replica-<ordinal>` **before**
-`docker start` (create → connect → start, so peer DNS resolves from the
-process's first instruction). Rationale: Docker Desktop (macOS) cannot route
-published ports of a `docker run` container attached only to an overlay — the
-classic publish path needs a bridge interface and the ingress routing mesh
-only serves swarm services — so bridge carries host→container forwarding
-(`127.0.0.1:<allocatedHttpPort>`) while the overlay carries cross-host peer
-traffic. On Linux both paths worked pre-dual-homing; dual-homing makes macOS
-local dev work too and changes nothing semantically on Linux.
+bridge** (entry port `--publish`ed there), the overlay is attached via
+`docker network connect --alias replica-<ordinal>` **before** `docker start`
+(create → connect → start, so both networks exist from the process's first
+instruction). Rationale: Docker Desktop (macOS) cannot route published ports
+of a container attached only to an overlay — and it programs (and, on the
+heal path, re-programs) the forward against the *create-time* network, so
+bridge must come first — while the overlay carries cross-host peer traffic
+via embedded DNS. The container's `--hostname` is deliberately the
+**container name, not the replica alias**: Docker maps the hostname in
+`/etc/hosts` to the create-time network's IP, and a `replica-N` hosts entry
+would shadow the overlay alias for the container's *own* lookups. Services
+that bind the address their own name resolves to (MySQL Group Replication's
+XCom `group_replication_local_address`) must see the overlay IP that peers
+dial; with the hostname decoupled, `replica-N` resolves through embedded DNS
+to the overlay IP from everywhere. On Linux both paths worked
+pre-dual-homing; dual-homing makes macOS local dev work too.
 
 After start, the AR gates on the entry port actually answering HTTP (any
 status) before registering the service — a TCP accept is not enough, because

--- a/bin/xdn-cluster-up.sh
+++ b/bin/xdn-cluster-up.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# xdn-cluster-up.sh
+#
+# Brings up the 1-RC-+-3-AR XDN cluster on the CloudLab pod (10.10.1.1-4) and
+# (optionally) launches a demo cluster service from the driver (10.10.1.5).
+#
+# Prerequisites — already done on this pod, only restate if rebuilding from
+# zero:
+#   - rsync'd repo at /users/fadhil/xdn-cl/ on each of .1/.2/.3/.4
+#   - Docker swarm initialized across .1-.4 (`bin/xdnd dist-init` does this)
+#   - xdn-etcd-cluster:test and xdn-rqlite-cluster:test images present
+#     on .1/.2/.3/.4 (`docker build` in services/<name>/ on each)
+#   - bookcatalog image pulled on each AR (`docker pull fadhilkurnia/xdn-bookcatalog`)
+#
+# Usage (from the driver at 10.10.1.5):
+#   bin/xdn-cluster-up.sh                       # just start XDN, no service
+#   bin/xdn-cluster-up.sh --launch-etcd         # also launch a 3-node etcd
+#   bin/xdn-cluster-up.sh --launch-bookcat      # also launch bookcatalog+rqlite
+
+set -euo pipefail
+
+REMOTE=/users/fadhil/xdn-cl
+CFG=conf/gigapaxos.xdn.cluster-launch.cloudlab.properties
+JF='-ea -Djavax.net.ssl.keyStorePassword=qwerty -Djavax.net.ssl.trustStorePassword=qwerty -Djavax.net.ssl.keyStore=conf/keyStore.jks -Djavax.net.ssl.trustStore=conf/trustStore.jks -Djava.util.logging.config.file=conf/logging.properties -Dlog4j.configuration=conf/log4j.properties -DgigapaxosConfig='"$CFG"' -Djdk.httpclient.allowRestrictedHeaders=connection,content-length,host --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED'
+
+echo "[1/3] starting RC (node 0) on 10.10.1.4 and ARs (nodes 1,2,3) on .1/.2/.3 ..."
+for pair in "10.10.1.4 0" "10.10.1.1 1" "10.10.1.2 2" "10.10.1.3 3"; do
+  read ip nid <<<"$pair"
+  ssh -fn -o BatchMode=yes "$ip" "
+    cd $REMOTE && mkdir -p logs
+    nohup java $JF -cp \$(ls jars/*.jar | tr '\n' ':') \
+      edu.umass.cs.reconfiguration.ReconfigurableNode $nid \
+      > logs/node-$nid.log 2> logs/node-$nid.err < /dev/null &
+  "
+done
+
+echo "[2/3] waiting for HTTP frontends ..."
+for pair in "10.10.1.4 3300" "10.10.1.1 2300" "10.10.1.2 2300" "10.10.1.3 2300"; do
+  read ip port <<<"$pair"
+  until timeout 1 bash -c "</dev/tcp/$ip/$port" 2>/dev/null; do sleep 2; done
+  echo "  $ip:$port up"
+done
+
+echo "[3/3] XDN cluster ready. Set XDN_CONTROL_PLANE=10.10.1.4 to talk to it."
+
+case "${1:-}" in
+  --launch-etcd)
+    echo
+    echo "→ launching etcd-demo (3 replicas)"
+    XDN_CONTROL_PLANE=10.10.1.4 ./bin/xdn cluster launch etcd-demo \
+        --image xdn-etcd-cluster:test \
+        --port 2379 --peer-port 2380 \
+        --state /etcd-data/ --num-replicas 3
+    ;;
+  --launch-bookcat)
+    echo
+    echo "→ launching bookcat (rqlite cluster member + bookcatalog sidecar)"
+    XDN_CONTROL_PLANE=10.10.1.4 ./bin/xdn cluster launch bookcat \
+        -f services/bookcatalog-rqlite-cluster.yaml
+    echo
+    echo "Note: bookcatalog can race rqlite startup. If 'curl … /api/books' returns"
+    echo "'don't have any cluster info', restart the sidecars once rqlite is healthy."
+    echo "Container names follow the node id from the spec: c1.e0.bookcat.<nid>.xdn.io"
+    echo "where nid is 1,2,3 on hosts 10.10.1.1, 10.10.1.2, 10.10.1.3 respectively."
+    ;;
+esac

--- a/bin/xdnd
+++ b/bin/xdnd
@@ -75,6 +75,66 @@ function parse_common_dist_args() {
   printf "%s %s %s\n" "$config" "$ssh_key" "$username"
 }
 
+# init_docker_swarm bootstraps a Docker swarm spanning every XDN host so cluster services
+# (xdn cluster launch) can share an attachable overlay network. All hosts join as managers —
+# small research clusters, and we want any AR to be able to create per-cluster overlay nets.
+#
+# Args: <ip1> <ip2> ... <ipN> <ssh_key> <username>
+# Idempotent: a host already in a swarm is left alone.
+function init_docker_swarm() {
+  local args=("$@")
+  local n=${#args[@]}
+  if [ "$n" -lt 3 ]; then
+    return 0
+  fi
+  local USERNAME="${args[$((n - 1))]}"
+  local SSH_KEY="${args[$((n - 2))]}"
+  local IPS=("${args[@]:0:$((n - 2))}")
+  if [ "${#IPS[@]}" -lt 1 ]; then
+    return 0
+  fi
+
+  local MANAGER="${IPS[0]}"
+  echo "[swarm] init on manager $MANAGER ..."
+  if ! ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new "$USERNAME@$MANAGER" \
+    "set -e; \
+     state=\$(docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null || echo unknown); \
+     if [ \"\$state\" != \"active\" ]; then \
+       docker swarm init --advertise-addr $MANAGER >/dev/null; \
+     fi"; then
+    echo "[swarm] init failed on $MANAGER" >&2
+    return 1
+  fi
+
+  local TOKEN
+  TOKEN=$(ssh -i "$SSH_KEY" "$USERNAME@$MANAGER" "docker swarm join-token manager -q")
+  if [ -z "$TOKEN" ]; then
+    echo "[swarm] could not retrieve manager join token from $MANAGER" >&2
+    return 1
+  fi
+
+  local failed=0
+  for ((i = 1; i < ${#IPS[@]}; i++)); do
+    local node="${IPS[$i]}"
+    echo "[swarm] join $node ..."
+    if ! ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new "$USERNAME@$node" \
+      "set -e; \
+       state=\$(docker info --format '{{.Swarm.LocalNodeState}}' 2>/dev/null || echo unknown); \
+       if [ \"\$state\" != \"active\" ]; then \
+         docker swarm join --token $TOKEN $MANAGER:2377 >/dev/null; \
+       fi"; then
+      echo "[swarm] join failed on $node" >&2
+      failed=1
+    fi
+  done
+
+  if [ $failed -ne 0 ]; then
+    return 1
+  fi
+  echo "[swarm] ${#IPS[@]} node(s) in swarm — overlay networks ready"
+  return 0
+}
+
 function do_distributed_initialization() {
   echo "Initializing all the machines from the provided config ..."
 
@@ -148,6 +208,15 @@ function do_distributed_initialization() {
   if [ $failed -ne 0 ]; then
     echo ""
     echo "[dist-init] completed with failures. Logs in: $LOG_DIR"
+    exit 1
+  fi
+
+  # Bootstrap a Docker swarm across the same hosts so cluster services (xdn cluster launch)
+  # have an attachable overlay network for their replicas. XDN does not use Swarm for
+  # scheduling — only for cross-host container networking.
+  if ! init_docker_swarm "${unique_ips[@]}" "$SSH_KEY" "$USERNAME"; then
+    echo ""
+    echo "[dist-init] swarm bootstrap failed; cluster launches will not work until swarm is up." >&2
     exit 1
   fi
 

--- a/conf/gigapaxos.xdn.cluster-launch.cloudlab.properties
+++ b/conf/gigapaxos.xdn.cluster-launch.cloudlab.properties
@@ -1,0 +1,30 @@
+APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp
+
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+
+ENABLE_ACTIVE_REPLICA_HTTP=true
+ENABLE_RECONFIGURATOR_HTTP=true
+BATCHING_ENABLED=true
+REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator
+ENABLE_STARTUP_LEADER_ELECTION=false
+HIBERNATE_OPTION=true
+SYNC=true
+
+NIO_MAX_PAYLOAD_SIZE=805306368
+
+INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator
+INITIAL_STATE_NUM_REPLICAS_EXTRACTOR_CLASS=edu.umass.cs.xdn.XdnServiceNumReplicasExtractor
+XDN_PB_STATEDIFF_RECORDER_TYPE=RSYNC
+XDN_PB_ENABLE_NON_DETERMINISTIC_INIT=true
+
+REPLICATE_ALL=false
+EMULATE_UNREPLICATED=false
+HTTP_AR_FRONTEND_BATCH_ENABLED=true
+
+# 1 reconfigurator on 10.10.1.4, three active replicas one per remaining worker.
+# Numeric IDs keep RequestPacket compact on the wire (saves ~2× bytes on Paxos packets).
+reconfigurator.0=10.10.1.4:3000
+
+active.1=10.10.1.1:2000
+active.2=10.10.1.2:2000
+active.3=10.10.1.3:2000

--- a/services/bookcatalog-rqlite-cluster.yaml
+++ b/services/bookcatalog-rqlite-cluster.yaml
@@ -1,0 +1,26 @@
+# bookcat — a multi-component XDN cluster service: bookcatalog frontend + a local rqlite
+# sidecar on every replica. The three rqlite containers form a Raft cluster across the
+# swarm overlay (xdn-cluster-bookcat); bookcatalog talks to its local rqlite at
+# 127.0.0.1:4001 because the two containers share a network namespace.
+#
+# Launch:
+#   xdn cluster launch bookcat -f services/bookcatalog-rqlite-cluster.yaml
+name: bookcat
+mode: cluster
+state: rqlite:/rqlite-data/
+peer_port: 4002
+num_replicas: 3
+
+components:
+  - rqlite:
+      image: xdn-rqlite-cluster:test
+      stateful: true            # marks rqlite as the cluster member (joins peers on the overlay)
+      expose: 4001              # exposed inside the shared namespace, not published to host
+  - bookcatalog:
+      image: fadhilkurnia/xdn-bookcatalog
+      port: 80                  # entry port; XDN frontend → host:<alloc> → namespace:80
+      entry: true
+      environments:
+        - DB_TYPE: rqlite
+        - DB_HOST: 127.0.0.1
+        - DB_PORT: "4001"

--- a/services/etcd-cluster/Dockerfile
+++ b/services/etcd-cluster/Dockerfile
@@ -1,0 +1,19 @@
+# Thin wrapper around upstream etcd that maps the XDN_CLUSTER_* environment contract
+# (injected by xdn cluster launch) onto etcd's own ETCD_* flags. XDN provides identity
+# and networking; etcd handles its own consensus inside.
+#
+# The upstream `quay.io/coreos/etcd` image is distroless (no /bin/sh), so this is a
+# two-stage build: copy the etcd + etcdctl binaries onto an alpine base that ships a
+# shell our entrypoint can exec.
+#
+# Build locally before running the integration test:
+#   docker build -t xdn-etcd-cluster:test services/etcd-cluster/
+FROM quay.io/coreos/etcd:v3.5.10 AS etcd-source
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=etcd-source /usr/local/bin/etcd /usr/local/bin/etcd
+COPY --from=etcd-source /usr/local/bin/etcdctl /usr/local/bin/etcdctl
+COPY entrypoint.sh /xdn-entrypoint.sh
+RUN chmod +x /xdn-entrypoint.sh
+ENTRYPOINT ["/xdn-entrypoint.sh"]

--- a/services/etcd-cluster/README.md
+++ b/services/etcd-cluster/README.md
@@ -1,0 +1,43 @@
+# xdn-etcd-cluster
+
+Reference image for `xdn cluster launch`. It wraps upstream
+[`quay.io/coreos/etcd`](https://quay.io/repository/coreos/etcd) with an entrypoint that
+translates the `XDN_CLUSTER_*` contract injected by XDN into etcd's native `ETCD_*` flags
+(`ETCD_INITIAL_CLUSTER`, `ETCD_INITIAL_ADVERTISE_PEER_URLS`, etc.). etcd itself runs Raft;
+XDN only places the replicas, gives each a stable `replica-N` identity on a Swarm overlay,
+and routes client traffic to a replica's local v3 HTTP gateway.
+
+## Build
+
+```bash
+docker build -t xdn-etcd-cluster:test services/etcd-cluster/
+```
+
+## Launch (3-node cluster, single host)
+
+```bash
+docker swarm init                              # one-time, gives us overlay networking
+./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.properties start all
+
+export XDN_CONTROL_PLANE=localhost
+xdn cluster launch etcd-demo \
+    --image xdn-etcd-cluster:test \
+    --port 2379 --peer-port 2380 \
+    --state /etcd-data/ \
+    --num-replicas 3
+
+# Write through replica 0, read back via replica 1
+curl -s http://localhost:2300/v3/kv/put -H 'XDN: etcd-demo' \
+     -d '{"key":"Zm9v","value":"YmFy"}'
+curl -s http://localhost:2301/v3/kv/range -H 'XDN: etcd-demo' \
+     -d '{"key":"Zm9v"}'
+```
+
+## Env contract
+
+| XDN variable             | Forwarded to etcd as                       |
+|--------------------------|---------------------------------------------|
+| `XDN_CLUSTER_SELF`       | `--name`, peer/client URL host             |
+| `XDN_CLUSTER_PEERS`      | `--initial-cluster` (joined to `<name>=http://<name>:<peer_port>`) |
+| `XDN_CLUSTER_PEER_PORT`  | peer URL port (default 2380)               |
+| `XDN_CLUSTER_PHASE`      | `--initial-cluster-state` (`new`/`existing`)|

--- a/services/etcd-cluster/entrypoint.sh
+++ b/services/etcd-cluster/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Maps the XDN_CLUSTER_* env contract (set by `xdn cluster launch`) onto etcd's
+# native ETCD_* flags. Then exec's etcd.
+#
+# Required env (provided by XdnGigapaxosApp.initContainerizedClusterService):
+#   XDN_CLUSTER_ORDINAL   this replica's 0-based ordinal
+#   XDN_CLUSTER_SIZE      total cluster size
+#   XDN_CLUSTER_SELF      stable hostname (replica-N)
+#   XDN_CLUSTER_PEERS     comma-separated replica names (replica-0,..,replica-N-1)
+#   XDN_CLUSTER_PEER_PORT etcd peer port (2380 by default)
+#   XDN_CLUSTER_PHASE     "bootstrap" on epoch 0, "join" when added later
+set -eu
+
+: "${XDN_CLUSTER_ORDINAL:?XDN_CLUSTER_ORDINAL is required}"
+: "${XDN_CLUSTER_SIZE:?XDN_CLUSTER_SIZE is required}"
+: "${XDN_CLUSTER_SELF:?XDN_CLUSTER_SELF is required}"
+: "${XDN_CLUSTER_PEERS:?XDN_CLUSTER_PEERS is required}"
+
+PEER_PORT="${XDN_CLUSTER_PEER_PORT:-2380}"
+CLIENT_PORT="${ETCD_CLIENT_PORT:-2379}"
+DATA_DIR="${ETCD_DATA_DIR:-/etcd-data}"
+TOKEN="${ETCD_INITIAL_CLUSTER_TOKEN:-xdn-etcd-cluster}"
+
+# Build INITIAL_CLUSTER as "replica-0=http://replica-0:2380,replica-1=http://replica-1:2380,..."
+INITIAL_CLUSTER=""
+old_ifs="$IFS"
+IFS=,
+for name in $XDN_CLUSTER_PEERS; do
+  entry="${name}=http://${name}:${PEER_PORT}"
+  if [ -z "$INITIAL_CLUSTER" ]; then
+    INITIAL_CLUSTER="$entry"
+  else
+    INITIAL_CLUSTER="${INITIAL_CLUSTER},${entry}"
+  fi
+done
+IFS="$old_ifs"
+
+case "${XDN_CLUSTER_PHASE:-bootstrap}" in
+  join) CLUSTER_STATE=existing ;;
+  *)    CLUSTER_STATE=new ;;
+esac
+
+mkdir -p "$DATA_DIR"
+
+exec etcd \
+  --name="$XDN_CLUSTER_SELF" \
+  --data-dir="$DATA_DIR" \
+  --initial-cluster-token="$TOKEN" \
+  --initial-cluster="$INITIAL_CLUSTER" \
+  --initial-cluster-state="$CLUSTER_STATE" \
+  --initial-advertise-peer-urls="http://${XDN_CLUSTER_SELF}:${PEER_PORT}" \
+  --listen-peer-urls="http://0.0.0.0:${PEER_PORT}" \
+  --advertise-client-urls="http://${XDN_CLUSTER_SELF}:${CLIENT_PORT}" \
+  --listen-client-urls="http://0.0.0.0:${CLIENT_PORT}"

--- a/services/mysql-cluster/Dockerfile
+++ b/services/mysql-cluster/Dockerfile
@@ -1,0 +1,23 @@
+# Self-clustering MySQL for XDN cluster-mode services. Wraps the stock mysql:8.0 image and
+# maps the XDN_CLUSTER_* contract (injected by `xdn cluster launch`) onto MySQL 8 Group
+# Replication: a single-primary group whose members find each other over the swarm overlay
+# by their stable replica-N hostnames. XDN provides identity + networking; MySQL runs its
+# own consensus inside.
+#
+# Pinned to 8.0 (not 8.4) deliberately: Group Replication's distributed-recovery auth path
+# is the best-trodden on 8.0, which keeps this CI image robust.
+#
+# Build locally before running the integration test:
+#   docker build -t xdn-mysql-cluster:test services/mysql-cluster/
+FROM mysql:8.0
+COPY entrypoint.sh /xdn-entrypoint.sh
+# XDN starts cluster containers with --user=<host-uid>:<gid> (not root), so the entrypoint and
+# mysqld run as an arbitrary uid. Make the paths they must write — the config dir and the runtime
+# socket/pid dir — writable by any uid. (The datadir is a host bind-mount, already host-owned.)
+RUN chmod +x /xdn-entrypoint.sh \
+ && mkdir -p /var/run/mysqld \
+ && chmod 0777 /etc/mysql/conf.d /var/run/mysqld
+# GR group-communication port (XDN_CLUSTER_PEER_PORT) defaults to 33061; the client/app
+# port stays 3306. The entrypoint configures and starts mysqld itself.
+ENTRYPOINT ["/xdn-entrypoint.sh"]
+CMD ["mysqld"]

--- a/services/mysql-cluster/README.md
+++ b/services/mysql-cluster/README.md
@@ -1,0 +1,42 @@
+# xdn-mysql-cluster
+
+A self-clustering MySQL image for XDN **cluster-mode** services. It wraps `mysql:8.0` and
+translates the `XDN_CLUSTER_*` environment contract (set by `xdn cluster launch`) into a
+single-primary **MySQL Group Replication** group.
+
+Unlike etcd/rqlite, MySQL has no one-flag clustering, so the entrypoint does the assembly:
+
+| `XDN_CLUSTER_*` | MySQL Group Replication |
+|---|---|
+| `ORDINAL` | `server_id = ORDINAL + 1`; ordinal 0 bootstraps the group |
+| `SELF` (`replica-N`) | `report_host`, `group_replication_local_address` |
+| `PEERS` | `group_replication_group_seeds` (`replica-0:33061,...`) |
+| `PEER_PORT` (default 33061) | GR group-communication port (distinct from the 3306 client port) |
+| `PHASE` | `bootstrap` → ordinal 0 bootstraps; otherwise members join an existing group |
+
+## Bootstrap sequence (per node)
+
+1. Write a GR config (`gtid_mode=ON`, `binlog`, `plugin_load_add=group_replication.so`,
+   group name/seeds/local-address).
+2. Start mysqld via the stock entrypoint (datadir init + `MYSQL_ROOT_PASSWORD`).
+3. Create a node-local recovery user (`sql_log_bin=0`, so it generates no GTID) and point
+   the `group_replication_recovery` channel at it with `GET_SOURCE_PUBLIC_KEY=1`.
+4. `RESET MASTER` to drop the GTIDs the stock init produced — otherwise a joiner carries
+   transactions the group never saw and GR rejects it.
+5. Ordinal 0 (`phase=bootstrap`): bootstrap the group, then `CREATE DATABASE wordpress`
+   once so it replicates out. Other ordinals: `START GROUP_REPLICATION`, retrying until the
+   seed is reachable.
+
+## Notes
+
+- **Single-primary**: only the primary (ordinal 0 at bootstrap) accepts writes; secondaries
+  are `super_read_only`. A client connecting to a secondary can read and connect, but not
+  write — fine for a connectivity check, not for accepting new writes.
+- `innodb_buffer_pool_size=128M` keeps memory modest so several members plus an app tier fit
+  on one CI runner.
+- Used by `XdnWordPressClusterTest` (multi-component cluster: this MySQL as the stateful
+  member + a WordPress entry sidecar sharing its network namespace).
+
+```bash
+docker build -t xdn-mysql-cluster:test services/mysql-cluster/
+```

--- a/services/mysql-cluster/entrypoint.sh
+++ b/services/mysql-cluster/entrypoint.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Maps the XDN_CLUSTER_* env contract (set by `xdn cluster launch`) onto MySQL 8
+# Group Replication. XDN provides identity + overlay networking (stable replica-N
+# hostnames); MySQL handles its own (single-primary) consensus inside the group.
+#
+# Required env (provided by XdnGigapaxosApp.initContainerizedClusterService):
+#   XDN_CLUSTER_ORDINAL   this replica's 0-based ordinal  -> server_id, bootstrap-or-join
+#   XDN_CLUSTER_SIZE      total cluster size              (informational)
+#   XDN_CLUSTER_SELF      stable hostname (replica-N)     -> report_host, local_address
+#   XDN_CLUSTER_PEERS     comma-separated replica names   -> group_seeds
+#   XDN_CLUSTER_PEER_PORT GR group-communication port (default 33061; NOT the 3306 client port)
+#   XDN_CLUSTER_PHASE     "bootstrap" on epoch 0, "join" when added later
+#   MYSQL_ROOT_PASSWORD   root password (also what the WordPress sidecar connects with)
+#
+# Optional:
+#   XDN_MYSQL_GROUP_UUID, XDN_MYSQL_REPL_USER, XDN_MYSQL_REPL_PASSWORD, XDN_MYSQL_DATABASE
+#
+# Why the dance below (RESET MASTER, recovery user with sql_log_bin=0): the stock mysql
+# init creates system objects under gtid_mode=ON, so each freshly-initialized node has a
+# different GTID_EXECUTED. Group Replication refuses to let a joiner in if it carries
+# transactions the group never saw. Clearing GTIDs on every node right before START makes
+# them all start from an empty, compatible history; the group's data (the app database) is
+# then created once on the primary and replicated out.
+set -euo pipefail
+
+: "${XDN_CLUSTER_ORDINAL:?XDN_CLUSTER_ORDINAL is required}"
+: "${XDN_CLUSTER_SELF:?XDN_CLUSTER_SELF is required}"
+: "${XDN_CLUSTER_PEERS:?XDN_CLUSTER_PEERS is required}"
+: "${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD is required}"
+
+PEER_PORT="${XDN_CLUSTER_PEER_PORT:-33061}"
+PHASE="${XDN_CLUSTER_PHASE:-bootstrap}"
+GROUP_UUID="${XDN_MYSQL_GROUP_UUID:-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}"
+REPL_USER="${XDN_MYSQL_REPL_USER:-xdnrepl}"
+REPL_PW="${XDN_MYSQL_REPL_PASSWORD:-xdnreplpass}"
+APP_DB="${XDN_MYSQL_DATABASE:-wordpress}"
+SERVER_ID="$(( XDN_CLUSTER_ORDINAL + 1 ))"
+
+# group_seeds = "replica-0:33061,replica-1:33061,..."
+SEEDS=""
+old_ifs="$IFS"; IFS=,
+for name in $XDN_CLUSTER_PEERS; do
+  entry="${name}:${PEER_PORT}"
+  SEEDS="${SEEDS:+$SEEDS,}$entry"
+done
+IFS="$old_ifs"
+
+cat > /etc/mysql/conf.d/zz-xdn-group-replication.cnf <<EOF
+[mysqld]
+server_id                         = ${SERVER_ID}
+gtid_mode                         = ON
+enforce_gtid_consistency          = ON
+binlog_checksum                   = NONE
+log_bin                           = binlog
+relay_log                         = relay-bin
+log_replica_updates               = ON
+binlog_format                     = ROW
+report_host                       = ${XDN_CLUSTER_SELF}
+plugin_load_add                         = group_replication.so
+# The "loose-" prefix is essential: during the stock image's "mysqld --initialize" phase the
+# group_replication plugin is not loaded yet, so without it these would be fatal "unknown
+# variable" errors and mysqld would crash-loop. With it, they are warnings until the plugin
+# loads on real startup.
+loose-group_replication_group_name      = ${GROUP_UUID}
+loose-group_replication_local_address   = ${XDN_CLUSTER_SELF}:${PEER_PORT}
+loose-group_replication_group_seeds     = ${SEEDS}
+loose-group_replication_start_on_boot   = OFF
+loose-group_replication_bootstrap_group = OFF
+# Let distributed recovery fetch the donor's public key so caching_sha2_password auth works
+# over the (non-TLS) recovery connection. This is a system variable — it canNOT be set via
+# CHANGE REPLICATION SOURCE on the recovery channel (that fails with ER 3139).
+loose-group_replication_recovery_get_public_key = ON
+# keep memory modest: up to N of these run on one CI runner alongside the JVM
+innodb_buffer_pool_size           = 128M
+performance_schema                = ON
+EOF
+
+echo "[xdn-mysql] ${XDN_CLUSTER_SELF} server_id=${SERVER_ID} phase=${PHASE} seeds=${SEEDS}"
+
+# Hand off to the stock entrypoint to initialize the datadir + root password, in the
+# background. We deliberately do NOT set MYSQL_DATABASE — the app DB is created once on the
+# primary after the group is up so it replicates with a clean GTID.
+docker-entrypoint.sh mysqld &
+MYSQLD_PID=$!
+
+# All admin SQL goes over TCP so we never accidentally talk to the stock entrypoint's
+# temporary (skip-networking) init server — only the real server listens on 3306.
+mysql_tcp() { mysql --protocol=tcp -h127.0.0.1 -uroot -p"${MYSQL_ROOT_PASSWORD}" -N -B -e "$1"; }
+
+echo "[xdn-mysql] waiting for mysqld to accept TCP connections ..."
+ready=0
+for _ in $(seq 1 150); do
+  if mysqladmin --protocol=tcp -h127.0.0.1 -uroot -p"${MYSQL_ROOT_PASSWORD}" ping >/dev/null 2>&1; then
+    ready=1; break
+  fi
+  if ! kill -0 "$MYSQLD_PID" 2>/dev/null; then
+    echo "[xdn-mysql] mysqld exited during startup" >&2; wait "$MYSQLD_PID"; exit 1
+  fi
+  sleep 2
+done
+[ "$ready" = 1 ] || { echo "[xdn-mysql] timed out waiting for mysqld" >&2; exit 1; }
+
+# Skip re-configuring an already-grouped node (e.g. container restart).
+state="$(mysql_tcp "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${XDN_CLUSTER_SELF}'" 2>/dev/null || true)"
+if [ "$state" != "ONLINE" ] && [ "$state" != "RECOVERING" ]; then
+  echo "[xdn-mysql] configuring group replication recovery user + channel"
+  # Recovery user is local to each node (sql_log_bin=0 -> no GTID), so creating it can't
+  # desync GTID histories. The caching_sha2 public-key fetch needed for non-TLS recovery is
+  # enabled via the group_replication_recovery_get_public_key system variable (see config above).
+  mysql_tcp "SET SESSION sql_log_bin=0;
+             CREATE USER IF NOT EXISTS '${REPL_USER}'@'%' IDENTIFIED BY '${REPL_PW}';
+             GRANT REPLICATION SLAVE, BACKUP_ADMIN, GROUP_REPLICATION_STREAM ON *.* TO '${REPL_USER}'@'%';
+             FLUSH PRIVILEGES;
+             SET SESSION sql_log_bin=1;"
+  mysql_tcp "CHANGE REPLICATION SOURCE TO SOURCE_USER='${REPL_USER}', SOURCE_PASSWORD='${REPL_PW}' FOR CHANNEL 'group_replication_recovery';"
+
+  # Clear the GTIDs the stock init generated so every node starts from a compatible history.
+  mysql_tcp "RESET MASTER;"
+
+  if [ "${XDN_CLUSTER_ORDINAL}" = "0" ] && [ "${PHASE}" = "bootstrap" ]; then
+    echo "[xdn-mysql] bootstrapping the group"
+    mysql_tcp "SET GLOBAL group_replication_bootstrap_group=ON;
+               START GROUP_REPLICATION;
+               SET GLOBAL group_replication_bootstrap_group=OFF;"
+    # Create the app database once, on the primary, so it replicates to the joiners.
+    mysql_tcp "CREATE DATABASE IF NOT EXISTS \`${APP_DB}\`;"
+  else
+    echo "[xdn-mysql] joining the group (retrying until the seed is reachable)"
+    joined=0
+    for _ in $(seq 1 60); do
+      if mysql_tcp "START GROUP_REPLICATION;" 2>/dev/null; then joined=1; break; fi
+      sleep 3
+    done
+    [ "$joined" = 1 ] || echo "[xdn-mysql] WARNING: START GROUP_REPLICATION never succeeded" >&2
+  fi
+fi
+
+# Report final membership state (best effort; informational).
+for _ in $(seq 1 60); do
+  st="$(mysql_tcp "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${XDN_CLUSTER_SELF}'" 2>/dev/null || true)"
+  if [ "$st" = "ONLINE" ]; then echo "[xdn-mysql] ${XDN_CLUSTER_SELF} is ONLINE"; break; fi
+  sleep 2
+done
+
+# Keep mysqld in the foreground so the container lives as long as the server does.
+wait "$MYSQLD_PID"

--- a/services/mysql-cluster/smoke-test.sh
+++ b/services/mysql-cluster/smoke-test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Standalone smoke test for the xdn-mysql-cluster image — validates that the MySQL Group
+# Replication entrypoint forms a 3-node group WITHOUT the rest of the XDN stack (no swarm,
+# no reconfigurator). This isolates the hardest part of XdnWordPressClusterTest so it can be
+# iterated on in ~2 minutes locally instead of via CI.
+#
+# Usage:
+#   ./services/mysql-cluster/smoke-test.sh           # run, report, then tear down
+#   KEEP=1 ./services/mysql-cluster/smoke-test.sh    # leave containers up for inspection
+#   WAIT=90 ./services/mysql-cluster/smoke-test.sh   # override the convergence wait (seconds)
+#
+# Exit code 0 means all 3 members reached ONLINE.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE="xdn-mysql-cluster:test"
+NETWORK="xdn-gr-smoke"
+DATA_ROOT="/tmp/xdn-gr-smoke"
+SIZE=3
+PEER_PORT=33061
+ROOT_PW="supersecret"
+# WAIT is the total polling budget. Datadir --initialize alone can take ~40s per node, and 3
+# init concurrently; then the real server starts, the group bootstraps, and joiners recover —
+# so convergence can take several minutes on a modest machine. The poll exits as soon as the
+# group is up, so a generous budget is harmless.
+WAIT="${WAIT:-360}"
+
+cleanup() {
+  for i in $(seq 0 $((SIZE - 1))); do
+    docker rm -f "replica-$i" >/dev/null 2>&1 || true
+  done
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  rm -rf "$DATA_ROOT" 2>/dev/null || true
+}
+
+# Always start from a clean slate; tear down on exit unless KEEP=1.
+cleanup
+if [ "${KEEP:-0}" != "1" ]; then
+  trap cleanup EXIT
+fi
+
+echo "=== building $IMAGE ==="
+docker build -t "$IMAGE" "$REPO_ROOT/services/mysql-cluster/"
+
+echo "=== creating overlay-equivalent bridge network $NETWORK ==="
+docker network create "$NETWORK" >/dev/null
+
+echo "=== launching $SIZE members (mimicking XDN: non-root --user, bind-mounted datadir) ==="
+for i in $(seq 0 $((SIZE - 1))); do
+  mkdir -p "$DATA_ROOT/replica-$i"
+  docker run -d \
+    --name "replica-$i" \
+    --hostname "replica-$i" \
+    --network "$NETWORK" \
+    --network-alias "replica-$i" \
+    --user "$(id -u):$(id -g)" \
+    -v /etc/passwd:/etc/passwd:ro \
+    --mount "type=bind,source=$DATA_ROOT/replica-$i,target=/var/lib/mysql" \
+    -e XDN_CLUSTER_ORDINAL="$i" \
+    -e XDN_CLUSTER_SIZE="$SIZE" \
+    -e XDN_CLUSTER_SELF="replica-$i" \
+    -e XDN_CLUSTER_PEERS="replica-0,replica-1,replica-2" \
+    -e XDN_CLUSTER_PEER_PORT="$PEER_PORT" \
+    -e XDN_CLUSTER_PHASE=bootstrap \
+    -e MYSQL_ROOT_PASSWORD="$ROOT_PW" \
+    "$IMAGE" >/dev/null
+  echo "  started replica-$i"
+done
+
+echo "=== polling up to ${WAIT}s for ${SIZE}x ONLINE (datadir init + bootstrap is slow) ==="
+deadline=$(( $(date +%s) + WAIT ))
+states=""
+online=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  states="$(docker exec replica-0 mysql -uroot -p"$ROOT_PW" -N -B \
+    -e "SELECT MEMBER_HOST, MEMBER_STATE FROM performance_schema.replication_group_members" \
+    2>/dev/null || true)"
+  online="$(printf '%s\n' "$states" | grep -c ONLINE || true)"
+  echo "  [$(date +%H:%M:%S)] ${online}/${SIZE} ONLINE"
+  if [ "$online" = "$SIZE" ]; then break; fi
+  sleep 10
+done
+
+echo "=== final member states ==="
+echo "${states:-  (replica-0 not queryable)}"
+
+echo "=== replica-0 log (tail) ==="
+docker logs --tail 40 replica-0 2>&1 || true
+
+echo
+if [ "$online" = "$SIZE" ]; then
+  echo "RESULT: PASS — all ${SIZE} members ONLINE"
+  exit 0
+else
+  echo "RESULT: FAIL — only ${online:-0}/${SIZE} members ONLINE"
+  echo "(inspect with: docker logs replica-1 ; docker logs replica-2)"
+  [ "${KEEP:-0}" = "1" ] && echo "(containers left running; remove with: $0 then KEEP unset, or docker rm -f replica-0 replica-1 replica-2)"
+  exit 1
+fi

--- a/services/rqlite-cluster/Dockerfile
+++ b/services/rqlite-cluster/Dockerfile
@@ -1,0 +1,15 @@
+# Thin wrapper around upstream rqlite that maps the XDN_CLUSTER_* environment contract
+# (injected by xdn cluster launch) onto rqlite's own -node-id / -join / -bootstrap-expect
+# flags. XDN provides identity + overlay networking; rqlite handles its own Raft.
+#
+# Build locally before launching:
+#   docker build -t xdn-rqlite-cluster:test services/rqlite-cluster/
+FROM rqlite/rqlite:8.43.4 AS rqlite-source
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=rqlite-source /bin/rqlited /usr/local/bin/rqlited
+COPY --from=rqlite-source /bin/rqlite /usr/local/bin/rqlite
+COPY entrypoint.sh /xdn-entrypoint.sh
+RUN chmod +x /xdn-entrypoint.sh
+ENTRYPOINT ["/xdn-entrypoint.sh"]

--- a/services/rqlite-cluster/README.md
+++ b/services/rqlite-cluster/README.md
@@ -1,0 +1,51 @@
+# xdn-rqlite-cluster
+
+Reference cluster image for `xdn cluster launch`. Each replica runs a single
+[rqlite](https://github.com/rqlite/rqlite) node (SQLite + Raft); the entrypoint translates
+the `XDN_CLUSTER_*` contract injected by XDN into rqlite's native CLI flags
+(`-node-id`, `-bootstrap-expect`, `-join`, `-raft-adv-addr`, ...). XDN provides identity
+and overlay networking; rqlite handles its own Raft replication.
+
+A SQL-speaking app like `bookcatalog` would treat the cluster as a single logical database
+endpoint via XDN's HTTP frontend on the cluster's HTTP port (default 4001).
+
+## Build
+```bash
+docker build -t xdn-rqlite-cluster:test services/rqlite-cluster/
+```
+
+## Launch (3 replicas)
+```bash
+docker swarm init                                # one-time, gives overlay nets
+./bin/gpServer.sh -DgigapaxosConfig=conf/gigapaxos.xdn.local.properties start all
+
+export XDN_CONTROL_PLANE=localhost
+xdn cluster launch bookcat-db \
+    --image xdn-rqlite-cluster:test \
+    --port 4001 --peer-port 4002 \
+    --state /rqlite-data/ \
+    --num-replicas 3
+```
+
+## Try it
+```bash
+# CREATE + INSERT through replica 0
+curl -s http://localhost:2300/db/execute -H 'XDN: bookcat-db' \
+     -d '["CREATE TABLE books (id INTEGER PRIMARY KEY, title TEXT)"]'
+curl -s http://localhost:2300/db/execute -H 'XDN: bookcat-db' \
+     -d '["INSERT INTO books(title) VALUES (\"Dune\")"]'
+
+# SELECT through replica 2 — value must round-trip via Raft
+curl -s http://localhost:2302/db/query?level=strong -H 'XDN: bookcat-db' \
+     -d '["SELECT * FROM books"]'
+```
+
+## Env contract
+
+| XDN variable             | Forwarded to rqlited as                              |
+|--------------------------|-------------------------------------------------------|
+| `XDN_CLUSTER_SELF`       | `-node-id`, `-http-adv-addr`, `-raft-adv-addr` host  |
+| `XDN_CLUSTER_PEERS`      | `-join http://<name>:4001,...`                       |
+| `XDN_CLUSTER_PEER_PORT`  | `-raft-addr` / `-raft-adv-addr` port (default 4002)  |
+| `XDN_CLUSTER_SIZE`       | `-bootstrap-expect <N>` (bootstrap only)             |
+| `XDN_CLUSTER_PHASE`      | bootstrap ⇒ pass `-bootstrap-expect`; join ⇒ omit it |

--- a/services/rqlite-cluster/entrypoint.sh
+++ b/services/rqlite-cluster/entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Maps the XDN_CLUSTER_* env contract (set by `xdn cluster launch`) onto rqlited's
+# flags. Then exec's rqlited.
+#
+# Required env (provided by XdnGigapaxosApp.initContainerizedClusterService):
+#   XDN_CLUSTER_ORDINAL   this replica's 0-based ordinal
+#   XDN_CLUSTER_SIZE      total cluster size — used for -bootstrap-expect
+#   XDN_CLUSTER_SELF      stable hostname (replica-N) — used for -node-id and adv addrs
+#   XDN_CLUSTER_PEERS     comma-separated replica names
+#   XDN_CLUSTER_PEER_PORT raft port (default 4002)
+#   XDN_CLUSTER_PHASE     "bootstrap" on epoch 0, "join" when added later
+set -eu
+
+: "${XDN_CLUSTER_ORDINAL:?XDN_CLUSTER_ORDINAL is required}"
+: "${XDN_CLUSTER_SIZE:?XDN_CLUSTER_SIZE is required}"
+: "${XDN_CLUSTER_SELF:?XDN_CLUSTER_SELF is required}"
+: "${XDN_CLUSTER_PEERS:?XDN_CLUSTER_PEERS is required}"
+
+RAFT_PORT="${XDN_CLUSTER_PEER_PORT:-4002}"
+HTTP_PORT="${RQLITE_HTTP_PORT:-4001}"
+DATA_DIR="${RQLITE_DATA_DIR:-/rqlite-data}"
+
+# Build join list: replica-0:4002,replica-1:4002,... (rqlite 8 wants the raft host:port
+# here, not the HTTP one — node-to-node join goes over the Raft transport)
+JOIN=""
+old_ifs="$IFS"
+IFS=,
+for name in $XDN_CLUSTER_PEERS; do
+  url="${name}:${RAFT_PORT}"
+  if [ -z "$JOIN" ]; then
+    JOIN="$url"
+  else
+    JOIN="${JOIN},${url}"
+  fi
+done
+IFS="$old_ifs"
+
+mkdir -p "$DATA_DIR"
+
+# On bootstrap every node passes -bootstrap-expect <N> and the same -join URL list, so the
+# first N nodes that reach each other form the cluster atomically. On join (reconfig) we
+# drop -bootstrap-expect; the node finds an existing leader from the -join list.
+case "${XDN_CLUSTER_PHASE:-bootstrap}" in
+  join)
+    exec rqlited \
+      -node-id "$XDN_CLUSTER_SELF" \
+      -http-addr "0.0.0.0:${HTTP_PORT}" \
+      -raft-addr "0.0.0.0:${RAFT_PORT}" \
+      -http-adv-addr "${XDN_CLUSTER_SELF}:${HTTP_PORT}" \
+      -raft-adv-addr "${XDN_CLUSTER_SELF}:${RAFT_PORT}" \
+      -join "$JOIN" \
+      "$DATA_DIR"
+    ;;
+  *)
+    exec rqlited \
+      -node-id "$XDN_CLUSTER_SELF" \
+      -http-addr "0.0.0.0:${HTTP_PORT}" \
+      -raft-addr "0.0.0.0:${RAFT_PORT}" \
+      -http-adv-addr "${XDN_CLUSTER_SELF}:${HTTP_PORT}" \
+      -raft-adv-addr "${XDN_CLUSTER_SELF}:${RAFT_PORT}" \
+      -bootstrap-expect "${XDN_CLUSTER_SIZE}" \
+      -join "$JOIN" \
+      "$DATA_DIR"
+    ;;
+esac

--- a/services/wordpress-mysql-cluster.yaml
+++ b/services/wordpress-mysql-cluster.yaml
@@ -1,0 +1,36 @@
+---
+# WordPress backed by a self-clustering MySQL, as an XDN *cluster-mode* service.
+#
+# This is the multi-component shape: the stateful member (MySQL Group Replication) joins
+# the swarm overlay as replica-N and runs its own consensus, while the WordPress entry
+# sidecar shares that member's network namespace and reaches it at 127.0.0.1:3306. Contrast
+# with xdn-cli/examples/wordpress.yaml, which is the *replicated* shape (plain mysql:8.4,
+# XDN does the replication).
+#
+# Build the clustered MySQL image first:  docker build -t xdn-mysql-cluster:test services/mysql-cluster/
+# Then:                                    xdn cluster launch wordpress-mysql-cluster -f services/wordpress-mysql-cluster.yaml
+name: wordpress-mysql-cluster
+mode: cluster
+peer_port: 33061              # MySQL Group Replication group-communication port (not 3306)
+num_replicas: 3
+state: mysql:/var/lib/mysql/  # the stateful component's data dir
+components:
+  - mysql:
+      image: xdn-mysql-cluster:test
+      stateful: true          # the cluster member: joins the overlay, runs Group Replication
+      expose: 3306            # client port, reachable by the sidecar at 127.0.0.1 (shared netns)
+      environments:
+        - MYSQL_ROOT_PASSWORD: supersecret
+  - wordpress:
+      image: wordpress:6.5.4-apache
+      port: 80                # entry port, published to the host and routed by the XDN frontend
+      entry: true
+      environments:
+        - WORDPRESS_DB_HOST: 127.0.0.1   # MySQL shares this container's network namespace
+        - WORDPRESS_DB_USER: root
+        - WORDPRESS_DB_PASSWORD: supersecret
+        - WORDPRESS_DB_NAME: wordpress
+        - WORDPRESS_CONFIG_EXTRA: |
+            define('DISABLE_WP_CRON', true);
+            define('AUTOMATIC_UPDATER_DISABLED', true);
+            define('WP_AUTO_UPDATE_CORE', false);

--- a/services/wordpress-mysql-cluster.yaml
+++ b/services/wordpress-mysql-cluster.yaml
@@ -34,3 +34,8 @@ components:
             define('DISABLE_WP_CRON', true);
             define('AUTOMATIC_UPDATER_DISABLED', true);
             define('WP_AUTO_UPDATE_CORE', false);
+            // XDN's frontend terminates TLS on :443 and forwards plain HTTP, so WordPress
+            // otherwise thinks it is on http:// and emits mixed-content asset URLs that the
+            // browser blocks. Tell WP it is behind HTTPS (honor X-Forwarded-Proto if the
+            // frontend sets it; otherwise assume https since the frontend always serves TLS).
+            if ((!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') || !isset($_SERVER['HTTPS'])) { $_SERVER['HTTPS'] = 'on'; }

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -25,6 +25,7 @@ import edu.umass.cs.xdn.request.*;
 import edu.umass.cs.xdn.service.ServiceComponent;
 import edu.umass.cs.xdn.service.ServiceInstance;
 import edu.umass.cs.xdn.service.ServiceProperty;
+import edu.umass.cs.xdn.utils.PortAllocator;
 import edu.umass.cs.xdn.utils.Shell;
 import edu.umass.cs.xdn.utils.ShellOutput;
 import edu.umass.cs.xdn.utils.Utils;
@@ -838,7 +839,7 @@ public class XdnGigapaxosApp
         idx++;
       }
 
-      int allocatedPort = getRandomPort();
+      int allocatedPort = PortAllocator.allocate();
       service =
           new ServiceInstance(property, serviceName, networkName, allocatedPort, containerNames);
     } else {
@@ -940,7 +941,7 @@ public class XdnGigapaxosApp
       return initContainerizedClusterService(service, serviceName, initialPlacementEpoch);
     }
 
-    int allocatedPort = getRandomPort();
+    int allocatedPort = PortAllocator.allocate();
     service.allocatedHttpPort = allocatedPort;
 
     // Remove already running containers, if any
@@ -1084,7 +1085,7 @@ public class XdnGigapaxosApp
   private boolean initContainerizedClusterService(
       ServiceInstance service, String serviceName, int placementEpoch) {
 
-    int allocatedPort = getRandomPort();
+    int allocatedPort = PortAllocator.allocate();
     service.allocatedHttpPort = allocatedPort;
 
     // idempotent restart: drop any stale containers from a previous attempt
@@ -1420,7 +1421,7 @@ public class XdnGigapaxosApp
 
     // prepare the initialized service
     String networkName = String.format("net::%s:%s", myNodeId, serviceName);
-    int allocatedPort = getRandomPort();
+    int allocatedPort = PortAllocator.allocate();
     ServiceInstance service =
         new ServiceInstance(property, serviceName, networkName, allocatedPort, containerNames);
 
@@ -2730,39 +2731,6 @@ public class XdnGigapaxosApp
   /**********************************************************************************************
    *                                  Begin utility methods                                     *
    *********************************************************************************************/
-
-  private int getRandomNumber(int min, int max) {
-    return (int) ((Math.random() * (max - min)) + min);
-  }
-
-  /**
-   * This method tries to find available port, most of the time. It is possible, in race condition,
-   * that the port deemed as available is being used by others even when this method return the
-   * port.
-   *
-   * @return port number that is potentially available
-   */
-  private int getRandomPort() {
-    int maxAttempt = 5;
-    int port = getRandomNumber(50000, 65000);
-    boolean isPortAvailable = false;
-
-    // check if port is already used by others
-    while (!isPortAvailable && maxAttempt > 0) {
-      try {
-        // success connection means the port is already used
-        Socket s = new Socket("localhost", port);
-        s.close();
-        port = getRandomNumber(50000, 65000);
-      } catch (IOException e) {
-        // unsuccessful connection could mean that the port is available
-        isPortAvailable = true;
-      }
-      maxAttempt--;
-    }
-
-    return port;
-  }
 
   private boolean startContainer(
       String imageName,

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -1201,6 +1201,61 @@ public class XdnGigapaxosApp
       }
     }
 
+    // Hold off marking the service live until the entry port answers HTTP. Without this, a
+    // request can reach XdnHttpForwarderClient before the container binds its port; on Linux
+    // that fails fast (RST) and the client retries, but Docker Desktop's port forwarder
+    // accepts the connection and leaves it hanging, wedging the serial batch pipeline behind
+    // a request that never completes. Best-effort on timeout: a slow-booting image keeps
+    // today's behavior instead of failing the epoch start.
+    long readinessStartMs = System.currentTimeMillis();
+    boolean entryReady = waitForHttpReadiness(allocatedPort, 30_000);
+    if (!entryReady) {
+      // Docker Desktop's port forwarder occasionally never wires a freshly published port:
+      // the container is healthy inside, the host port accepts TCP, but no bytes ever flow.
+      // A container restart re-programs the forward. Linux never takes this branch — a bound
+      // port there answers within the first wait. Sidecars restart after the member so they
+      // re-join its fresh network namespace.
+      logger.log(
+          Level.WARNING,
+          "{0}:{1} cluster service {2} entry port {3} dead after 30s; restarting container(s)"
+              + " to re-program the port forward",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            serviceName,
+            String.valueOf(allocatedPort)
+          });
+      Shell.runCommand("docker restart " + clusterContainerName, true);
+      for (int i = 0; i < service.containerNames.size(); i++) {
+        if (i != clusterIdx) {
+          Shell.runCommand("docker restart " + service.containerNames.get(i), true);
+        }
+      }
+      entryReady = waitForHttpReadiness(allocatedPort, 30_000);
+    }
+    if (entryReady) {
+      logger.log(
+          Level.INFO,
+          "{0}:{1} cluster service {2} entry port {3} answered HTTP in {4}ms",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            serviceName,
+            String.valueOf(allocatedPort),
+            String.valueOf(System.currentTimeMillis() - readinessStartMs)
+          });
+    } else {
+      logger.log(
+          Level.WARNING,
+          "{0}:{1} cluster service {2} entry port {3} not answering HTTP after 60s; proceeding",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            serviceName,
+            String.valueOf(allocatedPort)
+          });
+    }
+
     service.composeFilePath = null;
     service.composeProjectName = null;
     service.initializationSucceed = true;
@@ -2306,7 +2361,23 @@ public class XdnGigapaxosApp
     // coordinator's own-write re-application after this restore.
     Integer httpPort = this.activeServicePorts.get(serviceName);
     if (httpPort == null) httpPort = service.allocatedHttpPort;
-    long deadline = System.currentTimeMillis() + 30_000;
+    if (waitForHttpReadiness(httpPort, 30_000)) {
+      return true;
+    }
+    logger.log(
+        Level.SEVERE, "Service " + serviceName + " did not become ready after checkpoint restore");
+    return false;
+  }
+
+  /**
+   * Polls {@code http://127.0.0.1:<httpPort>/} until any HTTP status is returned or the timeout
+   * elapses. A TCP accept alone does not count: Docker Desktop's port forwarder accepts connections
+   * on a published port even while nothing is bound inside the container yet, so only a completed
+   * HTTP response proves the service is up. The short per-attempt read timeout is what makes the
+   * poll converge instead of hanging on such half-open forwards.
+   */
+  private boolean waitForHttpReadiness(int httpPort, long timeoutMs) {
+    long deadline = System.currentTimeMillis() + timeoutMs;
     while (System.currentTimeMillis() < deadline) {
       try {
         HttpURLConnection connection =
@@ -2325,8 +2396,6 @@ public class XdnGigapaxosApp
         }
       }
     }
-    logger.log(
-        Level.SEVERE, "Service " + serviceName + " did not become ready after checkpoint restore");
     return false;
   }
 
@@ -2794,13 +2863,21 @@ public class XdnGigapaxosApp
   }
 
   /**
-   * Starts a cluster-mode container on a swarm overlay network with a stable {@code
-   * replica-<ordinal>} hostname and network alias.
+   * Starts a cluster-mode container dual-homed on the default bridge and the swarm overlay network,
+   * with a stable {@code replica-<ordinal>} hostname and overlay alias.
    *
-   * <p>The HTTP entry port is {@code --publish}ed to the host so the local XDN frontend can forward
-   * to it at {@code 127.0.0.1:<allocatedHttpPort>} (Path 1). The cluster's internal peer port is
-   * <em>not</em> published — peers reach each other on the overlay via Docker's embedded DNS (e.g.
-   * {@code replica-2:2380}).
+   * <p>Dual-homing serves each path with the network that can actually carry it: the HTTP entry
+   * port is {@code --publish}ed via the <em>bridge</em>, so the local XDN frontend can forward to
+   * {@code 127.0.0.1:<allocatedHttpPort>} on every platform (Docker Desktop on macOS cannot route
+   * published ports of a {@code docker run} container attached only to an overlay — the classic
+   * publish path needs a bridge interface, and the routing mesh only serves swarm services);
+   * cluster-internal peer traffic rides the <em>overlay</em> via Docker's embedded DNS (e.g. {@code
+   * replica-2:2380}), which is what spans hosts. The peer port is never published.
+   *
+   * <p>The container is {@code docker create}d first and the overlay is attached with its alias
+   * <em>before</em> {@code docker start}, so peer names resolve from the process's first
+   * instruction — a {@code run}-then-{@code connect} sequence would race the entrypoint's initial
+   * peer resolution.
    *
    * <p>This is intentionally a separate method from the regular {@link #startContainer} so the
    * cluster path stays focused on a single component, with no statediff plumbing or healthcheck
@@ -2819,16 +2896,33 @@ public class XdnGigapaxosApp
 
     Shell.runCommand("docker container rm --force " + containerName, true);
 
+    // Pre-create the bind-mount source: Linux dockerd would auto-create a missing source
+    // (as root, breaking the --user mapping below), and Docker Desktop refuses outright
+    // ("bind source path does not exist") — worse, Docker Desktop caches that failed
+    // lookup, so the source must exist before the daemon ever sees the path.
+    if (mountDirSource != null && !mountDirSource.isEmpty()) {
+      try {
+        Files.createDirectories(Paths.get(mountDirSource));
+      } catch (IOException e) {
+        logger.log(
+            Level.SEVERE,
+            "{0}:{1} failed to create bind-mount source {2}: {3}",
+            new Object[] {
+              this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), mountDirSource, e
+            });
+        return false;
+      }
+    }
+
+    // Create on the default bridge (where --publish works everywhere); the overlay is
+    // attached below, before the container starts.
     List<String> cmd = new ArrayList<>();
     cmd.add("docker");
-    cmd.add("run");
-    cmd.add("-d");
+    cmd.add("create");
     cmd.add("--restart");
     cmd.add("unless-stopped");
     cmd.add("--name=" + containerName);
     cmd.add("--hostname=" + replicaName);
-    cmd.add("--network=" + overlayNetwork);
-    cmd.add("--network-alias=" + replicaName);
     if (entryPort != null) {
       cmd.add(String.format("--publish=%d:%d", allocatedHttpPort, entryPort));
     }
@@ -2856,6 +2950,36 @@ public class XdnGigapaxosApp
     if (exitCode != 0) {
       logger.log(
           Level.SEVERE,
+          "{0}:{1} failed to create cluster container {2}",
+          new Object[] {
+            this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), containerName
+          });
+      return false;
+    }
+
+    // Attach the overlay with the stable replica alias before the process starts.
+    String connectCommand =
+        String.format(
+            "docker network connect --alias %s %s %s", replicaName, overlayNetwork, containerName);
+    exitCode = Shell.runCommand(connectCommand, false);
+    if (exitCode != 0) {
+      logger.log(
+          Level.SEVERE,
+          "{0}:{1} failed to attach cluster container {2} to overlay {3}",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            containerName,
+            overlayNetwork
+          });
+      Shell.runCommand("docker container rm --force " + containerName, true);
+      return false;
+    }
+
+    exitCode = Shell.runCommand("docker start " + containerName, false);
+    if (exitCode != 0) {
+      logger.log(
+          Level.SEVERE,
           "{0}:{1} failed to start cluster container {2} on overlay {3}",
           new Object[] {
             this.myNodeId.toUpperCase(),
@@ -2867,7 +2991,7 @@ public class XdnGigapaxosApp
     }
     logger.log(
         Level.INFO,
-        "{0}:{1} - {2} cluster container started ({3} on {4})",
+        "{0}:{1} - {2} cluster container started ({3} dual-homed on bridge + {4})",
         new Object[] {
           this.myNodeId.toUpperCase(),
           this.getClass().getSimpleName(),

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -2864,7 +2864,7 @@ public class XdnGigapaxosApp
 
   /**
    * Starts a cluster-mode container dual-homed on the default bridge and the swarm overlay network,
-   * with a stable {@code replica-<ordinal>} hostname and overlay alias.
+   * reachable by peers under its stable {@code replica-<ordinal>} overlay alias.
    *
    * <p>Dual-homing serves each path with the network that can actually carry it: the HTTP entry
    * port is {@code --publish}ed via the <em>bridge</em>, so the local XDN frontend can forward to
@@ -2874,10 +2874,20 @@ public class XdnGigapaxosApp
    * cluster-internal peer traffic rides the <em>overlay</em> via Docker's embedded DNS (e.g. {@code
    * replica-2:2380}), which is what spans hosts. The peer port is never published.
    *
-   * <p>The container is {@code docker create}d first and the overlay is attached with its alias
-   * <em>before</em> {@code docker start}, so peer names resolve from the process's first
-   * instruction — a {@code run}-then-{@code connect} sequence would race the entrypoint's initial
-   * peer resolution.
+   * <p>The container is {@code docker create}d on the default bridge, the overlay is attached with
+   * the {@code replica-<ordinal>} alias, and only then is it started — both networks are in place
+   * before the process's first instruction (a {@code run}-then-{@code connect} sequence would race
+   * the entrypoint). Bridge must be the create-time network: Docker Desktop programs the host port
+   * forward against it, and both the initial wire-up and the restart heal below are unreliable when
+   * the container was created on the overlay.
+   *
+   * <p>The container's {@code --hostname} is deliberately the <em>container name</em>, not the
+   * replica alias: Docker maps the hostname in {@code /etc/hosts} to the create-time network's IP,
+   * and an {@code /etc/hosts} entry would shadow the overlay alias in DNS. Services that bind the
+   * address their own name resolves to (e.g. MySQL Group Replication's XCom via {@code
+   * group_replication_local_address = replica-N:port}) must get the overlay IP peers actually dial.
+   * With the hostname decoupled, {@code replica-N} resolves — from every replica, including its own
+   * container — through Docker's embedded DNS to the overlay IP.
    *
    * <p>This is intentionally a separate method from the regular {@link #startContainer} so the
    * cluster path stays focused on a single component, with no statediff plumbing or healthcheck
@@ -2914,15 +2924,16 @@ public class XdnGigapaxosApp
       }
     }
 
-    // Create on the default bridge (where --publish works everywhere); the overlay is
-    // attached below, before the container starts.
+    // Create on the default bridge (where the host port forward is reliable); the overlay
+    // carrying the replica alias is attached below, before the container starts. The hostname
+    // is the container name so the replica alias never lands in /etc/hosts (see javadoc).
     List<String> cmd = new ArrayList<>();
     cmd.add("docker");
     cmd.add("create");
     cmd.add("--restart");
     cmd.add("unless-stopped");
     cmd.add("--name=" + containerName);
-    cmd.add("--hostname=" + replicaName);
+    cmd.add("--hostname=" + containerName);
     if (entryPort != null) {
       cmd.add(String.format("--publish=%d:%d", allocatedHttpPort, entryPort));
     }

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -16,6 +16,9 @@ import edu.umass.cs.reconfiguration.interfaces.ReconfigurableRequest;
 import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.ZipFiles;
+import edu.umass.cs.xdn.cluster.ClusterTopology;
+import edu.umass.cs.xdn.cluster.ClusterTopologyAware;
+import edu.umass.cs.xdn.cluster.SwarmOverlayManager;
 import edu.umass.cs.xdn.docker.DockerComposeManager;
 import edu.umass.cs.xdn.recorder.*;
 import edu.umass.cs.xdn.request.*;
@@ -59,7 +62,8 @@ public class XdnGigapaxosApp
         Reconfigurable,
         BackupableApplication,
         CheckpointableApplication,
-        InitialStateValidator {
+        InitialStateValidator,
+        ClusterTopologyAware {
 
   private final boolean IS_RESTART_UPON_STATE_DIFF_APPLY = false;
 
@@ -91,6 +95,12 @@ public class XdnGigapaxosApp
 
   // mapping of service name to the current service instance
   private final Map<String, ServiceInstance> services;
+
+  // mapping of cluster service name to its per-replica topology (ordinal, size, phase).
+  // Pushed by StatefulClusterReplicaCoordinator just before restore() so the cluster branch in
+  // initContainerizedService2 can build the right XDN_CLUSTER_* env and --network-alias.
+  private final ConcurrentHashMap<String, ClusterTopology> clusterTopologies =
+      new ConcurrentHashMap<>();
 
   private final HashMap<String, SocketChannel> fsSocketConnection;
   private final HashMap<String, Boolean> isServiceActive;
@@ -232,6 +242,20 @@ public class XdnGigapaxosApp
     String cmd = "docker version";
     int exitCode = Shell.runCommand(cmd);
     return exitCode == 0;
+  }
+
+  @Override
+  public void setClusterTopology(String serviceName, ClusterTopology topology) {
+    if (topology == null) {
+      this.clusterTopologies.remove(serviceName);
+    } else {
+      this.clusterTopologies.put(serviceName, topology);
+    }
+  }
+
+  @Override
+  public void clearClusterTopology(String serviceName) {
+    this.clusterTopologies.remove(serviceName);
   }
 
   @Override
@@ -741,6 +765,19 @@ public class XdnGigapaxosApp
         throw new RuntimeException(e);
       }
 
+      // Cluster reconfiguration is deferred (Component 6): the xdn:final: branch needs to
+      // recompute the persistent ordinal map, signal XDN_CLUSTER_PHASE=join for fresh
+      // members, and run the per-service add/remove-replica commands declared in the spec
+      // YAML (see project_cluster_reconfig_hooks memory) before starting the new container.
+      // Until that lands, cluster services launch with pinned placement at epoch 0; trying
+      // to reconfigure fails fast here instead of silently corrupting cluster state.
+      if (property.isClusterManaged()) {
+        throw new UnsupportedOperationException(
+            "cluster service reconfiguration is not yet supported for "
+                + serviceName
+                + " — pin placement at launch (Component 6 follow-up)");
+      }
+
       // prepare statediff directory, if required
       String stateDirMountSource =
           stateDiffRecorder.getTargetDirectory(serviceName, newPlacementEpoch);
@@ -812,12 +849,22 @@ public class XdnGigapaxosApp
         throw new RuntimeException("Invalid initial state as JSON: " + e);
       }
 
-      if (!property.isDeterministic()) {
-        stateDiffRecorder.preInitialization(serviceName, initialPlacementEpoch);
-      } else {
-        String dir = stateDiffRecorder.getTargetDirectory(serviceName, initialPlacementEpoch);
-        Shell.runCommand("rm -rf " + dir);
-        Shell.runCommand("mkdir -p " + dir);
+      // Cluster services share a swarm overlay so peers see each other at replica-N;
+      // replicated services use the per-node bridge as before.
+      if (property.isClusterManaged()) {
+        networkName = SwarmOverlayManager.networkName(serviceName);
+      }
+
+      // Statediff is XDN's mechanism for blackbox state capture. Cluster services replicate
+      // their state via the cluster's own protocol, so the recorder is skipped entirely.
+      if (!property.isClusterManaged()) {
+        if (!property.isDeterministic()) {
+          stateDiffRecorder.preInitialization(serviceName, initialPlacementEpoch);
+        } else {
+          String dir = stateDiffRecorder.getTargetDirectory(serviceName, initialPlacementEpoch);
+          Shell.runCommand("rm -rf " + dir);
+          Shell.runCommand("mkdir -p " + dir);
+        }
       }
       // Prepare container names for each service component.
       // Format  : c<component-id>.e<reconfiguration-epoch>.<service-name>.<node-id>.xdn.io
@@ -885,6 +932,12 @@ public class XdnGigapaxosApp
               + " initialization",
           new Object[] {this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), serviceName});
       return true;
+    }
+
+    // Cluster services take a dedicated path: swarm overlay network, stable replica-N alias,
+    // XDN_CLUSTER_* env, and no XDN-managed statediff (the cluster handles its own state).
+    if (service.property.isClusterManaged()) {
+      return initContainerizedClusterService(service, serviceName, initialPlacementEpoch);
     }
 
     int allocatedPort = getRandomPort();
@@ -1014,6 +1067,202 @@ public class XdnGigapaxosApp
 
     // store all the current service metadata
     this.activeServicePorts.put(serviceName, allocatedPort);
+    return true;
+  }
+
+  /**
+   * Initializes a self-clustering ({@code mode: cluster}) service.
+   *
+   * <p>Diverges from the regular path in four ways: (1) attaches the container to a Docker swarm
+   * overlay network ({@code xdn-cluster-<svc>}) instead of the per-node bridge so peers see each
+   * other clusterwide; (2) gives the container a stable {@code replica-<ordinal>} hostname and
+   * network alias so peers can address it the same way from every host; (3) injects the {@code
+   * XDN_CLUSTER_*} env contract so the image (or a thin entrypoint wrapper) can wire itself up; (4)
+   * skips the statediff recorder entirely — the cluster replicates its state via its own protocol
+   * (e.g. etcd's Raft), so XDN has no blackbox state to capture.
+   */
+  private boolean initContainerizedClusterService(
+      ServiceInstance service, String serviceName, int placementEpoch) {
+
+    int allocatedPort = getRandomPort();
+    service.allocatedHttpPort = allocatedPort;
+
+    // idempotent restart: drop any stale containers from a previous attempt
+    for (String name : service.containerNames) {
+      Shell.runCommand("docker rm -f " + name, true);
+    }
+
+    // ensure the swarm overlay exists. Created on the manager and propagates to workers on
+    // attach; idempotent so any AR can race here without a coordinator.
+    String overlay = SwarmOverlayManager.networkName(serviceName);
+    if (!SwarmOverlayManager.ensureOverlay(overlay)) {
+      logger.log(
+          Level.SEVERE,
+          "{0}:{1} failed to create overlay network {2}; is `docker swarm init` run on this"
+              + " node?",
+          new Object[] {this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), overlay});
+      return false;
+    }
+
+    // bind-mount state dir lives under /tmp/xdn/cluster/state — distinct from the statediff
+    // recorder's tree because cluster services don't use the recorder at all.
+    String stateDirMountSource =
+        String.format(
+            "/tmp/xdn/cluster/state/%s/%s/e%d/", this.myNodeId, serviceName, placementEpoch);
+    String stateDirMountTarget = service.property.getStatefulComponentDirectory();
+    Shell.runCommand("rm -rf " + stateDirMountSource, true);
+    Shell.runCommand("mkdir -p " + stateDirMountSource, true);
+
+    ClusterTopology topology = this.clusterTopologies.get(serviceName);
+    if (topology == null) {
+      throw new RuntimeException(
+          "missing cluster topology for "
+              + serviceName
+              + " — coordinator must call setClusterTopology() before restore()");
+    }
+
+    // Identify the cluster member (the stateful component — the one whose Raft joins peers
+    // across the overlay) and the entry component (whose port gets published to the host so
+    // XDN's HTTP frontend can reach it). In a single-image cluster both are the same
+    // component; in a multi-component cluster (e.g. bookcatalog + local rqlite) they are
+    // different and the sidecars share the cluster member's network namespace.
+    ServiceComponent clusterMember = service.property.getStatefulComponent();
+    ServiceComponent entry = service.property.getEntryComponent();
+    if (clusterMember == null) {
+      clusterMember = entry;
+    }
+    int clusterIdx = service.property.getComponents().indexOf(clusterMember);
+    String clusterContainerName = service.containerNames.get(clusterIdx);
+
+    // Build XDN_CLUSTER_* env for the cluster member.
+    Map<String, String> clusterEnv = new LinkedHashMap<>();
+    if (clusterMember.getEnvironmentVariables() != null) {
+      clusterEnv.putAll(clusterMember.getEnvironmentVariables());
+    }
+    String stableName = "replica-" + topology.myOrdinal();
+    StringBuilder peers = new StringBuilder();
+    for (int i = 0; i < topology.clusterSize(); i++) {
+      if (i > 0) peers.append(',');
+      peers.append("replica-").append(i);
+    }
+    clusterEnv.put("XDN_CLUSTER_ORDINAL", String.valueOf(topology.myOrdinal()));
+    clusterEnv.put("XDN_CLUSTER_SIZE", String.valueOf(topology.clusterSize()));
+    clusterEnv.put("XDN_CLUSTER_SELF", stableName);
+    clusterEnv.put("XDN_CLUSTER_PEERS", peers.toString());
+    if (service.property.getPeerPort() != null) {
+      clusterEnv.put("XDN_CLUSTER_PEER_PORT", String.valueOf(service.property.getPeerPort()));
+    }
+    clusterEnv.put(
+        "XDN_CLUSTER_PHASE", topology.phase() == ClusterTopology.Phase.JOIN ? "join" : "bootstrap");
+
+    // The published host port maps to whichever component is the entry. In a multi-component
+    // cluster the entry sidecar shares the cluster member's network namespace, so binding
+    // alloc:<entry-port> on the cluster member's docker run routes external traffic into the
+    // sidecar listening on that port inside the namespace.
+    Integer publishedContainerPort = entry != null ? entry.getEntryPort() : null;
+
+    boolean isSuccess =
+        startClusterContainer(
+            clusterMember.getImageName(),
+            clusterContainerName,
+            overlay,
+            stableName,
+            publishedContainerPort,
+            allocatedPort,
+            clusterMember.isStateful() ? stateDirMountSource : null,
+            clusterMember.isStateful() ? stateDirMountTarget : null,
+            clusterEnv);
+    if (!isSuccess) {
+      throw new RuntimeException("failed to start cluster member for " + serviceName);
+    }
+
+    // Start any sidecar components sharing the cluster member's network namespace, in their
+    // declared order. Each sidecar inherits the cluster member's hostname, network aliases,
+    // and published ports — so a sidecar listening on the entry port becomes externally
+    // reachable, and a sidecar that connects to 127.0.0.1:<cluster-member-port> talks to the
+    // local cluster member with zero hops.
+    for (int i = 0; i < service.property.getComponents().size(); i++) {
+      if (i == clusterIdx) {
+        continue;
+      }
+      ServiceComponent sidecar = service.property.getComponents().get(i);
+      Map<String, String> sidecarEnv =
+          sidecar.getEnvironmentVariables() != null
+              ? new LinkedHashMap<>(sidecar.getEnvironmentVariables())
+              : new LinkedHashMap<>();
+      boolean ok =
+          startClusterSidecar(
+              sidecar.getImageName(),
+              service.containerNames.get(i),
+              clusterContainerName,
+              sidecarEnv);
+      if (!ok) {
+        throw new RuntimeException("failed to start cluster sidecar " + sidecar.getComponentName());
+      }
+    }
+
+    service.composeFilePath = null;
+    service.composeProjectName = null;
+    service.initializationSucceed = true;
+    this.activeServicePorts.put(serviceName, allocatedPort);
+    return true;
+  }
+
+  /**
+   * Starts a sidecar container that shares the cluster member's network namespace.
+   *
+   * <p>The sidecar gets no {@code --network-alias}, {@code --hostname}, or {@code --publish} flags
+   * — those are inherited from the cluster member that owns the namespace. The sidecar just runs
+   * its image with its own env; from inside, it sees the cluster member as {@code 127.0.0.1} (and
+   * conversely, a port the sidecar binds inside the namespace becomes reachable on the host through
+   * whatever {@code --publish} the cluster member set).
+   */
+  private boolean startClusterSidecar(
+      String imageName,
+      String containerName,
+      String namespaceOwnerContainerName,
+      Map<String, String> env) {
+
+    Shell.runCommand("docker container rm --force " + containerName, true);
+
+    List<String> cmd = new ArrayList<>();
+    cmd.add("docker");
+    cmd.add("run");
+    cmd.add("-d");
+    cmd.add("--restart");
+    cmd.add("unless-stopped");
+    cmd.add("--name=" + containerName);
+    cmd.add("--network=container:" + namespaceOwnerContainerName);
+    if (env != null) {
+      for (Map.Entry<String, String> e : env.entrySet()) {
+        cmd.add("--env");
+        cmd.add(e.getKey() + "=" + e.getValue());
+      }
+    }
+    cmd.add(imageName);
+
+    int exitCode = Shell.runCommand(cmd, false);
+    if (exitCode != 0) {
+      logger.log(
+          Level.SEVERE,
+          "{0}:{1} failed to start cluster sidecar {2} sharing namespace of {3}",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            containerName,
+            namespaceOwnerContainerName
+          });
+      return false;
+    }
+    logger.log(
+        Level.INFO,
+        "{0}:{1} - {2} sidecar started (sharing namespace of {3})",
+        new Object[] {
+          this.myNodeId.toUpperCase(),
+          this.getClass().getSimpleName(),
+          containerName,
+          namespaceOwnerContainerName
+        });
     return true;
   }
 
@@ -2204,6 +2453,18 @@ public class XdnGigapaxosApp
       return true;
     }
 
+    // Cluster services own their state via their own protocol — there is nothing for XDN to
+    // capture as a blackbox tar, so skip the rsync+tar pipeline entirely.
+    if (serviceInstance.property.isClusterManaged()) {
+      logger.log(
+          Level.FINE,
+          "{0}:{1} skipping final-state capture for cluster service {2}:{3}",
+          new Object[] {
+            this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), serviceName, epoch
+          });
+      return true;
+    }
+
     // Remove the previously captured final state, if any.
     String removeCommand = String.format("rm -rf %s", finalStateDirPath);
     int code = Shell.runCommand(removeCommand, true);
@@ -2529,6 +2790,91 @@ public class XdnGigapaxosApp
         "{0}:{1} - {2} docker instance started",
         new Object[] {this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), containerName});
 
+    return true;
+  }
+
+  /**
+   * Starts a cluster-mode container on a swarm overlay network with a stable {@code
+   * replica-<ordinal>} hostname and network alias.
+   *
+   * <p>The HTTP entry port is {@code --publish}ed to the host so the local XDN frontend can forward
+   * to it at {@code 127.0.0.1:<allocatedHttpPort>} (Path 1). The cluster's internal peer port is
+   * <em>not</em> published — peers reach each other on the overlay via Docker's embedded DNS (e.g.
+   * {@code replica-2:2380}).
+   *
+   * <p>This is intentionally a separate method from the regular {@link #startContainer} so the
+   * cluster path stays focused on a single component, with no statediff plumbing or healthcheck
+   * dependencies.
+   */
+  private boolean startClusterContainer(
+      String imageName,
+      String containerName,
+      String overlayNetwork,
+      String replicaName,
+      Integer entryPort,
+      int allocatedHttpPort,
+      String mountDirSource,
+      String mountDirTarget,
+      Map<String, String> env) {
+
+    Shell.runCommand("docker container rm --force " + containerName, true);
+
+    List<String> cmd = new ArrayList<>();
+    cmd.add("docker");
+    cmd.add("run");
+    cmd.add("-d");
+    cmd.add("--restart");
+    cmd.add("unless-stopped");
+    cmd.add("--name=" + containerName);
+    cmd.add("--hostname=" + replicaName);
+    cmd.add("--network=" + overlayNetwork);
+    cmd.add("--network-alias=" + replicaName);
+    if (entryPort != null) {
+      cmd.add(String.format("--publish=%d:%d", allocatedHttpPort, entryPort));
+    }
+    if (mountDirSource != null && !mountDirSource.isEmpty() && mountDirTarget != null) {
+      cmd.add("--mount");
+      cmd.add(String.format("type=bind,source=%s,target=%s", mountDirSource, mountDirTarget));
+    }
+    if (env != null) {
+      for (Map.Entry<String, String> e : env.entrySet()) {
+        cmd.add("--env");
+        cmd.add(e.getKey() + "=" + e.getValue());
+      }
+    }
+    int uid = Utils.getUid();
+    int gid = Utils.getGid();
+    if (uid != 0 && mountDirTarget != null && !mountDirTarget.isEmpty()) {
+      cmd.add("-v");
+      cmd.add("/etc/passwd:/etc/passwd:ro");
+      cmd.add(String.format("--user=%d:%d", uid, gid));
+      cmd.add("--cap-add=sys_nice");
+    }
+    cmd.add(imageName);
+
+    int exitCode = Shell.runCommand(cmd, false);
+    if (exitCode != 0) {
+      logger.log(
+          Level.SEVERE,
+          "{0}:{1} failed to start cluster container {2} on overlay {3}",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            containerName,
+            overlayNetwork
+          });
+      return false;
+    }
+    logger.log(
+        Level.INFO,
+        "{0}:{1} - {2} cluster container started ({3} on {4})",
+        new Object[] {
+          this.myNodeId.toUpperCase(),
+          this.getClass().getSimpleName(),
+          containerName,
+          replicaName,
+          overlayNetwork
+        });
     return true;
   }
 

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -465,6 +465,9 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
   private boolean createNotFoundResponse(Request request, ExecutedCallback callback) {
     // Unwrap the XDN payload. Single requests and batches follow different shapes.
     String serviceName = request.getServiceName();
+    System.out.printf(
+        ">> XDNReplicaCoordinator:%s@%x 404 for name=%s known=%s%n",
+        myNodeID, System.identityHashCode(this), serviceName, this.serviceCoordinator.keySet());
     Request innerRequest = request;
     if (request instanceof ReplicableClientRequest rcr) {
       innerRequest = rcr.getRequest();
@@ -742,8 +745,11 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
     this.serviceProperties.put(serviceName, serviceProperty);
 
     System.out.printf(
-        ">> XDNReplicaCoordinator:%s name=%s coordinator=%s\n",
-        myNodeID, serviceName, coordinator.getClass().getSimpleName());
+        ">> XDNReplicaCoordinator:%s@%x name=%s coordinator=%s\n",
+        myNodeID,
+        System.identityHashCode(this),
+        serviceName,
+        coordinator.getClass().getSimpleName());
     return true;
   }
 

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -541,7 +541,10 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
 
     // prepare for the response
     String protocolName = coordinator != null ? coordinator.getClass().getSimpleName() : "?";
-    String requestedConsistency = currServiceProperty.getConsistencyModel().toString();
+    String requestedConsistency =
+        currServiceProperty.isClusterManaged()
+            ? "cluster-managed"
+            : currServiceProperty.getConsistencyModel().toString();
     String offeredConsistency = getConsistencyModelFromCoordinator(serviceName, coordinator);
     String roleName = "replica";
 

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -25,6 +25,7 @@ import edu.umass.cs.reconfiguration.reconfigurationpackets.ReplicableClientReque
 import edu.umass.cs.reconfiguration.reconfigurationpackets.SetCoordinatorNodeRequest;
 import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
 import edu.umass.cs.sequential.AwReplicaCoordinator;
+import edu.umass.cs.xdn.cluster.StatefulClusterReplicaCoordinator;
 import edu.umass.cs.xdn.interfaces.behavior.RequestBehaviorType;
 import edu.umass.cs.xdn.request.XdnGetReplicaInfoRequest;
 import edu.umass.cs.xdn.request.XdnHttpRequest;
@@ -88,6 +89,7 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
   private final AbstractReplicaCoordinator<NodeIDType> clientCentricReplicaCoordinator;
   private final AbstractReplicaCoordinator<NodeIDType> causalReplicaCoordinator;
   private final AbstractReplicaCoordinator<NodeIDType> lazyReplicaCoordinator;
+  private final AbstractReplicaCoordinator<NodeIDType> statefulClusterCoordinator;
 
   // mapping between service name to the service's coordination manager
   private final Map<String, AbstractReplicaCoordinator<NodeIDType>> serviceCoordinator;
@@ -151,6 +153,8 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
         new CausalReplicaCoordinator<>(app, myID, unstringer, messenger);
     LazyReplicaCoordinator<NodeIDType> lazyReplicaCoordinator =
         new LazyReplicaCoordinator<>(app, myID, unstringer, messenger);
+    StatefulClusterReplicaCoordinator<NodeIDType> statefulClusterCoordinator =
+        new StatefulClusterReplicaCoordinator<>(app, myID, unstringer, messenger);
 
     this.primaryBackupCoordinator = primaryBackupReplicaCoordinator;
     this.paxosCoordinator = paxosReplicaCoordinator;
@@ -160,6 +164,7 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
     this.clientCentricReplicaCoordinator = bayouReplicaCoordinator;
     this.causalReplicaCoordinator = causalReplicaCoordinator;
     this.lazyReplicaCoordinator = lazyReplicaCoordinator;
+    this.statefulClusterCoordinator = statefulClusterCoordinator;
 
     // initialize empty service -> coordinator mapping
     this.serviceCoordinator = new ConcurrentHashMap<>();
@@ -625,6 +630,10 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
     if (coordinator instanceof LazyReplicaCoordinator<NodeIDType>) {
       return ConsistencyModel.EVENTUAL.toString();
     }
+    if (coordinator instanceof StatefulClusterReplicaCoordinator<NodeIDType>) {
+      // Consistency is owned by the cluster itself (e.g. etcd's Raft), not by XDN.
+      return "cluster-managed";
+    }
     return "?";
   }
 
@@ -768,6 +777,13 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
 
   private AbstractReplicaCoordinator<NodeIDType> inferCoordinatorByProperties(
       ServiceProperty serviceProperties) {
+    // Cluster services run their own consensus inside the containers; XDN only places, names,
+    // and routes. Picked before the determinism/consistency branches because those fields are
+    // meaningless for a self-clustering service.
+    if (serviceProperties.isClusterManaged()) {
+      return this.statefulClusterCoordinator;
+    }
+
     // An explicitly declared EVENTUAL consistency always uses the anti-entropy
     // LazyReplicaCoordinator, regardless of determinism or declared behaviors:
     // frontier-based checkpoint transfer converges replicas to identical state even

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -35,6 +35,7 @@ import edu.umass.cs.xdn.service.ConsistencyModel;
 import edu.umass.cs.xdn.service.RequestMatcher;
 import edu.umass.cs.xdn.service.ServiceInstance;
 import edu.umass.cs.xdn.service.ServiceProperty;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.*;
 import java.io.IOException;
@@ -502,10 +503,15 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
   }
 
   private static HttpResponse buildNotFoundResponse(String errorMessage, HttpHeaders headers) {
+    ByteBuf body = Unpooled.copiedBuffer(errorMessage.getBytes());
+    // Content-Length is required for correct framing: the HTTP frontend may override the
+    // Connection header to keep-alive, and a keep-alive response without explicit framing
+    // leaves the client blocked waiting for EOF to delimit the body.
+    headers.setInt(HttpHeaderNames.CONTENT_LENGTH, body.readableBytes());
     return new DefaultFullHttpResponse(
         HttpVersion.HTTP_1_1,
         HttpResponseStatus.NOT_FOUND,
-        Unpooled.copiedBuffer(errorMessage.getBytes()),
+        body,
         headers,
         new DefaultHttpHeaders());
   }

--- a/src/edu/umass/cs/xdn/cluster/ClusterTopology.java
+++ b/src/edu/umass/cs/xdn/cluster/ClusterTopology.java
@@ -1,0 +1,25 @@
+package edu.umass.cs.xdn.cluster;
+
+/**
+ * Per-replica identity that {@link StatefulClusterReplicaCoordinator} pushes to {@code
+ * XdnGigapaxosApp} before starting the cluster's container.
+ *
+ * <p>Carries only what is derived from the replica set itself — ordinal, total size, and the launch
+ * phase. Spec-level fields (peer port, cluster adapter) stay in {@code ServiceProperty}, which the
+ * app already has at container-start time.
+ *
+ * @param myOrdinal this replica's ordinal in {@code 0 .. clusterSize - 1}; stable across
+ *     reconfiguration so {@code replica-0} stays {@code replica-0}.
+ * @param clusterSize total number of replicas in the cluster.
+ * @param phase {@link Phase#BOOTSTRAP} on epoch-0 cluster formation, {@link Phase#JOIN} when a
+ *     replica is added to an existing cluster.
+ */
+public record ClusterTopology(int myOrdinal, int clusterSize, Phase phase) {
+
+  public enum Phase {
+    /** First-time cluster formation — all replicas come up together. */
+    BOOTSTRAP,
+    /** This replica is being added to an already-running cluster. */
+    JOIN
+  }
+}

--- a/src/edu/umass/cs/xdn/cluster/ClusterTopologyAware.java
+++ b/src/edu/umass/cs/xdn/cluster/ClusterTopologyAware.java
@@ -1,0 +1,19 @@
+package edu.umass.cs.xdn.cluster;
+
+/**
+ * Side-channel by which {@link StatefulClusterReplicaCoordinator} delivers the per-replica {@link
+ * ClusterTopology} to the application layer ({@code XdnGigapaxosApp}) before {@code restore()} is
+ * called.
+ *
+ * <p>Defined here rather than as a method on {@code Replicable} so the {@code
+ * edu.umass.cs.xdn.cluster} package can be imported by the coordinator without pulling in the full
+ * {@code XdnGigapaxosApp} class.
+ */
+public interface ClusterTopologyAware {
+
+  /** Stores the topology for {@code serviceName}; must be called before {@code restore()}. */
+  void setClusterTopology(String serviceName, ClusterTopology topology);
+
+  /** Drops any stored topology for {@code serviceName}; called on replica-group deletion. */
+  void clearClusterTopology(String serviceName);
+}

--- a/src/edu/umass/cs/xdn/cluster/StatefulClusterReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/cluster/StatefulClusterReplicaCoordinator.java
@@ -1,0 +1,189 @@
+package edu.umass.cs.xdn.cluster;
+
+import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
+import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
+import edu.umass.cs.gigapaxos.interfaces.Replicable;
+import edu.umass.cs.gigapaxos.interfaces.Request;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+import edu.umass.cs.nio.interfaces.Messenger;
+import edu.umass.cs.nio.interfaces.Stringifiable;
+import edu.umass.cs.reconfiguration.AbstractReplicaCoordinator;
+import edu.umass.cs.reconfiguration.interfaces.ReconfigurableRequest;
+import edu.umass.cs.reconfiguration.reconfigurationpackets.ReplicableClientRequest;
+import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.json.JSONObject;
+
+/**
+ * Pass-through coordinator for self-clustering services (the {@code xdn cluster launch} command).
+ *
+ * <p>Unlike every other coordinator in XDN, this one does <strong>not</strong> replicate requests
+ * across replicas. The containerized service handles its own coordination (e.g. etcd, CockroachDB,
+ * a Postgres replication cluster, an etcd ensemble). XDN's job here is only:
+ *
+ * <ul>
+ *   <li>place {@code N} replica containers on {@code N} nodes,
+ *   <li>assign each a stable ordinal identity ({@code 0..N-1}, deterministic from the sorted node
+ *       set),
+ *   <li>publish a {@link ClusterTopology} to the application layer so the container is started on
+ *       the right overlay network with the right {@code XDN_CLUSTER_*} environment variables,
+ *   <li>execute incoming requests on the local replica's container — no consensus, no broadcast.
+ * </ul>
+ */
+public class StatefulClusterReplicaCoordinator<NodeIDType>
+    extends AbstractReplicaCoordinator<NodeIDType> {
+
+  private final NodeIDType myNodeId;
+  private final Replicable app;
+  private final Set<IntegerPacketType> packetTypes;
+
+  private record ClusterReplicaInstance<NodeIDType>(
+      String serviceName,
+      int currEpoch,
+      String initStateSnapshot,
+      List<NodeIDType> orderedNodes,
+      int myOrdinal) {}
+
+  private final ConcurrentMap<String, ClusterReplicaInstance<NodeIDType>> currentInstances;
+
+  private final Logger logger =
+      Logger.getLogger(StatefulClusterReplicaCoordinator.class.getSimpleName());
+
+  public StatefulClusterReplicaCoordinator(
+      Replicable app,
+      NodeIDType myId,
+      Stringifiable<NodeIDType> nodeIdDeserializer,
+      Messenger<NodeIDType, JSONObject> messenger) {
+    super(app, messenger);
+    this.myNodeId = myId;
+    this.app = app;
+
+    assert messenger.getMyID().equals(myId) : "Invalid node ID given in the messenger";
+    assert nodeIdDeserializer.valueOf(this.myNodeId.toString()).equals(this.myNodeId)
+        : "Invalid node ID deserializer given";
+
+    // Pass-through: this coordinator has no protocol packets of its own. The XDN service/HTTP
+    // request types are registered by XdnReplicaCoordinator itself, so the empty set is correct.
+    this.packetTypes = new HashSet<>();
+    this.currentInstances = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public Set<IntegerPacketType> getRequestTypes() {
+    return this.packetTypes;
+  }
+
+  @Override
+  public boolean coordinateRequest(Request request, ExecutedCallback callback)
+      throws IOException, RequestParseException {
+    if (logger.isLoggable(Level.FINE)) {
+      logger.log(
+          Level.FINE,
+          ">> {0} StatefulClusterReplicaCoordinator -- receiving request {1}",
+          new Object[] {myNodeId, request.getClass().getSimpleName()});
+    }
+
+    String serviceName = request.getServiceName();
+    if (!this.currentInstances.containsKey(serviceName)) {
+      logger.log(Level.WARNING, "Ignoring request for unknown cluster service={0}", serviceName);
+      return true;
+    }
+
+    Request unwrapped = request;
+    if (unwrapped instanceof ReplicableClientRequest rcr) {
+      unwrapped = rcr.getRequest();
+    }
+
+    // stop-epoch: tear down the local replica via app.restore(name, null)
+    if (unwrapped instanceof ReconfigurableRequest rc && rc.isStop()) {
+      boolean isSuccess = this.app.restore(serviceName, null);
+      callback.executed(rc, isSuccess);
+      return true;
+    }
+
+    // any other client request: execute locally and return — the cluster handles its own
+    // replication, so there is no inter-replica coordination to perform here.
+    if (unwrapped instanceof ClientRequest clientRequest) {
+      boolean isExecSuccess = this.app.execute(clientRequest);
+      callback.executed(clientRequest, isExecSuccess);
+      return true;
+    }
+
+    throw new IllegalStateException(
+        "Unexpected request type for cluster service: " + request.getRequestType());
+  }
+
+  @Override
+  public boolean createReplicaGroup(
+      String serviceName,
+      int epoch,
+      String state,
+      Set<NodeIDType> nodes,
+      String placementMetadata) {
+    if (logger.isLoggable(Level.INFO)) {
+      logger.log(
+          Level.INFO,
+          ">> {0}:StatefulClusterReplicaCoordinator -- createReplicaGroup name={1} nodes={2} "
+              + "epoch={3}",
+          new Object[] {myNodeId, serviceName, nodes, epoch});
+    }
+
+    // Deterministic ordinal assignment: every node sorts the same set the same way, so every
+    // node computes the same nodeId -> ordinal map without any handshake. Reconfiguration
+    // (Component 6) will replace this with a persisted ordinal map carried in ServiceProperty.
+    List<NodeIDType> orderedNodes = new ArrayList<>(nodes);
+    orderedNodes.sort(Comparator.comparing(Object::toString));
+    int myOrdinal = orderedNodes.indexOf(myNodeId);
+    if (myOrdinal < 0) {
+      throw new IllegalStateException(
+          "createReplicaGroup called on node " + myNodeId + " not in the replica set " + nodes);
+    }
+
+    ClusterReplicaInstance<NodeIDType> instance =
+        new ClusterReplicaInstance<>(
+            serviceName, epoch, state, Collections.unmodifiableList(orderedNodes), myOrdinal);
+    this.currentInstances.put(serviceName, instance);
+
+    // Push the topology to the app BEFORE restore(): initContainerizedService2's cluster branch
+    // reads it to build the XDN_CLUSTER_* env and pick the right --network-alias.
+    if (this.app instanceof ClusterTopologyAware aware) {
+      aware.setClusterTopology(
+          serviceName,
+          new ClusterTopology(myOrdinal, orderedNodes.size(), ClusterTopology.Phase.BOOTSTRAP));
+    }
+
+    return this.app.restore(serviceName, state);
+  }
+
+  @Override
+  public boolean deleteReplicaGroup(String serviceName, int epoch) {
+    if (!this.currentInstances.containsKey(serviceName)) {
+      return true;
+    }
+    ClusterReplicaInstance<NodeIDType> instance = this.currentInstances.get(serviceName);
+    if (instance.currEpoch != epoch) {
+      return true;
+    }
+    this.currentInstances.remove(serviceName);
+    if (this.app instanceof ClusterTopologyAware aware) {
+      aware.clearClusterTopology(serviceName);
+    }
+    return this.app.restore(serviceName, null);
+  }
+
+  @Override
+  public Set<NodeIDType> getReplicaGroup(String serviceName) {
+    ClusterReplicaInstance<NodeIDType> instance = this.currentInstances.get(serviceName);
+    return instance != null ? new HashSet<>(instance.orderedNodes()) : null;
+  }
+}

--- a/src/edu/umass/cs/xdn/cluster/SwarmOverlayManager.java
+++ b/src/edu/umass/cs/xdn/cluster/SwarmOverlayManager.java
@@ -1,0 +1,56 @@
+package edu.umass.cs.xdn.cluster;
+
+import edu.umass.cs.xdn.utils.Shell;
+
+/**
+ * Idempotent helpers for the per-cluster Docker Swarm overlay network.
+ *
+ * <p>Each cluster service gets one attachable overlay network ({@code xdn-cluster-<svc>}) that
+ * spans every node hosting a replica. Containers join it with {@code docker run --network
+ * xdn-cluster-<svc> --network-alias replica-<ordinal>}; Docker's embedded DNS then resolves {@code
+ * replica-0..replica-N} clusterwide, so peers talk to each other on the overlay without any host
+ * port publishing.
+ *
+ * <p>Requires that {@code docker swarm init}/{@code docker swarm join} has already been run on
+ * every XDN node — see {@code bin/xdnd dist-init}. Swarm is used <em>only</em> for the network; XDN
+ * keeps doing its own placement with plain {@code docker run}.
+ */
+public final class SwarmOverlayManager {
+
+  /** Prefix applied to {@code serviceName} to derive the overlay network name. */
+  public static final String OVERLAY_NETWORK_PREFIX = "xdn-cluster-";
+
+  private SwarmOverlayManager() {}
+
+  /** Returns the overlay network name conventionally used for {@code serviceName}. */
+  public static String networkName(String serviceName) {
+    return OVERLAY_NETWORK_PREFIX + serviceName;
+  }
+
+  /**
+   * Ensures an attachable overlay network {@code networkName} exists. No-op if already present.
+   *
+   * @return true on success (existed or was created), false on failure.
+   */
+  public static boolean ensureOverlay(String networkName) {
+    // already exists?
+    if (Shell.runCommand("docker network inspect " + networkName, true) == 0) {
+      return true;
+    }
+    // create. We don't pass --subnet/--ip-range; Docker picks a non-conflicting one.
+    if (Shell.runCommand("docker network create -d overlay --attachable " + networkName, true)
+        == 0) {
+      return true;
+    }
+    // When multiple ARs race to create the same overlay on the same swarm, all but one of
+    // their `create` calls fail. Re-inspect: if a peer won the race, the network now exists
+    // and we're done.
+    return Shell.runCommand("docker network inspect " + networkName, true) == 0;
+  }
+
+  /** Removes the overlay network. Treats "already gone" as success. */
+  public static boolean removeOverlay(String networkName) {
+    int rm = Shell.runCommand("docker network rm " + networkName, true);
+    return rm == 0 || Shell.runCommand("docker network inspect " + networkName, true) != 0;
+  }
+}

--- a/src/edu/umass/cs/xdn/service/DeploymentMode.java
+++ b/src/edu/umass/cs/xdn/service/DeploymentMode.java
@@ -1,0 +1,34 @@
+package edu.umass.cs.xdn.service;
+
+/**
+ * How a service is deployed and replicated.
+ *
+ * <ul>
+ *   <li>{@link #REPLICATED} (default) — XDN performs the replication and coordination; the
+ *       containerized service is a blackbox that is unaware it is replicated.
+ *   <li>{@link #CLUSTER} — the containerized service handles its own coordination/replication (e.g.
+ *       etcd, CockroachDB, a Postgres replication cluster). XDN only provides placement, a stable
+ *       per-replica identity, an overlay network for peer discovery, and request routing.
+ * </ul>
+ */
+public enum DeploymentMode {
+  REPLICATED,
+  CLUSTER;
+
+  public static DeploymentMode fromString(String raw) {
+    if (raw == null || raw.isEmpty()) {
+      return REPLICATED;
+    }
+    switch (raw.trim().toLowerCase()) {
+      case "replicated":
+      case "service":
+        return REPLICATED;
+      case "cluster":
+      case "clustered":
+        return CLUSTER;
+      default:
+        throw new IllegalStateException(
+            "invalid deployment mode '" + raw + "', valid values are: replicated, cluster");
+    }
+  }
+}

--- a/src/edu/umass/cs/xdn/service/ServiceProperty.java
+++ b/src/edu/umass/cs/xdn/service/ServiceProperty.java
@@ -35,6 +35,18 @@ public class ServiceProperty {
   private final Integer minReplicas;
   private final Integer maxReplicas;
 
+  /** REPLICATED (default) or CLUSTER — see {@link DeploymentMode}. */
+  private final DeploymentMode deploymentMode;
+
+  /** The cluster's internal/peer protocol port. Non-null only for cluster services. */
+  private final Integer peerPort;
+
+  /**
+   * Persistent nodeId -&gt; ordinal map for a cluster service. Mutable because ordinals must be
+   * preserved across reconfiguration epochs (a relocated replica keeps its ordinal).
+   */
+  private Map<String, Integer> ordinalMap;
+
   private ServiceProperty(
       String serviceName,
       boolean isDeterministic,
@@ -44,7 +56,10 @@ public class ServiceProperty {
       List<RequestMatcher> requestMatchers,
       Integer numReplicas,
       Integer minReplicas,
-      Integer maxReplicas) {
+      Integer maxReplicas,
+      DeploymentMode deploymentMode,
+      Integer peerPort,
+      Map<String, Integer> ordinalMap) {
     this.serviceName = serviceName;
     this.isDeterministic = isDeterministic;
     this.stateDirectory = stateDirectory;
@@ -54,6 +69,9 @@ public class ServiceProperty {
     this.numReplicas = numReplicas;
     this.minReplicas = minReplicas;
     this.maxReplicas = maxReplicas;
+    this.deploymentMode = deploymentMode;
+    this.peerPort = peerPort;
+    this.ordinalMap = ordinalMap;
   }
 
   public ServiceComponent getEntryComponent() {
@@ -98,6 +116,40 @@ public class ServiceProperty {
       isDeterministic = json.getBoolean("deterministic");
     }
 
+    // parsing deployment mode (default REPLICATED). A cluster service handles its own
+    // coordination, so XDN only places it, gives it a stable identity, and routes to it.
+    DeploymentMode deploymentMode = DeploymentMode.REPLICATED;
+    if (json.has("mode") && !json.isNull("mode")) {
+      deploymentMode = DeploymentMode.fromString(json.getString("mode"));
+    }
+    boolean isClusterManaged = deploymentMode == DeploymentMode.CLUSTER;
+
+    // parsing cluster-only fields: the internal peer port. Reconfiguration lifecycle hooks
+    // (add/remove-replica commands) live in the per-service spec when Component 6 lands, not
+    // in Java code — see project_cluster_reconfig_hooks memory.
+    Integer peerPort = null;
+    if (isClusterManaged) {
+      if (!json.has("peer_port") || json.isNull("peer_port")) {
+        throw new IllegalStateException("peer_port is required for a cluster service");
+      }
+      peerPort = json.getInt("peer_port");
+      if (peerPort < 1 || peerPort > 65535) {
+        throw new IllegalStateException("peer_port must be in 1..65535 (got " + peerPort + ")");
+      }
+    }
+
+    // parsing the persistent nodeId -> ordinal map, if carried over from a previous epoch
+    Map<String, Integer> ordinalMap = null;
+    if (json.has("ordinal_map") && !json.isNull("ordinal_map")) {
+      ordinalMap = new HashMap<>();
+      JSONObject ordinalMapJson = json.getJSONObject("ordinal_map");
+      Iterator it = ordinalMapJson.keys();
+      while (it.hasNext()) {
+        String nodeId = it.next().toString();
+        ordinalMap.put(nodeId, ordinalMapJson.getInt(nodeId));
+      }
+    }
+
     // parsing and validating state directory
     String stateDirectory = json.getString("state");
     if (stateDirectory.isEmpty()) {
@@ -108,13 +160,21 @@ public class ServiceProperty {
     }
 
     // parsing and validating consistency model, the default consistency
-    // model is SEQUENTIAL_CONSISTENCY.
+    // model is SEQUENTIAL_CONSISTENCY. A cluster service owns its own consistency, so the
+    // field is optional there and the stored value is only a never-consulted placeholder.
     ConsistencyModel consistencyModel;
-    String consistencyModelString = json.getString("consistency");
-    if (consistencyModelString == null) {
-      consistencyModel = ConsistencyModel.SEQUENTIAL;
+    if (isClusterManaged) {
+      consistencyModel =
+          json.has("consistency") && !json.isNull("consistency")
+              ? parseConsistencyModel(json.getString("consistency"))
+              : ConsistencyModel.SEQUENTIAL;
     } else {
-      consistencyModel = parseConsistencyModel(consistencyModelString);
+      String consistencyModelString = json.getString("consistency");
+      if (consistencyModelString == null) {
+        consistencyModel = ConsistencyModel.SEQUENTIAL;
+      } else {
+        consistencyModel = parseConsistencyModel(consistencyModelString);
+      }
     }
 
     // parsing and validating service component(s)
@@ -188,6 +248,20 @@ public class ServiceProperty {
     Integer maxReplicas = optionalReplicaField(json, "max_replicas");
     validateReplicaConfig(numReplicas, minReplicas, maxReplicas);
 
+    // Cluster services can be either single-image (image alone) or multi-component (one
+    // stateful component is the cluster member on the overlay; the others are sidecars
+    // sharing its network namespace). The generic validation below already enforces exactly
+    // one stateful + one entry component, which is exactly what cluster mode wants.
+    if (isClusterManaged) {
+      if (!json.has("image") && !json.has("components")) {
+        throw new IllegalStateException(
+            "a cluster service requires either 'image' or 'components'");
+      }
+      if (numReplicas == null) {
+        throw new IllegalStateException("num_replicas is required for a cluster service");
+      }
+    }
+
     ServiceProperty prop =
         new ServiceProperty(
             serviceName,
@@ -198,7 +272,10 @@ public class ServiceProperty {
             parsedRequestMatchers,
             numReplicas,
             minReplicas,
-            maxReplicas);
+            maxReplicas,
+            deploymentMode,
+            peerPort,
+            ordinalMap);
 
     // automatically infer is-stateful of component via the state directory
     if (stateDirectory != null && stateDirectory.split(":").length == 2) {
@@ -579,6 +656,27 @@ public class ServiceProperty {
     return maxReplicas;
   }
 
+  public DeploymentMode getDeploymentMode() {
+    return deploymentMode;
+  }
+
+  public boolean isClusterManaged() {
+    return deploymentMode == DeploymentMode.CLUSTER;
+  }
+
+  public Integer getPeerPort() {
+    return peerPort;
+  }
+
+  public Map<String, Integer> getOrdinalMap() {
+    return ordinalMap;
+  }
+
+  /** Persists the nodeId -&gt; ordinal map so identities survive a reconfiguration epoch. */
+  public void setOrdinalMap(Map<String, Integer> ordinalMap) {
+    this.ordinalMap = ordinalMap;
+  }
+
   public String toJsonString() {
     assert !this.components.isEmpty() : "unexpected empty component";
 
@@ -593,6 +691,7 @@ public class ServiceProperty {
         jsonObject.put("consistency", this.consistencyModel.toString().toLowerCase());
         jsonObject.put("deterministic", this.isDeterministic);
         putReplicaFields(jsonObject);
+        putClusterFields(jsonObject);
       } catch (JSONException e) {
         throw new RuntimeException(e);
       }
@@ -613,6 +712,7 @@ public class ServiceProperty {
       }
       servicePropertyJsonObject.put("components", componentArray);
       putReplicaFields(servicePropertyJsonObject);
+      putClusterFields(servicePropertyJsonObject);
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
@@ -629,6 +729,22 @@ public class ServiceProperty {
     }
     if (this.maxReplicas != null) {
       target.put("max_replicas", this.maxReplicas.intValue());
+    }
+  }
+
+  /**
+   * Serializes cluster-only fields so a cluster service survives the reconfiguration round-trip.
+   */
+  private void putClusterFields(JSONObject target) throws JSONException {
+    if (this.deploymentMode != DeploymentMode.CLUSTER) {
+      return;
+    }
+    target.put("mode", "cluster");
+    if (this.peerPort != null) {
+      target.put("peer_port", this.peerPort.intValue());
+    }
+    if (this.ordinalMap != null && !this.ordinalMap.isEmpty()) {
+      target.put("ordinal_map", new JSONObject(this.ordinalMap));
     }
   }
 }

--- a/src/edu/umass/cs/xdn/utils/PortAllocator.java
+++ b/src/edu/umass/cs/xdn/utils/PortAllocator.java
@@ -1,0 +1,74 @@
+package edu.umass.cs.xdn.utils;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Allocates host ports for containers' published entry ports.
+ *
+ * <p>A port is probed by binding it on the wildcard address, exactly what dockerd will do when it
+ * publishes the port. A connect-probe is not sufficient: a port held as the source of an outbound
+ * socket has no listener (so a connect fails, suggesting "free") yet still blocks dockerd's later
+ * bind with EADDRINUSE.
+ *
+ * <p>The range sits above Linux's default ephemeral window (32768-60999) so kernel-assigned client
+ * ports never race an allocation on CI or production hosts. macOS's ephemeral range extends to
+ * 65535, leaving a small overlap on dev machines that the bind-probe covers in practice.
+ *
+ * <p>Recently granted ports are remembered and skipped: in tests, multiple ActiveReplicas share one
+ * JVM and allocate concurrently, and a probe-then-close on one replica leaves a window where
+ * another replica could probe the same port successfully before either docker bind happens. The
+ * memory is a bounded ring, so no deallocation plumbing is needed.
+ */
+public final class PortAllocator {
+
+  private static final int RANGE_START = 61000;
+  private static final int RANGE_END = 65000; // exclusive
+  private static final int MAX_ATTEMPTS = 20;
+  private static final int RECENT_CAPACITY = 128;
+
+  private static final Set<Integer> recentPorts = new HashSet<>();
+  private static final Deque<Integer> recentOrder = new ArrayDeque<>();
+
+  private PortAllocator() {}
+
+  /**
+   * Returns a host port in [{@value RANGE_START}, {@value RANGE_END}) that was bindable at probe
+   * time and was not granted recently. Falls back to an unprobed random port if every attempt
+   * fails, letting docker surface the failure loudly.
+   */
+  public static synchronized int allocate() {
+    for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      int port = ThreadLocalRandom.current().nextInt(RANGE_START, RANGE_END);
+      if (recentPorts.contains(port)) {
+        continue;
+      }
+      try (ServerSocket probe = new ServerSocket()) {
+        probe.setReuseAddress(false);
+        probe.bind(new InetSocketAddress(port));
+        remember(port);
+        return port;
+      } catch (IOException e) {
+        // in use; try another
+      }
+    }
+    int port = ThreadLocalRandom.current().nextInt(RANGE_START, RANGE_END);
+    remember(port);
+    return port;
+  }
+
+  private static void remember(int port) {
+    if (recentPorts.add(port)) {
+      recentOrder.addLast(port);
+      if (recentOrder.size() > RECENT_CAPACITY) {
+        recentPorts.remove(recentOrder.removeFirst());
+      }
+    }
+  }
+}

--- a/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
+++ b/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
@@ -1,0 +1,159 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.xdn.util.XdnTestCluster;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test for {@code xdn cluster launch}.
+ *
+ * <p>Launches a 3-replica etcd ensemble through XDN's pass-through {@code
+ * StatefulClusterReplicaCoordinator}, then proves both halves of the design:
+ *
+ * <ul>
+ *   <li>The cluster's own consensus works: a key written through replica-0 is observable on
+ *       replicas 1 and 2 over their XDN HTTP frontends.
+ *   <li>XDN reports the new coordinator + consistency through its replica-info endpoint.
+ * </ul>
+ *
+ * <p>Requires Docker, a swarm-initialized daemon (the test ensures this), and the {@code
+ * xdn-etcd-cluster:test} image built from {@code services/etcd-cluster/}.
+ */
+public class XdnClusterLaunchTest {
+
+  private static final String SERVICE = "etcd-cluster-test";
+  private static final int CLIENT_PORT = 2379;
+  private static final int PEER_PORT = 2380;
+  private static final Duration LEADER_ELECTION_BUDGET = Duration.ofSeconds(45);
+
+  private final HttpClient http =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+  @Test
+  public void testEtcdClusterLaunch() throws Exception {
+    assertTrue(XdnTestCluster.isDockerAvailable(), "docker is required for this test");
+    assertTrue(
+        XdnTestCluster.ensureDockerSwarm(),
+        "cluster services need Swarm overlay networking — `docker swarm init` failed");
+    assertTrue(
+        XdnTestCluster.buildEtcdClusterImage(),
+        "could not build xdn-etcd-cluster:test from services/etcd-cluster/");
+
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+
+      cluster.launchClusterService(
+          SERVICE, "xdn-etcd-cluster:test", "/etcd-data/", CLIENT_PORT, PEER_PORT, 3);
+
+      // Wait for every replica's frontend to forward successfully — that's our proxy for
+      // "the cluster has elected a leader and is serving the v3 API."
+      long deadline = System.nanoTime() + LEADER_ELECTION_BUDGET.toNanos();
+      for (int idx = 0; idx < 3; idx++) {
+        waitForHealth(cluster, idx, deadline);
+      }
+
+      // Write a key through replica 0 and read it back through replicas 1 and 2. If etcd's
+      // own Raft is working and XDN is forwarding correctly, this round-trip succeeds.
+      String key = "xdn-cluster-test-key";
+      String value = "hello-cluster";
+      assertEquals(200, putKey(cluster, 0, key, value).statusCode(), "etcd PUT via replica 0");
+
+      for (int idx = 1; idx <= 2; idx++) {
+        HttpResponse<String> rr = rangeKey(cluster, idx, key);
+        assertEquals(200, rr.statusCode(), "etcd RANGE via replica " + idx);
+        String decoded = decodeFirstKv(rr.body());
+        assertEquals(value, decoded, "key read from replica " + idx + " disagrees with replica 0");
+      }
+
+      // Check replica-info advertises the new coordinator + consistency tag.
+      HttpResponse<String> info =
+          cluster.sendGetRequest(SERVICE, "/api/v2/services/" + SERVICE + "/replica/info");
+      assertEquals(200, info.statusCode(), "replica/info request failed");
+      JSONObject infoJson = new JSONObject(info.body());
+      assertEquals(
+          "StatefulClusterReplicaCoordinator",
+          infoJson.getString("protocol"),
+          "expected the cluster coordinator");
+      assertEquals(
+          "cluster-managed",
+          infoJson.getString("consistency"),
+          "expected cluster-managed consistency tag");
+    }
+  }
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  private void waitForHealth(XdnTestCluster cluster, int replicaIdx, long deadlineNs)
+      throws Exception {
+    Exception last = null;
+    while (System.nanoTime() < deadlineNs) {
+      try {
+        HttpResponse<String> r = cluster.sendGetRequest(SERVICE, replicaIdx, "/health");
+        // etcd's /health returns 200 with {"health":"true"} when ready
+        if (r.statusCode() == 200 && r.body().contains("\"true\"")) {
+          return;
+        }
+        last = new IllegalStateException("replica " + replicaIdx + " not healthy: " + r.body());
+      } catch (Exception e) {
+        last = e;
+      }
+      Thread.sleep(1000);
+    }
+    throw new AssertionError("etcd replica " + replicaIdx + " never reported healthy", last);
+  }
+
+  private HttpResponse<String> putKey(XdnTestCluster cluster, int replicaIdx, String k, String v)
+      throws Exception {
+    JSONObject body = new JSONObject();
+    try {
+      body.put("key", Base64.getEncoder().encodeToString(k.getBytes()));
+      body.put("value", Base64.getEncoder().encodeToString(v.getBytes()));
+    } catch (JSONException e) {
+      throw new AssertionError(e);
+    }
+    return postJson(cluster, replicaIdx, "/v3/kv/put", body.toString());
+  }
+
+  private HttpResponse<String> rangeKey(XdnTestCluster cluster, int replicaIdx, String k)
+      throws Exception {
+    JSONObject body = new JSONObject();
+    try {
+      body.put("key", Base64.getEncoder().encodeToString(k.getBytes()));
+    } catch (JSONException e) {
+      throw new AssertionError(e);
+    }
+    return postJson(cluster, replicaIdx, "/v3/kv/range", body.toString());
+  }
+
+  private HttpResponse<String> postJson(
+      XdnTestCluster cluster, int replicaIdx, String path, String body) throws Exception {
+    int port = cluster.getActiveHttpPort("AR" + replicaIdx);
+    HttpRequest req =
+        HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + port + path))
+            .timeout(Duration.ofSeconds(10))
+            .header("XDN", SERVICE)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+    return http.send(req, HttpResponse.BodyHandlers.ofString());
+  }
+
+  private String decodeFirstKv(String rangeResponse) throws JSONException {
+    JSONObject json = new JSONObject(rangeResponse);
+    if (!json.has("kvs")) {
+      return null;
+    }
+    JSONObject first = json.getJSONArray("kvs").getJSONObject(0);
+    return new String(Base64.getDecoder().decode(first.getString("value")));
+  }
+}

--- a/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
+++ b/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
@@ -108,7 +108,8 @@ public class XdnClusterLaunchTest {
           return;
         }
         System.out.printf(
-            ">> health poll replica=%d status=%d body=%.60s%n", replicaIdx, r.statusCode(), r.body());
+            ">> health poll replica=%d status=%d body=%.60s%n",
+            replicaIdx, r.statusCode(), r.body());
         last = new IllegalStateException("replica " + replicaIdx + " not healthy: " + r.body());
       } catch (Exception e) {
         System.out.printf(">> health poll replica=%d threw %s%n", replicaIdx, e);

--- a/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
+++ b/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
@@ -92,6 +92,10 @@ public class XdnClusterLaunchTest {
           "cluster-managed",
           infoJson.getString("consistency"),
           "expected cluster-managed consistency tag");
+      assertEquals(
+          "cluster-managed",
+          infoJson.getString("requestedConsistency"),
+          "cluster services must not report the placeholder consistency as requested");
     }
   }
 

--- a/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
+++ b/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
@@ -107,8 +107,11 @@ public class XdnClusterLaunchTest {
         if (r.statusCode() == 200 && r.body().contains("\"true\"")) {
           return;
         }
+        System.out.printf(
+            ">> health poll replica=%d status=%d body=%.60s%n", replicaIdx, r.statusCode(), r.body());
         last = new IllegalStateException("replica " + replicaIdx + " not healthy: " + r.body());
       } catch (Exception e) {
+        System.out.printf(">> health poll replica=%d threw %s%n", replicaIdx, e);
         last = e;
       }
       Thread.sleep(1000);

--- a/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
+++ b/test/edu/umass/cs/xdn/XdnClusterLaunchTest.java
@@ -33,7 +33,10 @@ public class XdnClusterLaunchTest {
   private static final String SERVICE = "etcd-cluster-test";
   private static final int CLIENT_PORT = 2379;
   private static final int PEER_PORT = 2380;
-  private static final Duration LEADER_ELECTION_BUDGET = Duration.ofSeconds(45);
+  // Covers etcd leader election plus, on Docker Desktop, one readiness-gate round trip in
+  // the AR (30s wait + container restart + 30s re-wait) when the host port forward needs
+  // re-programming. See initContainerizedClusterService's readiness gate.
+  private static final Duration LEADER_ELECTION_BUDGET = Duration.ofSeconds(120);
 
   private final HttpClient http =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
@@ -55,10 +58,12 @@ public class XdnClusterLaunchTest {
           SERVICE, "xdn-etcd-cluster:test", "/etcd-data/", CLIENT_PORT, PEER_PORT, 3);
 
       // Wait for every replica's frontend to forward successfully — that's our proxy for
-      // "the cluster has elected a leader and is serving the v3 API."
-      long deadline = System.nanoTime() + LEADER_ELECTION_BUDGET.toNanos();
+      // "the cluster has elected a leader and is serving the v3 API." Each replica gets its
+      // own budget: with a single shared deadline, one slow replica (e.g. a Docker Desktop
+      // readiness-gate retry on another AR delaying quorum) starves the later replicas of
+      // poll time and the failure is misattributed to them.
       for (int idx = 0; idx < 3; idx++) {
-        waitForHealth(cluster, idx, deadline);
+        waitForHealth(cluster, idx, System.nanoTime() + LEADER_ELECTION_BUDGET.toNanos());
       }
 
       // Write a key through replica 0 and read it back through replicas 1 and 2. If etcd's

--- a/test/edu/umass/cs/xdn/XdnPortAllocatorTest.java
+++ b/test/edu/umass/cs/xdn/XdnPortAllocatorTest.java
@@ -1,0 +1,42 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.xdn.utils.PortAllocator;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/** Docker-free unit test for {@link PortAllocator}. */
+public class XdnPortAllocatorTest {
+
+  @Test
+  public void testAllocatesAboveEphemeralRange() {
+    for (int i = 0; i < 50; i++) {
+      int port = PortAllocator.allocate();
+      assertTrue(
+          port >= 61000 && port < 65000,
+          "port " + port + " outside [61000, 65000): must stay above Linux's ephemeral window");
+    }
+  }
+
+  @Test
+  public void testAllocatedPortIsImmediatelyBindable() throws Exception {
+    int port = PortAllocator.allocate();
+    try (ServerSocket s = new ServerSocket()) {
+      s.setReuseAddress(false);
+      s.bind(new InetSocketAddress(port));
+    }
+  }
+
+  @Test
+  public void testNoRepeatsWithinRecentWindow() {
+    Set<Integer> seen = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      int port = PortAllocator.allocate();
+      assertTrue(seen.add(port), "port " + port + " granted twice within the recent window");
+    }
+  }
+}

--- a/test/edu/umass/cs/xdn/XdnWordPressClusterTest.java
+++ b/test/edu/umass/cs/xdn/XdnWordPressClusterTest.java
@@ -1,0 +1,267 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.xdn.util.XdnTestCluster;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test for a <b>multi-component</b> cluster service: a self-clustering MySQL (Group
+ * Replication) stateful member plus a WordPress entry sidecar that shares the member's network
+ * namespace. This exercises the parts of cluster mode that {@link XdnClusterLaunchTest} (single
+ * etcd image) does not — multi-component placement and sidecar netns sharing — against a database
+ * that, unlike etcd/rqlite, has no one-flag clustering.
+ *
+ * <p>Asserts the two halves of the design (per the chosen scope: cluster forms + app reaches DB):
+ *
+ * <ul>
+ *   <li>The MySQL group converges: all 3 members report {@code ONLINE} in {@code
+ *       performance_schema.replication_group_members}.
+ *   <li>On every replica the WordPress sidecar reaches its local MySQL and serves (a fresh install
+ *       redirects to {@code wp-admin/install.php}); a DB-connection failure would instead surface
+ *       as HTTP 500.
+ * </ul>
+ *
+ * <p>Requires Docker + a swarm-initialized daemon (the test ensures this) and builds {@code
+ * xdn-mysql-cluster:test} from {@code services/mysql-cluster/}; WordPress is pulled on first run.
+ * This is heavier than the etcd test (3 MySQL members + 3 WordPress tiers), so the budgets below
+ * are generous.
+ */
+public class XdnWordPressClusterTest {
+
+  private static final String SERVICE = "wp-mysql-cluster";
+  private static final String MYSQL_IMAGE = "xdn-mysql-cluster:test";
+  private static final String WORDPRESS_IMAGE = "wordpress:6.5.4-apache";
+  private static final String ROOT_PW = "supersecret";
+  private static final int NUM_REPLICAS = 3;
+  private static final int PEER_PORT = 33061; // MySQL Group Replication group-comm port
+
+  // MySQL GR bootstrap is slow: each member runs a full datadir --initialize (tens of seconds),
+  // all 3 concurrently, before the group even forms — so this budget is deliberately large. The
+  // poll exits as soon as the group is up, so the ceiling only matters on failure.
+  private static final Duration GROUP_BUDGET = Duration.ofSeconds(360);
+  private static final Duration WORDPRESS_BUDGET = Duration.ofSeconds(180);
+
+  @Test
+  public void testWordPressMysqlClusterLaunch() throws Exception {
+    assertTrue(XdnTestCluster.isDockerAvailable(), "docker is required for this test");
+    assertTrue(
+        XdnTestCluster.ensureDockerSwarm(),
+        "cluster services need Swarm overlay networking — `docker swarm init` failed");
+    assertTrue(
+        XdnTestCluster.buildImage(MYSQL_IMAGE, "services/mysql-cluster/"),
+        "could not build " + MYSQL_IMAGE + " from services/mysql-cluster/");
+    // Pre-pull WordPress so it is not fetched (~600MB) on the cluster CREATE's critical path —
+    // the create starts containers synchronously, and an on-demand pull there times the POST out.
+    assertTrue(dockerPull(WORDPRESS_IMAGE), "could not pull " + WORDPRESS_IMAGE + " before launch");
+
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+      cluster.launchClusterService(SERVICE, buildSpec());
+
+      // (1) The MySQL group converges to NUM_REPLICAS ONLINE members. We read this by exec'ing
+      // into any one member container — replication_group_members reflects the whole group.
+      awaitOnlineMembers(NUM_REPLICAS, GROUP_BUDGET);
+
+      // (2) Every replica's WordPress reaches its (local, shared-netns) MySQL and serves. A fresh
+      // WordPress 302-redirects to the installer; a broken DB connection would be a 500 instead.
+      for (int idx = 0; idx < NUM_REPLICAS; idx++) {
+        HttpResponse<String> resp = awaitWordPressServing(cluster, idx, WORDPRESS_BUDGET);
+        assertTrue(
+            looksLikeWordPress(resp),
+            "replica "
+                + idx
+                + " did not look like a WordPress install page: status="
+                + resp.statusCode());
+      }
+
+      // XDN advertises the cluster coordinator through replica-info, same as the etcd test.
+      HttpResponse<String> info =
+          cluster.sendGetRequest(SERVICE, "/api/v2/services/" + SERVICE + "/replica/info");
+      assertEquals(200, info.statusCode(), "replica/info request failed");
+      JSONObject infoJson = new JSONObject(info.body());
+      assertEquals(
+          "StatefulClusterReplicaCoordinator",
+          infoJson.getString("protocol"),
+          "expected the cluster coordinator");
+    }
+  }
+
+  // ── service spec ───────────────────────────────────────────────────────────
+
+  /** The multi-component cluster spec: mysql (stateful member) + wordpress (entry sidecar). */
+  private JSONObject buildSpec() throws JSONException {
+    JSONObject mysql =
+        new JSONObject()
+            .put("image", MYSQL_IMAGE)
+            .put("stateful", true) // the cluster member: joins the overlay, runs Group Replication
+            .put("expose", 3306) // client port, reached by the sidecar at 127.0.0.1 (shared netns)
+            .put("environments", env("MYSQL_ROOT_PASSWORD", ROOT_PW));
+
+    JSONObject wordpress =
+        new JSONObject()
+            .put("image", WORDPRESS_IMAGE)
+            .put("port", 80) // entry port: published to the host, routed by the XDN frontend
+            .put("entry", true)
+            .put(
+                "environments",
+                new JSONArray()
+                    .put(kv("WORDPRESS_DB_HOST", "127.0.0.1")) // MySQL shares this netns
+                    .put(kv("WORDPRESS_DB_USER", "root"))
+                    .put(kv("WORDPRESS_DB_PASSWORD", ROOT_PW))
+                    .put(kv("WORDPRESS_DB_NAME", "wordpress"))
+                    .put(kv("WORDPRESS_CONFIG_EXTRA", "define('DISABLE_WP_CRON', true);")));
+
+    // mysql must be component index 0 (the stateful member); wordpress is the entry sidecar.
+    JSONArray components =
+        new JSONArray()
+            .put(new JSONObject().put("mysql", mysql))
+            .put(new JSONObject().put("wordpress", wordpress));
+
+    return new JSONObject()
+        .put("mode", "cluster")
+        .put("peer_port", PEER_PORT)
+        .put("num_replicas", NUM_REPLICAS)
+        .put("state", "mysql:/var/lib/mysql/")
+        .put("components", components);
+  }
+
+  private static JSONArray env(String key, String value) throws JSONException {
+    return new JSONArray().put(kv(key, value));
+  }
+
+  private static JSONObject kv(String key, String value) throws JSONException {
+    return new JSONObject().put(key, value);
+  }
+
+  // ── MySQL group-membership probe (via docker exec) ───────────────────────────
+
+  private void awaitOnlineMembers(int expected, Duration timeout) throws Exception {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    int last = -1;
+    while (System.nanoTime() < deadline) {
+      Integer online = onlineMemberCount();
+      if (online != null) {
+        last = online;
+        if (online >= expected) {
+          return;
+        }
+      }
+      Thread.sleep(3000);
+    }
+    throw new AssertionError(
+        "MySQL Group Replication never reached "
+            + expected
+            + " ONLINE members (last seen: "
+            + last
+            + ")");
+  }
+
+  /** Returns the count of ONLINE GR members, or null if no member container is queryable yet. */
+  private Integer onlineMemberCount() throws Exception {
+    String container = firstMysqlContainer();
+    if (container == null) {
+      return null;
+    }
+    ProcResult r =
+        runProcess(
+            List.of(
+                "docker",
+                "exec",
+                container,
+                "mysql",
+                "-uroot",
+                "-p" + ROOT_PW,
+                "-N",
+                "-B",
+                "-e",
+                "SELECT COUNT(*) FROM performance_schema.replication_group_members"
+                    + " WHERE MEMBER_STATE = 'ONLINE'"));
+    if (r.exitCode != 0) {
+      return null; // mysqld may not be accepting connections yet
+    }
+    try {
+      return Integer.parseInt(r.stdout.trim());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /** Finds one running MySQL cluster-member container by image, regardless of XDN's naming. */
+  private String firstMysqlContainer() throws Exception {
+    ProcResult r =
+        runProcess(
+            List.of(
+                "docker", "ps", "--filter", "ancestor=" + MYSQL_IMAGE, "--format", "{{.Names}}"));
+    if (r.exitCode != 0) {
+      return null;
+    }
+    for (String line : r.stdout.split("\\R")) {
+      if (!line.isBlank()) {
+        return line.trim();
+      }
+    }
+    return null;
+  }
+
+  // ── WordPress reachability probe (via the XDN frontend) ──────────────────────
+
+  private HttpResponse<String> awaitWordPressServing(
+      XdnTestCluster cluster, int replicaIdx, Duration timeout) throws Exception {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    HttpResponse<String> last = null;
+    while (System.nanoTime() < deadline) {
+      try {
+        HttpResponse<String> r =
+            cluster.sendGetRequest(SERVICE, replicaIdx, "/", Duration.ofSeconds(5));
+        last = r;
+        // 5xx means WordPress is up but cannot reach/select its database — keep waiting.
+        if (r.statusCode() < 500) {
+          return r;
+        }
+      } catch (Exception ignored) {
+        // frontend not forwarding yet
+      }
+      Thread.sleep(2000);
+    }
+    throw new AssertionError(
+        "WordPress on replica "
+            + replicaIdx
+            + " never served a non-5xx response"
+            + (last != null ? " (last status " + last.statusCode() + ")" : ""));
+  }
+
+  private boolean looksLikeWordPress(HttpResponse<String> resp) {
+    int code = resp.statusCode();
+    String location = resp.headers().firstValue("Location").orElse("");
+    String body = resp.body() == null ? "" : resp.body();
+    if (code == 301 || code == 302) {
+      return location.contains("install.php") || location.contains("wp-admin");
+    }
+    return code == 200 && (body.contains("WordPress") || body.contains("wp-admin"));
+  }
+
+  // ── tiny process helper (captures stdout; avoids Shell's whitespace-splitting) ──
+
+  private static boolean dockerPull(String image) throws Exception {
+    return runProcess(List.of("docker", "pull", image)).exitCode() == 0;
+  }
+
+  private record ProcResult(String stdout, String stderr, int exitCode) {}
+
+  private static ProcResult runProcess(List<String> command) throws Exception {
+    Process p = new ProcessBuilder(new ArrayList<>(command)).start();
+    String out = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    String err = new String(p.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+    int exit = p.waitFor();
+    return new ProcResult(out, err, exit);
+  }
+}

--- a/test/edu/umass/cs/xdn/util/XdnTestCluster.java
+++ b/test/edu/umass/cs/xdn/util/XdnTestCluster.java
@@ -7,6 +7,7 @@ import edu.umass.cs.reconfiguration.interfaces.ReconfigurableNodeConfig;
 import edu.umass.cs.reconfiguration.reconfigurationutils.DefaultNodeConfig;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.xdn.utils.Shell;
+import edu.umass.cs.xdn.utils.ShellOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -49,6 +50,9 @@ public class XdnTestCluster implements AutoCloseable {
   public static final Duration PORT_WAIT_TIMEOUT = Duration.ofSeconds(30);
   public static final Duration SERVICE_READY_TIMEOUT = Duration.ofSeconds(90);
   public static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+  // Cluster creates are synchronous on container startup (and may pull large images on first
+  // use), so the CREATE response can take far longer than a normal request.
+  public static final Duration CLUSTER_CREATE_TIMEOUT = Duration.ofSeconds(120);
 
   private final HttpClient httpClient =
       HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
@@ -165,13 +169,24 @@ public class XdnTestCluster implements AutoCloseable {
       throws IOException, InterruptedException, JSONException {
 
     JSONObject serviceJson = new JSONObject();
-    serviceJson.put("name", serviceName);
     serviceJson.put("image", imageName);
     serviceJson.put("port", httpPort);
     serviceJson.put("state", stateDirectory.endsWith("/") ? stateDirectory : stateDirectory + "/");
     serviceJson.put("mode", "cluster");
     serviceJson.put("peer_port", peerPort);
     serviceJson.put("num_replicas", numReplicas);
+    launchClusterService(serviceName, serviceJson);
+  }
+
+  /**
+   * Launches a cluster service from a fully-formed spec. The spec must already carry {@code
+   * mode:cluster}, {@code peer_port}, {@code num_replicas}, and either an {@code image}
+   * (single-image cluster) or a {@code components} array (multi-component cluster, e.g. a stateful
+   * DB member plus an entry sidecar). Used by {@code XdnWordPressClusterTest}.
+   */
+  public void launchClusterService(String serviceName, JSONObject serviceJson)
+      throws IOException, InterruptedException, JSONException {
+    serviceJson.put("name", serviceName);
 
     String initialState = "xdn:init:" + serviceJson;
     String encodedInitialState = URLEncoder.encode(initialState, StandardCharsets.UTF_8);
@@ -179,7 +194,11 @@ public class XdnTestCluster implements AutoCloseable {
         "http://%s:%d/?type=CREATE&name=%s&initial_state=%s"
             .formatted(LOOPBACK, getReconfiguratorHttpPort(), serviceName, encodedInitialState);
     HttpRequest request =
-        HttpRequest.newBuilder().uri(URI.create(endpoint)).timeout(REQUEST_TIMEOUT).GET().build();
+        HttpRequest.newBuilder()
+            .uri(URI.create(endpoint))
+            .timeout(CLUSTER_CREATE_TIMEOUT)
+            .GET()
+            .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     if (response.statusCode() != 200) {
       throw new IllegalStateException(
@@ -200,13 +219,23 @@ public class XdnTestCluster implements AutoCloseable {
    * {@link #launchClusterService} when running on a CI runner that may have a fresh Docker daemon.
    */
   public static boolean ensureDockerSwarm() {
-    int state =
-        Shell.runCommand(
-            "sh -c \"docker info --format '{{.Swarm.LocalNodeState}}' | grep -q active\"", true);
-    if (state == 0) {
+    // Detect an existing swarm by capturing the node state directly. We must NOT use a shell
+    // pipeline here ("docker info ... | grep ...") because Shell.runCommand splits the command
+    // on whitespace and runs it without a shell, so the quotes/pipe would be mangled and the
+    // check would always (wrongly) report "not a swarm". The Go-template has no spaces, so it
+    // survives the split as a single argument.
+    ShellOutput info =
+        Shell.runCommandWithOutput("docker info --format {{.Swarm.LocalNodeState}}", true);
+    if (info.exitCode == 0 && info.stdout.trim().equals("active")) {
       return true;
     }
-    return Shell.runCommand("docker swarm init", true) == 0;
+    if (Shell.runCommand("docker swarm init", true) == 0) {
+      return true;
+    }
+    // On hosts with multiple network interfaces, `docker swarm init` refuses to choose an
+    // advertise address ("could not choose an IP address ... use --advertise-addr"). Loopback
+    // is fine here: this single-node swarm exists only to enable attachable overlay networks.
+    return Shell.runCommand("docker swarm init --advertise-addr 127.0.0.1", true) == 0;
   }
 
   /**
@@ -214,8 +243,12 @@ public class XdnTestCluster implements AutoCloseable {
    * XdnClusterLaunchTest}; idempotent enough that calling it twice is harmless.
    */
   public static boolean buildEtcdClusterImage() {
-    return Shell.runCommand("docker build -t xdn-etcd-cluster:test services/etcd-cluster/", true)
-        == 0;
+    return buildImage("xdn-etcd-cluster:test", "services/etcd-cluster/");
+  }
+
+  /** Issues {@code docker build -t <tag> <contextDir>}; idempotent enough to call repeatedly. */
+  public static boolean buildImage(String tag, String contextDir) {
+    return Shell.runCommand("docker build -t " + tag + " " + contextDir, true) == 0;
   }
 
   /**

--- a/test/edu/umass/cs/xdn/util/XdnTestCluster.java
+++ b/test/edu/umass/cs/xdn/util/XdnTestCluster.java
@@ -189,18 +189,21 @@ public class XdnTestCluster implements AutoCloseable {
     serviceJson.put("name", serviceName);
 
     String initialState = "xdn:init:" + serviceJson;
-    String encodedInitialState = URLEncoder.encode(initialState, StandardCharsets.UTF_8);
+    // RESTful create: POST /api/v2/services/{name} with the initial state in the body,
+    // same path as launchService (the legacy GET /?type=CREATE control API is deprecated).
+    String body = new JSONObject().put("initial_state", initialState).toString();
     String endpoint =
-        "http://%s:%d/?type=CREATE&name=%s&initial_state=%s"
-            .formatted(LOOPBACK, getReconfiguratorHttpPort(), serviceName, encodedInitialState);
+        "http://%s:%d/api/v2/services/%s"
+            .formatted(LOOPBACK, getReconfiguratorHttpPort(), serviceName);
     HttpRequest request =
         HttpRequest.newBuilder()
             .uri(URI.create(endpoint))
             .timeout(CLUSTER_CREATE_TIMEOUT)
-            .GET()
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
             .build();
     HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-    if (response.statusCode() != 200) {
+    if (response.statusCode() / 100 != 2) {
       throw new IllegalStateException(
           "Cluster service creation failed with status " + response.statusCode());
     }

--- a/test/edu/umass/cs/xdn/util/XdnTestCluster.java
+++ b/test/edu/umass/cs/xdn/util/XdnTestCluster.java
@@ -151,6 +151,74 @@ public class XdnTestCluster implements AutoCloseable {
   }
 
   /**
+   * Launches a self-clustering service via {@code xdn cluster launch}'s wire format. Distinct from
+   * {@link #launchService}: this one omits consistency/deterministic, sets {@code mode:cluster},
+   * and requires {@code peer_port} + {@code num_replicas}. Used by {@code XdnClusterLaunchTest}.
+   */
+  public void launchClusterService(
+      String serviceName,
+      String imageName,
+      String stateDirectory,
+      int httpPort,
+      int peerPort,
+      int numReplicas)
+      throws IOException, InterruptedException, JSONException {
+
+    JSONObject serviceJson = new JSONObject();
+    serviceJson.put("name", serviceName);
+    serviceJson.put("image", imageName);
+    serviceJson.put("port", httpPort);
+    serviceJson.put("state", stateDirectory.endsWith("/") ? stateDirectory : stateDirectory + "/");
+    serviceJson.put("mode", "cluster");
+    serviceJson.put("peer_port", peerPort);
+    serviceJson.put("num_replicas", numReplicas);
+
+    String initialState = "xdn:init:" + serviceJson;
+    String encodedInitialState = URLEncoder.encode(initialState, StandardCharsets.UTF_8);
+    String endpoint =
+        "http://%s:%d/?type=CREATE&name=%s&initial_state=%s"
+            .formatted(LOOPBACK, getReconfiguratorHttpPort(), serviceName, encodedInitialState);
+    HttpRequest request =
+        HttpRequest.newBuilder().uri(URI.create(endpoint)).timeout(REQUEST_TIMEOUT).GET().build();
+    HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new IllegalStateException(
+          "Cluster service creation failed with status " + response.statusCode());
+    }
+    JSONObject responseJson = new JSONObject(response.body());
+    if (responseJson.optBoolean("FAILED", false)) {
+      throw new IllegalStateException(
+          "Cluster service creation failed: "
+              + responseJson.optString("RESPONSE_MESSAGE", "unknown error"));
+    }
+    createdServices.add(serviceName);
+  }
+
+  /**
+   * Idempotent: ensures the local Docker daemon is part of a swarm (single-node is fine). The
+   * attachable overlay networks that cluster services use require this. Tests should call it before
+   * {@link #launchClusterService} when running on a CI runner that may have a fresh Docker daemon.
+   */
+  public static boolean ensureDockerSwarm() {
+    int state =
+        Shell.runCommand(
+            "sh -c \"docker info --format '{{.Swarm.LocalNodeState}}' | grep -q active\"", true);
+    if (state == 0) {
+      return true;
+    }
+    return Shell.runCommand("docker swarm init", true) == 0;
+  }
+
+  /**
+   * Issues {@code docker build} for the etcd cluster reference image. Used by {@code
+   * XdnClusterLaunchTest}; idempotent enough that calling it twice is harmless.
+   */
+  public static boolean buildEtcdClusterImage() {
+    return Shell.runCommand("docker build -t xdn-etcd-cluster:test services/etcd-cluster/", true)
+        == 0;
+  }
+
+  /**
    * Waits for a service to respond with a successful HTTP status by periodically issuing requests.
    */
   public HttpResponse<String> awaitServiceReady(String serviceName, Duration timeout)

--- a/xdn-cli/cmd/cluster.go
+++ b/xdn-cli/cmd/cluster.go
@@ -1,0 +1,258 @@
+// Package cmd defines the Cobra command tree for the xdn CLI.
+//
+// cluster.go adds the `xdn cluster` command group, whose `launch` subcommand deploys a
+// *self-clustering* service (analogous to a Kubernetes StatefulSet). Unlike `xdn launch`,
+// where XDN performs the replication itself, a cluster service handles its own coordination
+// inside the containers (e.g. an etcd ensemble, a Postgres replication cluster). XDN's job
+// reduces to: placement, stable ordinal identity, a swarm overlay for peer discovery, and
+// routing client traffic to a replica's local container.
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+// ClusterRootCmd is the parent of all `xdn cluster *` subcommands.
+var ClusterRootCmd = &cobra.Command{
+	Use:   "cluster <action>",
+	Short: "Deploy and manage self-clustering replicated services (StatefulSet-style)",
+}
+
+// ClusterLaunchCmd implements `xdn cluster launch <name>`.
+var ClusterLaunchCmd = &cobra.Command{
+	Use:   "launch <service-name>",
+	Short: "Launch a self-clustering service (the container handles its own coordination)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		serviceName := args[0]
+
+		// File-based path: needed for multi-component clusters (e.g. bookcatalog + local
+		// rqlite sidecar) since flags can only express a single image.
+		if fileName, _ := cmd.Flags().GetString("file"); fileName != "" {
+			return runClusterLaunchFromFile(serviceName, fileName)
+		}
+
+		image, _ := cmd.Flags().GetString("image")
+		httpPort, _ := cmd.Flags().GetInt("port")
+		peerPort, _ := cmd.Flags().GetInt("peer-port")
+		stateDir, _ := cmd.Flags().GetString("state")
+		numReplicas, _ := cmd.Flags().GetInt("num-replicas")
+		rawEnv, _ := cmd.Flags().GetStringArray("env")
+
+		if err := validateServiceName(serviceName); err != nil {
+			return err
+		}
+		if err := validateImageName(image); err != nil {
+			return err
+		}
+		if peerPort < 1 || peerPort > 65535 {
+			return fmt.Errorf("--peer-port must be in 1..65535 (got %d)", peerPort)
+		}
+		if numReplicas < 1 {
+			return fmt.Errorf("--num-replicas must be >= 1 for a cluster service")
+		}
+		if stateDir == "" || !strings.HasSuffix(stateDir, "/") {
+			return fmt.Errorf("--state must be a non-empty absolute path ending with '/'")
+		}
+
+		// Build the JSON spec. mode:cluster is the only deviation from a regular launch;
+		// the validator and reconfigurator-side extractor read the same xdn:init: prefix.
+		config := map[string]interface{}{
+			"name":         serviceName,
+			"image":        image,
+			"port":         httpPort,
+			"state":        stateDir,
+			"mode":         "cluster",
+			"peer_port":    peerPort,
+			"num_replicas": numReplicas,
+		}
+		if envList, err := parseEnvFlags(rawEnv); err != nil {
+			return err
+		} else if len(envList) > 0 {
+			config["environments"] = envList
+		}
+		jsonBody, err := json.Marshal(config)
+		if err != nil {
+			return fmt.Errorf("failed to encode cluster spec: %w", err)
+		}
+
+		printClusterLaunchHeader(serviceName, image, httpPort, peerPort, numReplicas, stateDir)
+
+		if err := sendCreateRequest(serviceName, string(jsonBody)); err != nil {
+			return err
+		}
+
+		colorPrint := color.New(color.FgGreen).Add(color.Bold)
+		_, _ = colorPrint.Printf("Cluster service launched 🎉\n")
+		fmt.Printf("Inspect placement:   xdn service info %s\n", serviceName)
+		fmt.Printf("Tear down:           xdn service destroy %s\n", serviceName)
+		fmt.Println()
+		return nil
+	},
+}
+
+func init() {
+	ClusterLaunchCmd.Flags().StringP("image", "i", "", "docker image for each cluster replica (required)")
+	ClusterLaunchCmd.Flags().IntP("port", "p", 80, "HTTP entry port forwarded by XDN's frontend")
+	ClusterLaunchCmd.Flags().Int("peer-port", 0, "cluster's internal peer/protocol port (required)")
+	ClusterLaunchCmd.Flags().StringP("state", "s", "", "absolute state directory inside the container, ending with '/' (required)")
+	ClusterLaunchCmd.Flags().IntP("num-replicas", "n", 0, "fixed cluster size — number of replicas (required)")
+	ClusterLaunchCmd.Flags().StringArrayP("env", "e", []string{}, "environment variables for the cluster image (repeat: --env KEY=VALUE)")
+	ClusterLaunchCmd.Flags().StringP("file", "f", "", "YAML/JSON file with the cluster spec (required for multi-component clusters)")
+	// Flag-based path requires these; file-based path validates them inside the YAML instead.
+	// Bypass the cobra requireds when -f is used by un-marking after the fact in PreRunE.
+	ClusterLaunchCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if fileName, _ := cmd.Flags().GetString("file"); fileName != "" {
+			return nil
+		}
+		for _, f := range []string{"image", "peer-port", "state", "num-replicas"} {
+			if !cmd.Flags().Changed(f) {
+				return fmt.Errorf("--%s is required (or pass --file <spec.yaml>)", f)
+			}
+		}
+		return nil
+	}
+
+	ClusterRootCmd.AddCommand(ClusterLaunchCmd)
+}
+
+// runClusterLaunchFromFile reads a YAML/JSON cluster spec from disk and hands it to the
+// control plane. The file is the only way to declare a multi-component cluster (one stateful
+// member + one or more sidecars sharing its network namespace).
+func runClusterLaunchFromFile(serviceName, fileName string) error {
+	body, err := os.ReadFile(fileName)
+	if err != nil {
+		return fmt.Errorf("unable to read spec file %s: %w", fileName, err)
+	}
+	jsonBody, err := yaml.YAMLToJSON(body)
+	if err != nil {
+		return fmt.Errorf("unable to parse spec file %s: %w", fileName, err)
+	}
+	var spec map[string]interface{}
+	if err := json.Unmarshal(jsonBody, &spec); err != nil {
+		return fmt.Errorf("spec file is not valid JSON/YAML: %w", err)
+	}
+	specName, _ := spec["name"].(string)
+	if specName != "" && specName != serviceName {
+		return fmt.Errorf(
+			"service name on command line (%q) doesn't match spec file 'name' (%q)",
+			serviceName, specName)
+	}
+	if specName == "" {
+		// Default the name from the command line if the YAML omits it, so the user can reuse
+		// the same spec under different names.
+		spec["name"] = serviceName
+		jsonBody, _ = json.Marshal(spec)
+	}
+	// Sanity-check mode: we won't refuse a non-cluster spec here (the validator will), but a
+	// warning helps catch accidentally passing a regular-launch YAML to `xdn cluster launch`.
+	if m, _ := spec["mode"].(string); m != "cluster" && m != "clustered" {
+		colorPrint := color.New(color.FgYellow)
+		_, _ = colorPrint.Fprintf(os.Stderr,
+			"warning: spec file does not set mode: cluster; the control plane will reject it\n")
+	}
+
+	printClusterLaunchFileHeader(serviceName, fileName, spec)
+
+	if err := sendCreateRequest(serviceName, string(jsonBody)); err != nil {
+		return err
+	}
+	colorPrint := color.New(color.FgGreen).Add(color.Bold)
+	_, _ = colorPrint.Printf("Cluster service launched 🎉\n")
+	fmt.Printf("Inspect placement:   xdn service info %s\n", serviceName)
+	fmt.Printf("Tear down:           xdn service destroy %s\n", serviceName)
+	fmt.Println()
+	return nil
+}
+
+func printClusterLaunchFileHeader(name, fileName string, spec map[string]interface{}) {
+	colorPrint := color.New(color.FgYellow).Add(color.Bold).Add(color.Underline)
+	fmt.Printf("Launching cluster ")
+	_, _ = colorPrint.Printf("%s", name)
+	fmt.Printf(" from spec %s with the following configuration:\n", fileName)
+	if v, ok := spec["peer_port"]; ok {
+		fmt.Printf(" peer port     : %v\n", v)
+	}
+	if v, ok := spec["num_replicas"]; ok {
+		fmt.Printf(" num replicas  : %v\n", v)
+	}
+	if v, ok := spec["state"]; ok {
+		fmt.Printf(" state dir     : %v\n", v)
+	}
+	if comps, ok := spec["components"].([]interface{}); ok {
+		fmt.Printf(" components    :\n")
+		for _, c := range comps {
+			if m, ok := c.(map[string]interface{}); ok {
+				for cname, body := range m {
+					if bm, ok := body.(map[string]interface{}); ok {
+						img, _ := bm["image"].(string)
+						role := ""
+						if v, _ := bm["stateful"].(bool); v {
+							role += " stateful"
+						}
+						if v, _ := bm["entry"].(bool); v {
+							role += " entry"
+						}
+						fmt.Printf("   - %-12s %s%s\n", cname+":", img, role)
+					}
+				}
+			}
+		}
+	} else if v, ok := spec["image"]; ok {
+		fmt.Printf(" docker image  : %v\n", v)
+	}
+	fmt.Println()
+}
+
+func validateServiceName(name string) error {
+	if name == "" {
+		return errors.New("service name is required")
+	}
+	if len(name) > 64 {
+		return errors.New("service name cannot exceed 64 characters")
+	}
+	alphanumeric := regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
+	if !alphanumeric.MatchString(name) {
+		return errors.New("service name can only contain alphanumerics, '-', and '_'")
+	}
+	return nil
+}
+
+// parseEnvFlags converts the repeated --env KEY=VALUE flag values into the JSON shape that
+// ServiceProperty.parseEnvironmentVariables expects (a list of single-entry maps).
+func parseEnvFlags(raw []string) ([]map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]map[string]string, 0, len(raw))
+	for _, kv := range raw {
+		idx := strings.Index(kv, "=")
+		if idx <= 0 {
+			return nil, fmt.Errorf("invalid --env value %q (expected KEY=VALUE)", kv)
+		}
+		out = append(out, map[string]string{kv[:idx]: kv[idx+1:]})
+	}
+	return out, nil
+}
+
+func printClusterLaunchHeader(name, image string, httpPort, peerPort, n int, stateDir string) {
+	colorPrint := color.New(color.FgYellow).Add(color.Bold).Add(color.Underline)
+	fmt.Printf("Launching cluster ")
+	_, _ = colorPrint.Printf("%s", name)
+	fmt.Printf(" with the following configuration:\n")
+	fmt.Printf(" docker image  : %s\n", image)
+	fmt.Printf(" http port     : %d  (XDN frontend → local replica)\n", httpPort)
+	fmt.Printf(" peer port     : %d  (cluster-internal; on overlay only)\n", peerPort)
+	fmt.Printf(" state dir     : %s\n", stateDir)
+	fmt.Printf(" num replicas  : %d\n", n)
+	fmt.Println()
+}

--- a/xdn-cli/cmd/launch.go
+++ b/xdn-cli/cmd/launch.go
@@ -435,6 +435,86 @@ func validateImageName(imageName string) error {
 	return nil
 }
 
+// sendCreateRequest wraps rawJSON with the xdn:init: prefix and issues the gigapaxos CREATE
+// request to the control plane. Returns nil on success or an error otherwise; prints the
+// failure message to stderr in either case so callers don't have to. Shared by both the
+// regular `xdn launch` and `xdn cluster launch` paths.
+func sendCreateRequest(serviceName, rawJSON string) error {
+	errColorPrint := color.New(color.FgRed).Add(color.Bold).Add(color.Underline)
+	controlPlane := os.Getenv("XDN_CONTROL_PLANE")
+	if controlPlane == "" {
+		controlPlane = DEFAULT_CONTROL_PLANE
+	}
+	controlPlaneHost := fmt.Sprintf("%s:%d", controlPlane, CONTROL_PLANE_PORT)
+
+	// Contact the control plane to actually deploy the service (RESTful create:
+	// POST /api/v2/services/{name} with the initial state in the JSON body).
+	encodedInitialState := fmt.Sprintf("xdn:init:%s", rawJSON)
+	createBody, err := json.Marshal(struct {
+		InitialState string `json:"initial_state"`
+	}{InitialState: encodedInitialState})
+	if err != nil {
+		fmt.Printf(" ")
+		_, _ = errColorPrint.Printf("ERROR")
+		fmt.Printf(": Failed to encode launch request: %s\n", err.Error())
+		return fmt.Errorf("failed to encode launch request: %s", err.Error())
+	}
+	createEndpoint := fmt.Sprintf("http://%s/api/v2/services/%s",
+		controlPlaneHost, serviceName)
+	httpReq, err := http.NewRequest(http.MethodPost, createEndpoint, bytes.NewReader(createBody))
+	if err != nil {
+		fmt.Printf(" ")
+		_, _ = errColorPrint.Printf("ERROR")
+		fmt.Printf(": Failed to build launch request: %s\n", err.Error())
+		return fmt.Errorf("failed to build launch request: %s", err.Error())
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	client := http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			fmt.Printf(" ")
+			_, _ = errColorPrint.Printf("ERROR")
+			fmt.Printf(": Cannot reach XDN control plane at `%s`.\n\n", controlPlane)
+			fmt.Printf(" Is the Control Plane running there?\n\n")
+			return fmt.Errorf("cannot reach XDN control plane at `%s`", controlPlane)
+		}
+		fmt.Printf(" ")
+		_, _ = errColorPrint.Printf("ERROR")
+		fmt.Printf(": Failed to launch the service: \n%s\n", err.Error())
+		return fmt.Errorf("cannot send launch request to XDN control plane at `%s`", controlPlane)
+	}
+	// RESTful create returns 201 Created on success (202/200 also tolerated).
+	if resp.StatusCode/100 != 2 {
+		fmt.Printf(" ")
+		_, _ = errColorPrint.Printf("ERROR")
+		fmt.Printf(": Failed to launch the service, received non success code.\n")
+		return fmt.Errorf("failed to launch the service, received http non success code %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf(" ")
+		_, _ = errColorPrint.Printf("ERROR")
+		fmt.Printf(": Failed to launch the service: \n%s\n", err.Error())
+		return fmt.Errorf("failed to launch the service, error reading the response: %s", err.Error())
+	}
+
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "\"FAILED\":true") {
+		fmt.Printf(" ")
+		_, _ = errColorPrint.Printf("ERROR")
+		fmt.Printf(" ")
+		fmt.Printf("Failed to launch the service: \n")
+		var jsonMap map[string]interface{}
+		_ = json.Unmarshal([]byte(bodyStr), &jsonMap)
+		errMsg, _ := jsonMap["RESPONSE_MESSAGE"].(string)
+		fmt.Printf(" %s\n", errMsg)
+		return fmt.Errorf("failed to launch the service, error: %s", errMsg)
+	}
+	return nil
+}
+
 func runLaunchCommand(prop CommonProperties) error {
 	colorPrint := color.New(color.FgYellow).Add(color.Bold).Add(color.Underline)
 	errColorPrint := color.New(color.FgRed).Add(color.Bold).Add(color.Underline)
@@ -478,72 +558,8 @@ func runLaunchCommand(prop CommonProperties) error {
 		return fmt.Errorf("cannot reach XDN control plane at `%s`", controlPlane)
 	}
 
-	// contact the control plane to actually deploy the service (RESTful create:
-	// POST /api/v2/services/{name} with the initial state in the JSON body).
-	encodedInitialState := fmt.Sprintf("xdn:init:%s", prop.rawJsonProperties)
-	createBody, err := json.Marshal(struct {
-		InitialState string `json:"initial_state"`
-	}{InitialState: encodedInitialState})
-	if err != nil {
-		fmt.Printf(" ")
-		_, _ = errColorPrint.Printf("ERROR")
-		fmt.Printf(": Failed to encode launch request: %s\n", err.Error())
-		return fmt.Errorf("failed to encode launch request: %s", err.Error())
-	}
-	createEndpoint := fmt.Sprintf("http://%s/api/v2/services/%s",
-		controlPlaneHost, prop.serviceName)
-	httpReq, err := http.NewRequest(http.MethodPost, createEndpoint, bytes.NewReader(createBody))
-	if err != nil {
-		fmt.Printf(" ")
-		_, _ = errColorPrint.Printf("ERROR")
-		fmt.Printf(": Failed to build launch request: %s\n", err.Error())
-		return fmt.Errorf("failed to build launch request: %s", err.Error())
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	client := http.Client{Timeout: 60 * time.Second}
-	resp, err := client.Do(httpReq)
-	if err != nil {
-		if errors.Is(err, syscall.ECONNREFUSED) {
-			fmt.Printf(" ")
-			_, _ = errColorPrint.Printf("ERROR")
-			fmt.Printf(": Cannot reach XDN control plane at `%s`.\n\n",
-				controlPlane)
-			fmt.Printf(" Is the Control Plane running there?\n\n")
-			return fmt.Errorf("cannot reach XDN control plane at `%s`", controlPlane)
-		}
-		fmt.Printf(" ")
-		_, _ = errColorPrint.Printf("ERROR")
-		fmt.Printf(": Failed to launch the service: \n%s\n", err.Error())
-		return fmt.Errorf("cannot send launch request to XDN control plane at `%s`", controlPlane)
-	}
-	// RESTful create returns 201 Created on success (202/200 also tolerated).
-	if resp.StatusCode/100 != 2 {
-		fmt.Printf(" ")
-		_, _ = errColorPrint.Printf("ERROR")
-		fmt.Printf(": Failed to launch the service, received non success code.\n")
-		return fmt.Errorf("failed to launch the service, received http non success code %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Printf(" ")
-		_, _ = errColorPrint.Printf("ERROR")
-		fmt.Printf(": Failed to launch the service: \n%s\n", err.Error())
-		return fmt.Errorf("failed to launch the service, error reading the response: %s", err.Error())
-	}
-
-	bodyStr := string(body)
-	if strings.Contains(bodyStr, "\"FAILED\":true") {
-		fmt.Printf(" ")
-		_, _ = errColorPrint.Printf("ERROR")
-		fmt.Printf(" ")
-		fmt.Printf("Failed to launch the service: \n")
-		var jsonMap map[string]interface{}
-		_ = json.Unmarshal([]byte(bodyStr), &jsonMap)
-		errMsgIf := jsonMap["RESPONSE_MESSAGE"]
-		errMsg := errMsgIf.(string)
-		fmt.Printf(" %s\n", errMsg)
-		return fmt.Errorf("failed to launch the service, error: %s", errMsg)
+	if err := sendCreateRequest(prop.serviceName, prop.rawJsonProperties); err != nil {
+		return err
 	}
 
 	dummyServiceURL := colorPrint.Sprintf(

--- a/xdn-cli/cmd/root.go
+++ b/xdn-cli/cmd/root.go
@@ -56,6 +56,7 @@ func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.AddCommand(LaunchCmd)
 	rootCmd.AddCommand(ServiceRootCmd)
+	rootCmd.AddCommand(ClusterRootCmd)
 }
 
 func Execute() {


### PR DESCRIPTION
## Summary

Adds **cluster-mode** ("StatefulSet-style") services to XDN: N replicas form a
single self-clustering application (etcd, rqlite, …) over a Docker Swarm overlay
network, coordinated by a dedicated replica coordinator.

Rebased onto current `main` and split into reviewable commits. The live-migration
PoC that shared this branch is **intentionally excluded** (kept on a separate
branch — it's an unintegrated research spike with no source-code footprint).

## Commits

1. **add stateful cluster service coordinator** — `cluster/` package
   (`StatefulClusterReplicaCoordinator`, `ClusterTopology`, `ClusterTopologyAware`,
   `SwarmOverlayManager`); `ServiceProperty` cluster fields + `DeploymentMode`;
   routing in `XdnReplicaCoordinator` and a cluster branch in `XdnGigapaxosApp`;
   a relaxed `PaxosInstanceStateMachine` entry-replica assertion for numeric node IDs.
2. **add `xdn cluster` CLI and docker swarm bootstrap** — new CLI command;
   `xdnd dist-init` bootstraps Swarm so overlays span hosts; `xdn-cluster-up.sh`
   + cloudlab config for a 4-host deployment.
3. **add etcd and rqlite cluster reference services** — example self-clustering
   services + a bookcatalog-on-rqlite descriptor.
4. **add cluster launch test, CI wiring, and docs** — `XdnClusterLaunchTest`,
   `XdnTestCluster` cluster support, CI matrix entry, `CLAUDE.md` section.

## Testing

- `ant clean jar xdn-compile-tests` — builds clean against current `main`.
- `XdnClusterLaunchTest` exercises cluster launch in CI (needs Docker Swarm).