### PR TITLE
IPv6 deployment for XDN (consensus + data plane)

### DIFF
--- a/aws/ar-userdata.tftpl
+++ b/aws/ar-userdata.tftpl
@@ -49,6 +49,8 @@ cat > /opt/xdn/bin/xdn-tls-pull.sh <<'PULL'
 #!/usr/bin/env bash
 set -euo pipefail
 export AWS_REGION="${aws_region}"
+# ARs are IPv6-only (no public IPv4), so reach S3 over its dual-stack (IPv6) endpoint.
+export AWS_USE_DUALSTACK_ENDPOINT=true
 b="${tls_bucket}"
 dst=/opt/xdn/conf/tls
 install -d -m 0755 "$dst"

--- a/aws/ar-userdata.tftpl
+++ b/aws/ar-userdata.tftpl
@@ -21,13 +21,13 @@ ACTIVE_REPLICA_TLS_CERT_CHAIN=/opt/xdn/conf/tls/fullchain.pem
 ACTIVE_REPLICA_TLS_PRIVATE_KEY=/opt/xdn/conf/tls/privkey.pem
 TLSPROPS
 
-# node id + JVM opts. JAVA_TOOL_OPTIONS forces the IPv4 stack: gigapaxos
-# RequestPacket.toBytes assumes 4-byte (IPv4) addresses, but on this dual-stack
-# VPC the wildcard bind fallback (the public EIP is not bindable) would be IPv6
-# (16 bytes), breaking Paxos packet serialization (AssertionError "N != M").
+# node id + JVM opts. The gigapaxos wire format is now IPv6-capable (16-byte
+# addresses, see AddressCodec), so we NO LONGER force the IPv4 stack -- the AR
+# advertises and binds its GLOBAL IPv6 for consensus, and the TLS frontend binds
+# that IPv6 on :443. preferIPv6Addresses nudges name resolution toward IPv6.
 cat > /opt/xdn/conf/node-id <<'NODEID'
 NODE_ID=${node_id}
-JAVA_TOOL_OPTIONS=-Djava.net.preferIPv4Stack=true
+JAVA_TOOL_OPTIONS=-Djava.net.preferIPv6Addresses=true
 NODEID
 
 # AWS CLI is needed to pull the cert from S3 (not baked into the current AMI).

--- a/aws/last-built-amis.txt
+++ b/aws/last-built-amis.txt
@@ -3,3 +3,5 @@ xdn-rc-20260529-044253	ami-0af90e71c86a6ac6b	us-east-1
 xdn-ar-20260601-163424	ami-02037dbf544575eef	us-east-1
 xdn-ar-20260601-225129	ami-0beb9798e469f1fc7	us-east-1
 xdn-ar-20260602-000227	ami-0895cd15a28b707aa	us-east-1
+xdn-ar-20260602-140003	ami-05ab6b5c1b45eb8dd	us-east-1
+xdn-rc-20260602-135957	ami-0281566cb7fdbd374	us-east-1

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -251,13 +251,13 @@ resource "aws_key_pair" "deployer" {
 variable "rc_ami" {
   description = "AMI for the Reconfigurator (RC) + coredns node (includes docker-ce-cli for CREATE-time image validation)."
   type        = string
-  default     = "ami-0af90e71c86a6ac6b"
+  default     = "ami-0281566cb7fdbd374" # IPv6: coredns AAAA + IPv6-consensus jar
 }
 
 variable "ar_ami" {
   description = "AMI for the ActiveReplica (AR) edge nodes."
   type        = string
-  default     = "ami-0895cd15a28b707aa"
+  default     = "ami-05ab6b5c1b45eb8dd" # IPv6 + TLS jar
 }
 
 variable "ar_count" {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -187,18 +187,9 @@ resource "aws_security_group" "allow_ssh_ipv6" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-  # Rule B5: intra-cluster traffic over PUBLIC IPs. Because gigapaxos.properties
-  #          advertises the nodes' EIPs, consensus (e.g. :2000, :3000) flows
-  #          node->node via public IPs. Allow all ports ONLY from the cluster's
-  #          own EIPs -- this keeps :2000/:3000 off the open internet (they are
-  #          NOT in any 0.0.0.0/0 rule) while letting members reach each other.
-  ingress {
-    description = "Intra-cluster consensus over public IPs (RC + AR EIPs only)"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = concat(["${aws_eip.rc.public_ip}/32"], [for e in aws_eip.ar : "${e.public_ip}/32"])
-  }
+  # (Former Rule B5 -- intra-cluster consensus over public IPv4 EIPs -- removed:
+  #  consensus now flows over IPv6 (Rule B6), and the ARs no longer have public
+  #  IPv4. The RC keeps its EIP for management/DNS only.)
 
   # Rule B6: intra-cluster consensus over IPv6. gigapaxos now advertises the
   #          nodes' GLOBAL IPv6 addresses, so consensus (:2000/:3000) and the
@@ -364,14 +355,15 @@ resource "aws_instance" "rc" {
 
 # 9b. ActiveReplica edge nodes, one per remaining subnet (subnet[i+1]).
 resource "aws_instance" "ar" {
-  count                  = var.ar_count
-  ami                    = var.ar_ami
-  instance_type          = "t3.large"
-  subnet_id              = aws_subnet.ipv6_subnets[count.index + 1].id
-  private_ip             = local.ar_private_ips[count.index]
-  ipv6_addresses         = [local.ar_ipv6s[count.index]] # consensus + frontend bind
-  vpc_security_group_ids = [aws_security_group.allow_ssh_ipv6.id]
-  key_name               = aws_key_pair.deployer.key_name
+  count                       = var.ar_count
+  ami                         = var.ar_ami
+  instance_type               = "t3.large"
+  subnet_id                   = aws_subnet.ipv6_subnets[count.index + 1].id
+  private_ip                  = local.ar_private_ips[count.index]
+  ipv6_addresses              = [local.ar_ipv6s[count.index]] # consensus + frontend bind
+  associate_public_ip_address = false                         # IPv6-only: no billed public IPv4
+  vpc_security_group_ids      = [aws_security_group.allow_ssh_ipv6.id]
+  key_name                    = aws_key_pair.deployer.key_name
 
   # Lets the baked Caddy answer the ACME DNS-01 challenge via Route53 (no keys).
   iam_instance_profile = aws_iam_instance_profile.ar_acme.name
@@ -412,22 +404,11 @@ resource "aws_eip_association" "rc" {
   allocation_id = aws_eip.rc.id
 }
 
-# 10b. Stable public IPs for the ARs. Required now that gigapaxos.properties
-#      advertises public addresses: coredns returns these to clients, so they
-#      must be stable (ephemeral IPs change on stop/start and would break DNS).
-#      Allocated standalone (no instance) so the AR user_data can reference them
-#      without a dependency cycle.
-resource "aws_eip" "ar" {
-  count  = var.ar_count
-  domain = "vpc"
-  tags   = { Name = "xdn-ar-eip-${count.index}" }
-}
-
-resource "aws_eip_association" "ar" {
-  count         = var.ar_count
-  instance_id   = aws_instance.ar[count.index].id
-  allocation_id = aws_eip.ar[count.index].id
-}
+# 10b. (Removed) The ARs no longer have public IPv4. Their data plane is IPv6
+#      (coredns returns AAAA -> the AR's global IPv6) and their egress is IPv6
+#      (Docker Hub/S3-dualstack/apt all reachable over IPv6). SSH/management is
+#      via the RC as a jump host over the private/IPv6 path. This drops 3 billed
+#      public IPv4 addresses.
 
 # 10c. ACME DNS-01 delegation zone.
 #      coredns (the xdn plugin) is authoritative for the apex and only knows how
@@ -606,17 +587,17 @@ output "rc_elastic_ip" {
   description = "RC address for everything (SSH, XDN_CONTROL_PLANE :3300, and the xdnapp.com authoritative NS). The instance's auto-assigned public IP is released once this EIP attaches, so always use this."
 }
 
-output "ar_public_ips" {
-  value       = aws_eip.ar[*].public_ip
-  description = "Elastic IPs of the ActiveReplica nodes (also what coredns returns for service names)."
+output "ar_ipv6_addresses" {
+  value       = local.ar_ipv6s
+  description = "Global IPv6 of the ActiveReplica nodes (what coredns returns as AAAA for <service>.xdnapp.com). The ARs have no public IPv4."
 }
 
 output "cluster_node_addresses" {
   value = merge(
-    { "0" = "${aws_eip.rc.public_ip} (RC)" },
-    { for i in range(var.ar_count) : tostring(i + 1) => "${aws_eip.ar[i].public_ip} (AR)" },
+    { "0" = "${aws_eip.rc.public_ip} (RC, IPv4 mgmt) / [${local.rc_ipv6}] (consensus)" },
+    { for i in range(var.ar_count) : tostring(i + 1) => "[${local.ar_ipv6s[i]}] (AR, IPv6-only)" },
   )
-  description = "Numeric node id -> PUBLIC address advertised in gigapaxos.properties (node 0 is the RC)."
+  description = "Numeric node id -> advertised consensus address (IPv6). The RC also keeps an IPv4 EIP for management/DNS."
 }
 
 output "acme_delegation_ns" {

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -200,6 +200,20 @@ resource "aws_security_group" "allow_ssh_ipv6" {
     cidr_blocks = concat(["${aws_eip.rc.public_ip}/32"], [for e in aws_eip.ar : "${e.public_ip}/32"])
   }
 
+  # Rule B6: intra-cluster consensus over IPv6. gigapaxos now advertises the
+  #          nodes' GLOBAL IPv6 addresses, so consensus (:2000/:3000) and the
+  #          client-facing offset ports flow node->node over IPv6. Allow all
+  #          ports from the VPC's own IPv6 range (only the cluster nodes live
+  #          there) -- keeps consensus off the open internet while letting
+  #          members reach each other over IPv6.
+  ingress {
+    description      = "Intra-cluster consensus over IPv6 (VPC range only)"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    ipv6_cidr_blocks = [aws_vpc.ipv6_vpc.ipv6_cidr_block]
+  }
+
   # Rule C: Allow all 4 servers to talk to each other on any port (private path)
   ingress {
     description = "Allow all internal VPC traffic"
@@ -277,12 +291,24 @@ locals {
   rc_private_ip  = "10.0.1.10" # in subnet[0] = 10.0.1.0/24
   ar_private_ips = [for i in range(var.ar_count) : "10.0.${i + 2}.10"]
 
+  # Static GLOBAL IPv6 per node, derived from each subnet's /64 (host ::10).
+  # Unlike the IPv4 EIP (NAT'd, not locally bindable), an instance's IPv6 is on
+  # its ENI and IS directly bindable -- so gigapaxos can advertise AND bind the
+  # same IPv6 for consensus. Derived from the subnet (not the instance), so
+  # using it in both ipv6_addresses and user_data creates no dependency cycle.
+  # Note: the subnet IPv6 CIDR is known only after apply (AWS assigns the VPC
+  # block), which is fine -- these resolve at apply time.
+  rc_ipv6  = cidrhost(aws_subnet.ipv6_subnets[0].ipv6_cidr_block, 10)
+  ar_ipv6s = [for i in range(var.ar_count) : cidrhost(aws_subnet.ipv6_subnets[i + 1].ipv6_cidr_block, 10)]
+
   # gigapaxos cluster config shared by every node. Numeric node ids: RC=0, ARs=1..N.
-  # Nodes advertise their PUBLIC Elastic IPs so that coredns returns
-  # client-reachable addresses for <service>.xdnapp.com (and geo-routing works on
-  # real geolocated IPs). Consequence: consensus traffic flows node->node over
-  # public IPs; ports 2000/3000 are therefore restricted to the cluster's own
-  # EIPs in the security group (Rule B5) and never exposed to the open internet.
+  # Nodes advertise their GLOBAL IPv6 addresses for consensus (reconfigurator/
+  # active) -- the gigapaxos wire format is now IPv6-capable (16-byte addresses,
+  # see AddressCodec) and the JVM no longer forces the IPv4 stack. coredns returns
+  # these IPv6 addresses as AAAA for <service>.xdnapp.com, so the data plane is
+  # IPv6 too. IPv4 EIPs remain for SSH, the registrar NS glue, cp/rc/ns, and the
+  # ACME DNS-01 path. Consensus ports (2000/3000) are reachable node->node over
+  # IPv6 within the VPC (security group Rule B6), not exposed to the open internet.
   gigapaxos_properties = join("\n", concat([
     "APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp",
     "REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator",
@@ -299,9 +325,9 @@ locals {
     # RC control-plane API on :3300, which xdn-cli + coredns depend on
     # (default true; set explicitly for clarity).
     "ENABLE_RECONFIGURATOR_HTTP=true",
-    "reconfigurator.0=${aws_eip.rc.public_ip}:3000",
+    "reconfigurator.0=[${local.rc_ipv6}]:3000",
     ], [
-    for i in range(var.ar_count) : "active.${i + 1}=${aws_eip.ar[i].public_ip}:2000"
+    for i in range(var.ar_count) : "active.${i + 1}=[${local.ar_ipv6s[i]}]:2000"
   ]))
 }
 
@@ -311,6 +337,7 @@ resource "aws_instance" "rc" {
   instance_type          = "t3.large"
   subnet_id              = aws_subnet.ipv6_subnets[0].id
   private_ip             = local.rc_private_ip
+  ipv6_addresses         = [local.rc_ipv6] # consensus advertises + binds this
   vpc_security_group_ids = [aws_security_group.allow_ssh_ipv6.id]
   key_name               = aws_key_pair.deployer.key_name
 
@@ -342,6 +369,7 @@ resource "aws_instance" "ar" {
   instance_type          = "t3.large"
   subnet_id              = aws_subnet.ipv6_subnets[count.index + 1].id
   private_ip             = local.ar_private_ips[count.index]
+  ipv6_addresses         = [local.ar_ipv6s[count.index]] # consensus + frontend bind
   vpc_security_group_ids = [aws_security_group.allow_ssh_ipv6.id]
   key_name               = aws_key_pair.deployer.key_name
 

--- a/aws/rc-userdata.tftpl
+++ b/aws/rc-userdata.tftpl
@@ -10,14 +10,13 @@ cat > /opt/xdn/conf/gigapaxos.properties <<'PROPS'
 ${gigapaxos_properties}
 PROPS
 
-# node id + JVM opts (RC = node 0). JAVA_TOOL_OPTIONS forces the IPv4 stack:
-# gigapaxos RequestPacket.toBytes assumes 4-byte (IPv4) addresses, but on this
-# dual-stack VPC the wildcard bind fallback (the public EIP is not bindable)
-# would be IPv6 (16 bytes), breaking Paxos packet serialization. The xdn-rc unit
-# reads this file via EnvironmentFile, so the JVM picks it up.
+# node id + JVM opts (RC = node 0). The gigapaxos wire format is now IPv6-capable
+# (16-byte addresses, see AddressCodec), so we NO LONGER force the IPv4 stack --
+# the RC advertises and binds its GLOBAL IPv6 for consensus. preferIPv6Addresses
+# nudges name resolution toward IPv6. The xdn-rc unit reads this via EnvironmentFile.
 cat > /opt/xdn/conf/node-id <<'NODEID'
 NODE_ID=0
-JAVA_TOOL_OPTIONS=-Djava.net.preferIPv4Stack=true
+JAVA_TOOL_OPTIONS=-Djava.net.preferIPv6Addresses=true
 NODEID
 
 # Resolve the Route53 nameservers of the delegated _acme-challenge zone to IPs.

--- a/src/edu/umass/cs/gigapaxos/paxospackets/RequestPacket.java
+++ b/src/edu/umass/cs/gigapaxos/paxospackets/RequestPacket.java
@@ -38,6 +38,7 @@ import edu.umass.cs.gigapaxos.paxosutil.Ballot;
 import edu.umass.cs.gigapaxos.paxosutil.IntegerMap;
 import edu.umass.cs.gigapaxos.testing.TESTPaxosConfig.TC;
 import edu.umass.cs.nio.JSONNIOTransport;
+import edu.umass.cs.nio.nioutils.AddressCodec;
 import edu.umass.cs.nio.interfaces.Byteable;
 import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.utils.Config;
@@ -284,7 +285,7 @@ public class RequestPacket extends PaxosPacket implements Request,
 		case "short":
 			return Short.BYTES;
 		case "InetSocketAddress":
-			return Integer.BYTES + Short.BYTES;
+			return AddressCodec.SOCKADDR_BYTES;
 		}
 		assert (false) : clazz;
 		return -1;
@@ -775,9 +776,9 @@ public class RequestPacket extends PaxosPacket implements Request,
 	protected static final int SIZEOF_REQUEST_FIXED = 8 // long requestID
 			+ 1 // boolean stop
 
-			+ Integer.BYTES // client IP
+			+ AddressCodec.ADDRESS_BYTES // client IP (16B, IPv4-mapped)
 			+ Short.BYTES // client port
-			+ Integer.BYTES // received IP
+			+ AddressCodec.ADDRESS_BYTES // received IP (16B, IPv4-mapped)
 			+ Short.BYTES // received port
 
 			+ Integer.BYTES // int entryReplica
@@ -853,26 +854,14 @@ public class RequestPacket extends PaxosPacket implements Request,
 			bbuf.put(this.stop ? (byte) 1 : (byte) 0);
 			exactLength += (Long.BYTES + 1);
 
-			// addresses
-			/* Note: 0 is ambiguous with wildcard address, but that's okay
-			 * because an incoming packet will never come with a wildcard
-			 * address. */
-			bbuf.put(this.clientAddress != null ? this.clientAddress
-					.getAddress().getAddress() : new byte[4]);
-			// 0 (not -1) means invalid port
-			bbuf.putShort(this.clientAddress != null ? (short) this.clientAddress
-					.getPort() : 0);
-			/* Note: 0 is an ambiguous wildcard address that could also be a
-			 * legitimate value of the listening socket address. If the request
-			 * happens to have no listening address, we will end up assuming it
-			 * was received on the wildcard address. At worst, the matching for
-			 * the corresponding response back to the client can fail. */
-			bbuf.put(this.listenAddress != null ? this.listenAddress
-					.getAddress().getAddress() : new byte[4]);
-			// 0 (not -1) means invalid port
-			bbuf.putShort(this.listenAddress != null ? (short) this.listenAddress
-					.getPort() : 0);
-			exactLength += 2 * (Integer.BYTES + Short.BYTES);
+			// addresses (each 16-byte IPv4-mapped IP + 2-byte port; AddressCodec).
+			/* Note: port 0 means "no address" on read. 0 is ambiguous with the
+			 * wildcard address, but that's okay because an incoming packet will
+			 * never come with a wildcard address; and for the listen address, at
+			 * worst the matching of the response back to the client can fail. */
+			AddressCodec.put(bbuf, this.clientAddress);
+			AddressCodec.put(bbuf, this.listenAddress);
+			exactLength += 2 * AddressCodec.SOCKADDR_BYTES;
 
 			// other non-final fields
 			bbuf.putInt(this.entryReplica);
@@ -958,20 +947,11 @@ public class RequestPacket extends PaxosPacket implements Request,
 		this.stop = bbuf.get() == (byte) 1;
 		exactLength += (8 + 1);
 
-		// addresses
-		byte[] ca = new byte[4];
-		bbuf.get(ca);
-		int cport = (int) bbuf.getShort();
-		cport = cport >= 0 ? cport : cport + 2 * (Short.MAX_VALUE + 1);
-		this.clientAddress = cport != 0 ? new InetSocketAddress(
-				InetAddress.getByAddress(ca), cport) : null;
-		byte[] la = new byte[4];
-		bbuf.get(la);
-		int lport = (int) bbuf.getShort();
-		lport = lport >= 0 ? lport : lport + 2 * (Short.MAX_VALUE + 1);
-		this.listenAddress = lport != 0 ? new InetSocketAddress(
-				InetAddress.getByAddress(la), lport) : null;
-		exactLength += (4 + 2 + 4 + 2);
+		// addresses (each 16-byte IPv4-mapped IP + 2-byte port; AddressCodec).
+		// port 0 -> null (absent address).
+		this.clientAddress = AddressCodec.getOrNull(bbuf);
+		this.listenAddress = AddressCodec.getOrNull(bbuf);
+		exactLength += 2 * AddressCodec.SOCKADDR_BYTES;
 
 		// other non-final fields
 		this.entryReplica = bbuf.getInt();

--- a/src/edu/umass/cs/gigapaxos/paxosutil/PaxosPacketDemultiplexerFast.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/PaxosPacketDemultiplexerFast.java
@@ -37,6 +37,7 @@ import edu.umass.cs.nio.AbstractPacketDemultiplexer;
 import edu.umass.cs.nio.JSONPacket;
 import edu.umass.cs.nio.MessageExtractor;
 import edu.umass.cs.nio.interfaces.Stringifiable;
+import edu.umass.cs.nio.nioutils.AddressCodec;
 import edu.umass.cs.nio.nioutils.NIOHeader;
 import edu.umass.cs.utils.Config;
 import edu.umass.cs.utils.DelayProfiler;
@@ -234,39 +235,41 @@ public abstract class PaxosPacketDemultiplexerFast extends
 			long t = System.nanoTime();
 			if (PaxosPacket.getType(bytes) == PaxosPacketType.REQUEST) {
 				// affix header info only for request packets
-				byte[] caddress = header.sndr.getAddress().getAddress();
-				short cport = (short) header.sndr.getPort();
-				byte[] laddress = header.rcvr.getAddress().getAddress();
-				short lport = (short) header.rcvr.getPort();
 				ByteBuffer bbuf = ByteBuffer.wrap(bytes);
 				for (int i = 0; i < 3; i++)
 					bbuf.getInt();
 				int paxosIDLength = bbuf.get();
 
+				// Start of clientAddress in the RequestPacket layout: 3 ints
+				// (type, paxos type, version) + 1 (paxosID length) = 13, then the
+				// paxosID bytes + 8 (requestID) + 1 (stop). Each address is now a
+				// 16-byte (IPv4-mapped) IP + 2-byte port (see AddressCodec).
 				int offset = 13 + paxosIDLength + 8 + 1;
-				int expectedPos = offset + 4 + 2 + 4 + 2;
-				assert (bytes.length > offset + 12) : bytes.length + " <= "
-						+ expectedPos;
-				
-				//bbuf = ByteBuffer.wrap(bytes, offset, 12);
-				bbuf.position(offset).limit(offset +12);
-				
-				boolean noCA = bytes[offset + 4] == 0 && (bytes[offset + 5] == 0); 
-				boolean noLA = bytes[offset + 6 + 4] == 0
-						&& bytes[offset + 6 + 5] == 0;
+				final int addrPair = AddressCodec.SOCKADDR_BYTES;   // 18
+				final int bothAddrs = 2 * addrPair;                 // 36
+				assert (bytes.length > offset + bothAddrs) : bytes.length
+						+ " <= " + (offset + bothAddrs);
+
+				bbuf.position(offset).limit(offset + bothAddrs);
+
+				// port==0 (the 2 bytes right after each 16-byte IP) means "absent".
+				boolean noCA = bytes[offset + AddressCodec.ADDRESS_BYTES] == 0
+						&& bytes[offset + AddressCodec.ADDRESS_BYTES + 1] == 0;
+				boolean noLA = bytes[offset + addrPair + AddressCodec.ADDRESS_BYTES] == 0
+						&& bytes[offset + addrPair + AddressCodec.ADDRESS_BYTES + 1] == 0;
 				try {
 					if (noCA)
-						bbuf.put(caddress).putShort(cport);
+						AddressCodec.put(bbuf, header.sndr);
 					else
-						bbuf.position(bbuf.position() + 6);
+						bbuf.position(bbuf.position() + addrPair);
 					if (noLA)
-						bbuf.put(laddress).putShort(lport);
+						AddressCodec.put(bbuf, header.rcvr);
 					else
-						bbuf.position(bbuf.position() + 6);
+						bbuf.position(bbuf.position() + addrPair);
 
 				} catch (Exception e) {
-					assert (false) : bytes.length + " ? " + 16 + 4
-							+ paxosIDLength + 8 + 1;
+					assert (false) : bytes.length + " ? " + offset + " + "
+							+ bothAddrs;
 				}
 			}
 			try {

--- a/src/edu/umass/cs/nio/MessageNIOTransport.java
+++ b/src/edu/umass/cs/nio/MessageNIOTransport.java
@@ -34,6 +34,7 @@ import edu.umass.cs.nio.interfaces.Byteable;
 import edu.umass.cs.nio.interfaces.InterfaceMessageExtractor;
 import edu.umass.cs.nio.interfaces.InterfaceNIOTransport;
 import edu.umass.cs.nio.interfaces.NodeConfig;
+import edu.umass.cs.nio.nioutils.AddressCodec;
 import edu.umass.cs.nio.nioutils.NIOHeader;
 import edu.umass.cs.nio.nioutils.NIOInstrumenter;
 import edu.umass.cs.nio.nioutils.PacketDemultiplexerDefault;
@@ -386,13 +387,9 @@ public class MessageNIOTransport<NodeIDType, MessageType> extends
 	 */
 	public static final InetSocketAddress getSenderAddress(byte[] bytes)
 			throws UnknownHostException {
+		// Sender occupies the first SOCKADDR_BYTES of the NIOHeader.
 		ByteBuffer bbuf = ByteBuffer.wrap(bytes, 0, NIOHeader.BYTES);
-		byte[] addressBytes = new byte[4];
-		bbuf.get(addressBytes);
-		InetAddress address = InetAddress.getByAddress(addressBytes);
-		int port = (int) bbuf.getShort();
-		if(port < 0) port += 2 * (Short.MAX_VALUE + 1);
-		return new InetSocketAddress(address, port);
+		return AddressCodec.get(bbuf);
 	}
 
 	/**
@@ -402,13 +399,10 @@ public class MessageNIOTransport<NodeIDType, MessageType> extends
 	 */
 	public static final InetSocketAddress getReceiverAddress(byte[] bytes)
 			throws UnknownHostException {
-		ByteBuffer bbuf = ByteBuffer.wrap(bytes, 6, NIOHeader.BYTES);
-		byte[] addressBytes = new byte[4];
-		bbuf.get(addressBytes);
-		InetAddress address = InetAddress.getByAddress(addressBytes);
-		int port = (int)bbuf.getShort() ;
-		if(port < 0) port += 2 * (Short.MAX_VALUE + 1);
-		return new InetSocketAddress(address, port);
+		// Receiver immediately follows the sender (SOCKADDR_BYTES in).
+		ByteBuffer bbuf = ByteBuffer.wrap(bytes, AddressCodec.SOCKADDR_BYTES,
+				AddressCodec.SOCKADDR_BYTES);
+		return AddressCodec.get(bbuf);
 	}
 
 	/**

--- a/src/edu/umass/cs/nio/nioutils/AddressCodec.java
+++ b/src/edu/umass/cs/nio/nioutils/AddressCodec.java
@@ -1,0 +1,102 @@
+package edu.umass.cs.nio.nioutils;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+
+/**
+ * Fixed-width on-wire codec for {@link InetSocketAddress} that supports BOTH
+ * IPv4 and IPv6.
+ *
+ * <p>Every address is serialized as a fixed <b>16-byte</b> field followed by a
+ * 2-byte port ({@link #SOCKADDR_BYTES} total). IPv4 addresses are stored as
+ * their IPv4-mapped IPv6 form ({@code ::ffff:a.b.c.d}); on read,
+ * {@link InetAddress#getByAddress(byte[])} returns an {@code Inet4Address} for
+ * IPv4-mapped input and an {@code Inet6Address} otherwise, so an IPv4 address
+ * round-trips back to an IPv4 address.
+ *
+ * <p>Keeping the field fixed-width (just wider than the legacy 4 bytes) means
+ * all the fixed-offset packet layouts in gigapaxos remain deterministic; only
+ * the size constants and offsets change. This is a wire-format change: all
+ * nodes in a cluster must run a build that uses this codec.
+ *
+ * @author arun
+ */
+public class AddressCodec {
+
+	/** Bytes used for the IP address portion (16 = IPv6 / IPv4-mapped). */
+	public static final int ADDRESS_BYTES = 16;
+
+	/** Bytes used for a full address+port pair (16 + 2). */
+	public static final int SOCKADDR_BYTES = ADDRESS_BYTES + Short.BYTES;
+
+	/**
+	 * Encode {@code addr} (4- or 16-byte) into a 16-byte buffer, using the
+	 * IPv4-mapped IPv6 form for IPv4 input.
+	 *
+	 * @param addr 4- or 16-byte raw address, or {@code null} for all-zeros.
+	 * @return a 16-byte array.
+	 */
+	public static byte[] toSixteen(byte[] addr) {
+		if (addr == null)
+			return new byte[ADDRESS_BYTES];
+		if (addr.length == ADDRESS_BYTES)
+			return addr;
+		// 4-byte IPv4 -> ::ffff:a.b.c.d
+		byte[] mapped = new byte[ADDRESS_BYTES];
+		mapped[10] = (byte) 0xff;
+		mapped[11] = (byte) 0xff;
+		System.arraycopy(addr, 0, mapped, 12, 4);
+		return mapped;
+	}
+
+	/**
+	 * Write {@code sa} as 16 bytes of address + 2 bytes of port into {@code bbuf}.
+	 * A {@code null} address/port is written as zeros (port 0 signals "absent"
+	 * to {@link #getOrNull(ByteBuffer)}).
+	 *
+	 * @param bbuf destination buffer (advanced by {@link #SOCKADDR_BYTES}).
+	 * @param sa   the address (may be {@code null}).
+	 */
+	public static void put(ByteBuffer bbuf, InetSocketAddress sa) {
+		byte[] raw = (sa != null && sa.getAddress() != null) ? sa.getAddress()
+				.getAddress() : null;
+		bbuf.put(toSixteen(raw));
+		bbuf.putShort(sa != null ? (short) sa.getPort() : 0);
+	}
+
+	/**
+	 * Read a 16-byte address + 2-byte port, always returning a non-null
+	 * {@link InetSocketAddress} (mirrors the legacy {@code NIOHeader} behavior of
+	 * always constructing an address).
+	 *
+	 * @param bbuf source buffer (advanced by {@link #SOCKADDR_BYTES}).
+	 * @return the decoded address (never {@code null}).
+	 * @throws UnknownHostException if the 16 bytes are not a valid address.
+	 */
+	public static InetSocketAddress get(ByteBuffer bbuf)
+			throws UnknownHostException {
+		byte[] a = new byte[ADDRESS_BYTES];
+		bbuf.get(a);
+		int port = bbuf.getShort() & 0xffff;
+		return new InetSocketAddress(InetAddress.getByAddress(a), port);
+	}
+
+	/**
+	 * Like {@link #get(ByteBuffer)} but returns {@code null} when the port is 0,
+	 * matching the "absent address" convention used by {@code RequestPacket}.
+	 *
+	 * @param bbuf source buffer (advanced by {@link #SOCKADDR_BYTES}).
+	 * @return the decoded address, or {@code null} if the port was 0.
+	 * @throws UnknownHostException if the 16 bytes are not a valid address.
+	 */
+	public static InetSocketAddress getOrNull(ByteBuffer bbuf)
+			throws UnknownHostException {
+		byte[] a = new byte[ADDRESS_BYTES];
+		bbuf.get(a);
+		int port = bbuf.getShort() & 0xffff;
+		return port != 0 ? new InetSocketAddress(InetAddress.getByAddress(a),
+				port) : null;
+	}
+}

--- a/src/edu/umass/cs/nio/nioutils/AddressCodec.java
+++ b/src/edu/umass/cs/nio/nioutils/AddressCodec.java
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer;
  * the size constants and offsets change. This is a wire-format change: all
  * nodes in a cluster must run a build that uses this codec.
  *
- * @author arun
+ * @author fadhilkurnia
  */
 public class AddressCodec {
 

--- a/src/edu/umass/cs/nio/nioutils/NIOHeader.java
+++ b/src/edu/umass/cs/nio/nioutils/NIOHeader.java
@@ -1,6 +1,5 @@
 package edu.umass.cs.nio.nioutils;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
@@ -13,9 +12,10 @@ import edu.umass.cs.nio.MessageNIOTransport;
  */
 public class NIOHeader {
 	/**
-	 * Size in bytes.
+	 * Size in bytes: two (address, port) pairs, each 16-byte address + 2-byte
+	 * port (see {@link AddressCodec}). IPv4 addresses are stored IPv4-mapped.
 	 */
-	public static final int BYTES = 12;
+	public static final int BYTES = 2 * AddressCodec.SOCKADDR_BYTES;
 	/**
 	 * 
 	 */
@@ -41,26 +41,15 @@ public class NIOHeader {
 	
 	/**
 	 * @param bytes
-	 * @return NIOHeader constructed from the first 12 bytes.
+	 * @return NIOHeader constructed from the first {@link #BYTES} bytes.
 	 * @throws UnknownHostException
 	 */
 	public static NIOHeader getNIOHeader(byte[] bytes)
 			throws UnknownHostException {
-		ByteBuffer bbuf = ByteBuffer.wrap(bytes, 0, 12);
-		byte[] sip = new byte[4];
-		bbuf.get(sip, 0, 4);
-		int sport = (int)bbuf.getShort();
-		if (sport < 0)
-			sport += 2 * (Short.MAX_VALUE + 1);
-
-		byte[] dip = new byte[4];
-		bbuf.get(dip, 0, 4);
-		int dport = (int)bbuf.getShort();
-		if (dport < 0)
-			dport += 2 * (Short.MAX_VALUE + 1);
-		return new NIOHeader(new InetSocketAddress(
-				InetAddress.getByAddress(sip), sport), new InetSocketAddress(
-				InetAddress.getByAddress(dip), dport));
+		ByteBuffer bbuf = ByteBuffer.wrap(bytes, 0, BYTES);
+		InetSocketAddress sndr = AddressCodec.get(bbuf);
+		InetSocketAddress rcvr = AddressCodec.get(bbuf);
+		return new NIOHeader(sndr, rcvr);
 	}
 
 	public String toString() {
@@ -68,17 +57,13 @@ public class NIOHeader {
 	}
 
 	/**
-	 * @return {@code this} as a 12 byte array with 6 bytes for each IP, port
-	 *         pair.
+	 * @return {@code this} as a {@link #BYTES}-byte array: a 16-byte address +
+	 *         2-byte port for the sender, then the same for the receiver.
 	 */
 	public byte[] toBytes() {
-		ByteBuffer bbuf = ByteBuffer.wrap(new byte[12]);
-		bbuf.put(this.sndr != null ? this.sndr.getAddress().getAddress()
-				: new byte[4]);
-		bbuf.putShort(this.sndr != null ? (short) this.sndr.getPort() : 0);
-		bbuf.put(this.rcvr != null ? this.rcvr.getAddress().getAddress()
-				: new byte[4]);
-		bbuf.putShort(this.rcvr != null ? (short) this.rcvr.getPort() : 0);
+		ByteBuffer bbuf = ByteBuffer.wrap(new byte[BYTES]);
+		AddressCodec.put(bbuf, this.sndr);
+		AddressCodec.put(bbuf, this.rcvr);
 		return bbuf.array();
 	}
 }

--- a/src/edu/umass/cs/utils/Util.java
+++ b/src/edu/umass/cs/utils/Util.java
@@ -286,29 +286,48 @@ public class Util {
 	}
 
 	public static InetSocketAddress getInetSocketAddressFromString(String s) {
+		if (s == null)
+			return null;
 		// remove anything upto and including the first slash
 		// handles these inputs:
 		//   "10.0.1.50/10.0.1.50:24404"
 		//   "localhost/[0:0:0:0:0:0:0:1]:24404"
 		s = s.replaceAll(".*/", "");
-		String[] tokens = s.split(":");
-		if (tokens.length < 2) {
-			return null;
-		}
-		String ipHostName = s.substring(0, s.lastIndexOf(":"));
-		String portStr = tokens[tokens.length-1];
-		int port = Integer.parseInt(portStr);
-		return new InetSocketAddress(ipHostName, port);
+		return parseHostPort(s);
 	}
 
 	// assumes strict formatting and is more efficient
 	public static InetSocketAddress getInetSocketAddressFromStringStrict(
 			String s) {
-		String[] tokens = s.split(":");
-		if (tokens.length < 2) {
+		return parseHostPort(s);
+	}
+
+	/**
+	 * Parse a "host:port" string into an {@link InetSocketAddress}, supporting
+	 * IPv4, hostnames, and IPv6 in both bracketed ("[2001:db8::1]:80") and bare
+	 * ("2001:db8::1:80") forms. The port is taken after the last colon; for IPv6
+	 * the surrounding brackets, if any, are stripped from the host. Returns
+	 * {@code null} if there is no port or it is not a number.
+	 */
+	private static InetSocketAddress parseHostPort(String s) {
+		if (s == null)
+			return null;
+		int lastColon = s.lastIndexOf(':');
+		if (lastColon < 0)
+			return null;
+		String host = s.substring(0, lastColon);
+		String portStr = s.substring(lastColon + 1);
+		// strip [] around an IPv6 literal, e.g. "[::1]" -> "::1"
+		if (host.length() >= 2 && host.charAt(0) == '['
+				&& host.charAt(host.length() - 1) == ']')
+			host = host.substring(1, host.length() - 1);
+		int port;
+		try {
+			port = Integer.parseInt(portStr);
+		} catch (NumberFormatException e) {
 			return null;
 		}
-		return new InetSocketAddress(tokens[0], Integer.valueOf(tokens[1]));
+		return new InetSocketAddress(host, port);
 	}
 
 	public static InetAddress getInetAddressFromString(String s)

--- a/xdn-dns/plugin/xdn/xdn.go
+++ b/xdn-dns/plugin/xdn/xdn.go
@@ -119,22 +119,20 @@ func (x XDN) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 		return dns.RcodeRefused, nil
 	}
 
-	// prepare the A record to be sent
-	var rr dns.RR
-	rr = new(dns.A)
-	rr.(*dns.A).Hdr = dns.RR_Header{
-		Name:   state.QName(),
-		Rrtype: dns.TypeA,
-		Class:  state.QClass(),
-		Ttl:    responseTTLSec,
+	// Service names resolve to the AR's GLOBAL IPv6 (consensus advertises IPv6,
+	// so getIPSets returns IPv6 addresses). We answer AAAA only; an A query gets
+	// NODATA (empty NOERROR) so clients connect over IPv6.
+	if state.QType() != dns.TypeAAAA {
+		if err := w.WriteMsg(a); err != nil {
+			return dns.RcodeServerFailure, err
+		}
+		return dns.RcodeSuccess, nil
 	}
 
 	// send request to RC
 	IPs := x.getIPSets(serviceName)
-	if IPs == nil || len(IPs) == 0 {
-		a.Answer = []dns.RR{rr}
-		err := w.WriteMsg(a)
-		if err != nil {
+	if len(IPs) == 0 {
+		if err := w.WriteMsg(a); err != nil {
 			return dns.RcodeServerFailure, err
 		}
 		return dns.RcodeNameError, nil
@@ -150,12 +148,17 @@ func (x XDN) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	}
 	fmt.Println(">> IP: ", resultedIP)
 
-	rr.(*dns.A).A = net.ParseIP(resultedIP).To4()
-
-	// put the record into the answer, then send it
+	// prepare and send the AAAA record
+	rr := new(dns.AAAA)
+	rr.Hdr = dns.RR_Header{
+		Name:   state.QName(),
+		Rrtype: dns.TypeAAAA,
+		Class:  state.QClass(),
+		Ttl:    responseTTLSec,
+	}
+	rr.AAAA = net.ParseIP(resultedIP).To16()
 	a.Answer = []dns.RR{rr}
-	err = w.WriteMsg(a)
-	if err != nil {
+	if err = w.WriteMsg(a); err != nil {
 		return dns.RcodeServerFailure, err
 	}
 
@@ -202,26 +205,41 @@ func (x *XDN) getIPSets(serviceName string) []string {
 	var IPs []string
 	if respJSON["ACTIVE_REPLICAS"] != nil {
 		actives := respJSON["ACTIVE_REPLICAS"].([]interface{})
-		// example format: "p113.utah.cloudlab.us/127.0.0.1:2000"
+		// example formats: "p113.utah.cloudlab.us/127.0.0.1:2000"
+		//                  "host/[2001:db8::1]:2000"  or  "/[2001:db8::1]:2000"
 		for i := 0; i < len(actives); i++ {
 			rawString := actives[i].(string)
-			rawHostPort := strings.Split(rawString, ":")
-			if len(rawHostPort) != 2 {
+			ip := extractIP(rawString)
+			if ip == "" {
 				fmt.Println(">> error, invalid address format received:" +
 					rawString)
 				return nil
 			}
-			rawHost := strings.Split(rawHostPort[0], "/")
-			if len(rawHostPort) != 2 {
-				fmt.Println(">> error, invalid address host format received:" +
-					rawHostPort[0])
-				return nil
-			}
-			IPs = append(IPs, rawHost[1])
+			IPs = append(IPs, ip)
 		}
 	}
 
 	return IPs
+}
+
+// extractIP pulls the bare IP (IPv4 or IPv6) out of a gigapaxos address string
+// like "host/1.2.3.4:2000" or "host/[2001:db8::1]:2000". Splitting on ":" is
+// wrong for IPv6, so we drop the "host/" prefix and the trailing ":port",
+// honoring the [..] brackets around an IPv6 literal.
+func extractIP(raw string) string {
+	if i := strings.LastIndex(raw, "/"); i >= 0 {
+		raw = raw[i+1:]
+	}
+	if strings.HasPrefix(raw, "[") {
+		if j := strings.Index(raw, "]"); j > 0 {
+			return raw[1:j]
+		}
+		return ""
+	}
+	if i := strings.LastIndex(raw, ":"); i >= 0 {
+		return raw[:i]
+	}
+	return raw
 }
 
 // Picks one random IP from the list of IP Address. Assume IPs is not empty.


### PR DESCRIPTION
Runs XDN end-to-end over IPv6 — both inter-node consensus and the client-facing
  data plane — so ActiveReplicas no longer need billed public IPv4. Builds on the
  in-frontend HTTPS work already in `main`.

  ### Wire format (`nio` / `gigapaxos`)
  - New `AddressCodec`: fixed **16-byte** address encoding (IPv4 stored IPv4-mapped,
    `::ffff:a.b.c.d`) + 2-byte port. Keeps every fixed-offset paxos packet layout
    deterministic; only size constants/offsets change.
  - `NIOHeader`, `RequestPacket`, `MessageNIOTransport`, `PaxosPacketDemultiplexerFast`,
    `Util` updated to use it. Wire-format change: all nodes must run this build.

  ### DNS (`xdn-dns` coredns plugin)
  - Service names now answer **AAAA** (AR global IPv6); A → NODATA.
  - Control-plane names (`cp`/`rc`/`ns`) stay **A** (RC IPv4) for management.
  - IPv6-safe address parsing (`extractIP`, handles `[v6]:port`).

  ### AWS (Terraform)
  - Dual-stack VPC; RC + ARs get global IPv6; consensus + data plane bind IPv6.
  - ARs are **IPv6-only** (`associate_public_ip_address=false`, no EIPs). 
     RC keeps its EIP (SSH/jump, NS glue, control plane).
  - Cert pulled from S3 over the dual-stack endpoint; `preferIPv6Addresses`.
  - Pinned IPv6 AMIs.

  ### Verified
  IPv6-only ARs boot, pull the cert over IPv6, form consensus, and serve HTTPS
  read/write over IPv6. Services launched via the RC over IPv4 (`cp.xdnapp.com`),
  consumed over IPv6 (`AAAA`-only).