### PR TITLE
aws: move RC + ActiveReplicas to Graviton (arm64)

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -10,6 +10,7 @@ Terraform infrastructure and AMI builders for deploying XDN to EC2.
 | `create_rc_ami.sh` | Build an AMI for the Reconfigurator (RC) + coredns nameserver |
 | `create_ar_ami.sh` | Build an AMI for the ActiveReplica (AR) edge node |
 | `ami_common.sh` | Shared AWS plumbing sourced by the two builders (not run directly) |
+| `cluster_power.sh` | `pause`/`resume`/`status` the cluster's EC2 instances to cut idle cost |
 
 ## Prerequisites
 
@@ -64,10 +65,41 @@ terraform apply -var rc_instance_type=t4g.small
 ```
 
 Avoid `t4g.nano` (0.5 GB) for the RC — even with swap, ~128 MB heap is too tight.
-The ARs stay on `amd64` (`t3.large`) since they run Docker + heavy stateful
-apps; only the RC AMI is built for `arm64`. (Note: an EBS *snapshot* is billed
-by used blocks, not the provisioned volume size, so the 30→16 GB change mainly
-trims each running RC's gp3 volume cost; the snapshot was already lean.)
+By default the ARs stay on `amd64` (`t3.large`) since they run Docker + heavy
+stateful apps; see *Cutting AR cost* below for the Graviton/Spot/idle options.
+(Note: an EBS *snapshot* is billed by used blocks, not the provisioned volume
+size, so the 30→16 GB change mainly trims each running RC's gp3 volume cost; the
+snapshot was already lean.)
+
+### Cutting AR cost
+
+The 3 ActiveReplicas are ~90% of the monthly bill. Three compounding levers:
+
+1. **Stop when idle (biggest lever for an experiments cluster).** Stopped
+   instances bill only their EBS (~$7/mo total) instead of compute. The RC EIP
+   and every node's static private + IPv6 address persist across stop/start, so
+   the cluster resumes at the same endpoints:
+   ```bash
+   ./cluster_power.sh pause     # stop all RC + AR instances when idle
+   ./cluster_power.sh resume    # start them again before an experiment
+   ./cluster_power.sh status    # show type + power state per node
+   ```
+   Re-launch your services after a resume — service state under `/tmp` is not
+   guaranteed to survive a stop/start (treat each run as a fresh deploy).
+
+2. **Graviton (`arm64`) ARs — permanent ~20%.** Build an arm64 AR AMI
+   (`ARCH=arm64 ./create_ar_ami.sh`), point `ar_ami` at it, and set
+   `ar_instance_type=t4g.large`. **Requires multi-arch service images** (official
+   `mysql`/`postgres`/`wordpress`/`nginx` qualify; amd64-only custom images do
+   not — they'd fail with `exec format error`).
+
+3. **Spot ARs — ~60–70% off running hours.** Set `-var ar_use_spot=true`. Uses
+   *persistent* spot with `stop` interruption behavior, so a reclaim stops (not
+   terminates) the AR — EBS + addresses survive, AWS restarts it when capacity
+   returns, and `cluster_power.sh` can still pause/resume it. The 3-way quorum
+   tolerates losing one AR; best for long runs where mid-run reclaim is OK.
+
+For a ~25% duty cycle these take the ARs from ~$182/mo to roughly $15–40/mo.
 
 The AMIs are config-free: systemd units (`xdn-rc`, `xdn-dns`, `xdn-ar`) stay
 inert until launch-time `user_data` writes `/opt/xdn/conf/gigapaxos.properties`

--- a/aws/README.md
+++ b/aws/README.md
@@ -28,8 +28,46 @@ terminates the builder. The new AMI id is printed and appended to
 ./create_ar_ami.sh
 ```
 
-Common overrides (see `ami_common.sh` for all): `AWS_REGION`, `REPO_BRANCH`,
-`BUILDER_INSTANCE_TYPE`, `BUILDER_VOLUME_SIZE`, `SUBNET_ID`.
+Common overrides (see `ami_common.sh` for all): `ARCH`, `AWS_REGION`,
+`REPO_BRANCH`, `BUILDER_INSTANCE_TYPE`, `BUILDER_VOLUME_SIZE`, `SUBNET_ID`.
+
+### Architecture (x86-64 vs Graviton/arm64)
+
+`ARCH` selects the AMI's CPU architecture (`amd64`, the default, or `arm64`).
+It drives the base Ubuntu AMI, the Go toolchain download, and the builder
+family — `coredns` and `docker-ce-cli` are compiled/installed **natively**, so
+an `arm64` AMI is built on a Graviton builder (auto-defaults to `t4g.large`);
+you cannot cross-compile them here. The Java jars are arch-neutral bytecode.
+
+```bash
+ARCH=arm64 ./create_rc_ami.sh    # Graviton RC AMI for t4g.* instances
+```
+
+The RC is a lean control-plane node (reconfigurator JVM + coredns; no Docker
+daemon, no app containers, off the data path), so it's a good fit for the
+smallest Graviton instance. `main.tf` exposes per-role sizing via
+`rc_instance_type` (**default `t4g.micro`**, Graviton, ~$6/mo) and
+`ar_instance_type` (default `t3.large`). The default `rc_ami` is the **arm64**
+RC image; build/refresh it with `ARCH=arm64 ./create_rc_ami.sh` (clones
+`fork/main`, which carries the IPv6 jar). The RC build also uses a smaller
+16 GB root volume (vs the AR's 30 GB), matched by the RC's `root_block_device`,
+so the AMI snapshot and each RC instance's gp3 volume are smaller and cheaper.
+
+`t4g.micro` has only 1 GB RAM, so the RC JVM runs with a small (~256 MB) default
+max heap. To keep that safe, `rc-userdata.tftpl` provisions a 1 GB **swapfile**
+on boot, which absorbs boot/GC spikes (JVM + coredns + geo DB + OS) that would
+otherwise risk an OOM-kill. If you want more headroom, bump to `t4g.small`
+(2 GB) — same arm64 AMI, no rebuild:
+
+```bash
+terraform apply -var rc_instance_type=t4g.small
+```
+
+Avoid `t4g.nano` (0.5 GB) for the RC — even with swap, ~128 MB heap is too tight.
+The ARs stay on `amd64` (`t3.large`) since they run Docker + heavy stateful
+apps; only the RC AMI is built for `arm64`. (Note: an EBS *snapshot* is billed
+by used blocks, not the provisioned volume size, so the 30→16 GB change mainly
+trims each running RC's gp3 volume cost; the snapshot was already lean.)
 
 The AMIs are config-free: systemd units (`xdn-rc`, `xdn-dns`, `xdn-ar`) stay
 inert until launch-time `user_data` writes `/opt/xdn/conf/gigapaxos.properties`

--- a/aws/README.md
+++ b/aws/README.md
@@ -87,11 +87,16 @@ The 3 ActiveReplicas are ~90% of the monthly bill. Three compounding levers:
    Re-launch your services after a resume — service state under `/tmp` is not
    guaranteed to survive a stop/start (treat each run as a fresh deploy).
 
-2. **Graviton (`arm64`) ARs — permanent ~20%.** Build an arm64 AR AMI
-   (`ARCH=arm64 ./create_ar_ami.sh`), point `ar_ami` at it, and set
-   `ar_instance_type=t4g.large`. **Requires multi-arch service images** (official
-   `mysql`/`postgres`/`wordpress`/`nginx` qualify; amd64-only custom images do
-   not — they'd fail with `exec format error`).
+2. **Graviton (`arm64`) ARs — the default.** `ar_ami` is an arm64 AR AMI and
+   `ar_instance_type` defaults to **`t4g.small`** (2 GB, ~$12/mo each), which fits
+   light services/eval. Bump to `t4g.medium` (4 GB) or `t4g.large` (8 GB) for
+   heavy stateful apps (MySQL/Postgres) where 2 GB is too tight — same AMI, no
+   rebuild: `terraform apply -var ar_instance_type=t4g.large`. Changing size is an
+   in-place stop/retype/start (not a rebuild), but it still clears service state,
+   so re-launch services afterward. **Requires multi-arch service images**
+   (official `mysql`/`postgres`/`wordpress`/`nginx` qualify; amd64-only custom
+   images fail with `exec format error`). Rebuild the AMI with
+   `ARCH=arm64 ./create_ar_ami.sh`.
 
 3. **Spot ARs — ~60–70% off running hours.** Set `-var ar_use_spot=true`. Uses
    *persistent* spot with `stop` interruption behavior, so a reclaim stops (not

--- a/aws/ami_common.sh
+++ b/aws/ami_common.sh
@@ -16,8 +16,23 @@ set -euo pipefail
 # Configurable knobs (override via environment before running the entrypoint).
 # ---------------------------------------------------------------------------
 AWS_REGION="${AWS_REGION:-us-east-1}"
-BASE_AMI="${BASE_AMI:-}"                       # empty -> resolve latest Ubuntu 24.04 amd64
-BUILDER_INSTANCE_TYPE="${BUILDER_INSTANCE_TYPE:-t3.large}"
+
+# Target CPU architecture for the baked AMI: amd64 (x86-64; t3/m5/... families)
+# or arm64 (Graviton; t4g/m6g/... families, ~20% cheaper per GB). This drives
+# the base Ubuntu AMI, the Go toolchain download, and the builder family.
+# coredns and docker-ce-cli are compiled/installed NATIVELY on the builder, so
+# an arm64 AMI MUST be built on an arm64 (Graviton) builder -- you cannot
+# cross-compile them here. The Java jars are arch-neutral bytecode, so the only
+# arch-sensitive RC artifacts are the OS, the coredns binary, and the docker CLI.
+ARCH="${ARCH:-amd64}"
+case "$ARCH" in
+  amd64) _default_builder="t3.large" ;;   # x86-64 builder
+  arm64) _default_builder="t4g.large" ;;  # Graviton builder (native arm64 output)
+  *) printf '[err] ARCH must be amd64 or arm64 (got: %s)\n' "$ARCH" >&2; exit 1 ;;
+esac
+
+BASE_AMI="${BASE_AMI:-}"                       # empty -> resolve latest Ubuntu 24.04 for $ARCH
+BUILDER_INSTANCE_TYPE="${BUILDER_INSTANCE_TYPE:-$_default_builder}"  # must match $ARCH
 BUILDER_VOLUME_SIZE="${BUILDER_VOLUME_SIZE:-30}"   # GB, gp3 (8GB default is too small)
 KEY_NAME="${KEY_NAME:-xdn-aws-key}"
 SSH_KEY_PATH="${SSH_KEY_PATH:-$HOME/.ssh/xdn-aws-key}"
@@ -54,16 +69,16 @@ preflight() {
 }
 
 # ---------------------------------------------------------------------------
-# resolve_base_ami - latest Ubuntu 24.04 amd64 via Canonical's public SSM param.
+# resolve_base_ami - latest Ubuntu 24.04 ($ARCH) via Canonical's public SSM param.
 # ---------------------------------------------------------------------------
 resolve_base_ami() {
   if [[ -n "$BASE_AMI" ]]; then
     log "Using provided base AMI: $BASE_AMI"
     return
   fi
-  log "Resolving latest Ubuntu 24.04 amd64 AMI via SSM"
+  log "Resolving latest Ubuntu 24.04 $ARCH AMI via SSM"
   BASE_AMI=$(aws ssm get-parameter --region "$AWS_REGION" \
-    --name /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id \
+    --name "/aws/service/canonical/ubuntu/server/24.04/stable/current/${ARCH}/hvm/ebs-gp3/ami-id" \
     --query 'Parameter.Value' --output text)
   [[ "$BASE_AMI" == ami-* ]] || die "Failed to resolve base AMI (got: '$BASE_AMI')"
   log "Base AMI: $BASE_AMI"
@@ -193,11 +208,12 @@ emit_common_provision() {
 sudo apt-get update
 sudo apt-get install -y openjdk-21-jdk ant git rsync wget curl
 
-# --- Go ${GO_VERSION} (NOT 1.22.4 from bin/xdnd; coredns needs 1.23+) ---
-wget -q "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+# --- Go ${GO_VERSION} (NOT 1.22.4 from bin/xdnd; coredns needs 1.23+).
+#     Go's arch slug matches \$ARCH (amd64/arm64), so the same line builds both. ---
+wget -q "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz"
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"
-rm -f "go${GO_VERSION}.linux-amd64.tar.gz"
+sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-${ARCH}.tar.gz"
+rm -f "go${GO_VERSION}.linux-${ARCH}.tar.gz"
 
 # --- clone source and build the jars ---
 rm -rf "\$HOME/xdn"
@@ -276,14 +292,14 @@ bake_image() {
   log "Creating AMI: $ami_name"
   AMI_ID=$(aws_ec2 create-image --instance-id "$BUILDER_ID" \
     --name "$ami_name" \
-    --description "XDN ${ROLE} node ($REPO_BRANCH)" \
+    --description "XDN ${ROLE} node ($REPO_BRANCH, $ARCH)" \
     --query 'ImageId' --output text)
   [[ "$AMI_ID" == ami-* ]] || die "create-image failed"
   log "Waiting for AMI $AMI_ID to become available"
   aws_ec2 wait image-available --image-ids "$AMI_ID"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  printf '%s\t%s\t%s\n' "$ami_name" "$AMI_ID" "$AWS_REGION" \
+  printf '%s\t%s\t%s\t%s\n' "$ami_name" "$AMI_ID" "$AWS_REGION" "$ARCH" \
     >> "$script_dir/last-built-amis.txt"
   log "AMI ready: $AMI_ID"
 }
@@ -324,7 +340,7 @@ run_ami_build() {
   : "${AMI_NAME_PREFIX:?AMI_NAME_PREFIX must be set by the entrypoint}"
   local stamp ami_name
   stamp="$(date -u +%Y%m%d-%H%M%S)"   # captured once; stable for this run
-  ami_name="${AMI_NAME_PREFIX}-${stamp}"
+  ami_name="${AMI_NAME_PREFIX}-${ARCH}-${stamp}"
 
   preflight
   resolve_base_ami

--- a/aws/ar-userdata.tftpl
+++ b/aws/ar-userdata.tftpl
@@ -36,7 +36,11 @@ if ! command -v aws >/dev/null 2>&1; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get update -y
   apt-get install -y unzip curl
-  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+  # Match the host arch: `uname -m` prints x86_64 / aarch64, which is exactly the
+  # AWS CLI v2 bundle naming -- so this works on both x86 and Graviton (t4g) ARs.
+  # (Hardcoding x86_64 here installs a CLI that can't exec on arm64, so the cert
+  # pull silently fails and xdn-ar never starts -- its ConditionPathExists gate.)
+  curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o /tmp/awscliv2.zip
   ( cd /tmp && unzip -oq awscliv2.zip && ./aws/install )
   rm -rf /tmp/awscliv2.zip /tmp/aws
 fi

--- a/aws/cluster_power.sh
+++ b/aws/cluster_power.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# cluster_power.sh - pause/resume the XDN cluster's EC2 instances to cut compute
+# cost during idle periods. For an intermittently-used (experiments) cluster this
+# is the single biggest lever: STOPPED instances bill only their EBS (~$7/mo
+# total) instead of compute (~$150-180/mo for the ARs).
+#
+# The RC Elastic IP and every node's static private + global IPv6 address persist
+# across stop/start, so the cluster resumes at the SAME endpoints -- no DNS glue
+# change, no terraform churn (stop/start is not a terraform-managed attribute).
+#
+# Usage:
+#   ./cluster_power.sh pause     # stop all running RC + AR instances
+#   ./cluster_power.sh resume    # start all stopped RC + AR instances
+#   ./cluster_power.sh status    # show each node's instance type + power state
+#
+# After `resume`, allow ~1-2 min for the JVM / coredns / Docker units to come up,
+# then RE-LAUNCH your services: service state lives under /tmp on the nodes and is
+# not guaranteed to survive a stop/start (systemd-tmpfiles may reap it), so treat
+# each experiment run as a fresh deploy.
+#
+# NOTE on Spot: if you enabled `ar_use_spot`, the ARs use PERSISTENT spot with
+# `stop` interruption behavior, so this script can still stop/start them. One-time
+# spot instances can only be terminated, not stopped.
+set -euo pipefail
+REGION="${AWS_REGION:-us-east-1}"
+FILTER=("Name=tag:Name,Values=xdn-rc,xdn-ar-*")
+
+ids_in_state() {
+  aws ec2 describe-instances --region "$REGION" \
+    --filters "${FILTER[@]}" "Name=instance-state-name,Values=$1" \
+    --query 'Reservations[].Instances[].InstanceId' --output text
+}
+
+case "${1:-status}" in
+pause)
+  ids=$(ids_in_state running)
+  [ -z "$ids" ] && { echo "no running XDN instances"; exit 0; }
+  echo "stopping: $ids"
+  aws ec2 stop-instances --region "$REGION" --instance-ids $ids \
+    --query 'StoppingInstances[].{Id:InstanceId,State:CurrentState.Name}' --output table
+  ;;
+resume)
+  ids=$(ids_in_state stopped)
+  [ -z "$ids" ] && { echo "no stopped XDN instances"; exit 0; }
+  echo "starting: $ids"
+  aws ec2 start-instances --region "$REGION" --instance-ids $ids \
+    --query 'StartingInstances[].{Id:InstanceId,State:CurrentState.Name}' --output table
+  ;;
+status)
+  aws ec2 describe-instances --region "$REGION" --filters "${FILTER[@]}" \
+    "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+    --query 'Reservations[].Instances[].{Name:Tags[?Key==`Name`]|[0].Value,Type:InstanceType,State:State.Name}' \
+    --output table
+  ;;
+*)
+  echo "usage: $0 {pause|resume|status}" >&2
+  exit 1
+  ;;
+esac

--- a/aws/create_ar_ami.sh
+++ b/aws/create_ar_ami.sh
@@ -70,8 +70,10 @@ sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
 # --- Caddy (HTTPS termination): a custom build that bundles the route53 DNS-01
 #     provider, fetched from Caddy's download API (no Go/xcaddy needed here).
 #     Per-deployment config (Caddyfile) is injected at launch by user_data. ---
+# arch matches the builder (dpkg prints amd64/arm64, which is exactly what Caddy's
+# download API expects) so a Graviton AR AMI gets an arm64 Caddy, not an x86 one.
 sudo curl -fsSL -o /opt/xdn/bin/caddy \
-  "https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com/caddy-dns/route53"
+  "https://caddyserver.com/api/download?os=linux&arch=$(dpkg --print-architecture)&p=github.com/caddy-dns/route53"
 sudo chmod +x /opt/xdn/bin/caddy
 sudo ln -sf /opt/xdn/bin/caddy /usr/local/bin/caddy
 EOF

--- a/aws/create_rc_ami.sh
+++ b/aws/create_rc_ami.sh
@@ -7,11 +7,29 @@
 # values (node IPs, Corefile with the RC EIP) are injected later via Terraform
 # user_data. Baked systemd units stay inert until that config lands.
 #
-# Usage:   ./create_rc_ami.sh
-# Tunables: see ami_common.sh (AWS_REGION, BUILDER_INSTANCE_TYPE, REPO_BRANCH, ...).
+# Usage:   ./create_rc_ami.sh                 # x86-64 (amd64) AMI, default
+#          ARCH=arm64 ./create_rc_ami.sh      # Graviton (arm64) AMI for t4g.* RCs
+#
+# The RC is lean and off the data path, so it runs well on a small Graviton
+# instance (t4g.small/medium, ~20% cheaper per GB than t3). ARCH=arm64 builds a
+# native arm64 image on a Graviton builder (see ami_common.sh); point main.tf's
+# rc_ami + rc_instance_type at it. coredns and docker-ce-cli compile/install
+# natively, and the Java jars are arch-neutral, so nothing else changes.
+#
+# Tunables: see ami_common.sh (ARCH, AWS_REGION, BUILDER_INSTANCE_TYPE, REPO_BRANCH, ...).
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# The RC image is lean (Java jars + coredns + geo DB; no Docker daemon, Rust, or
+# FUSE), so it needs far less disk than the AR build. Default the build volume to
+# 16GB instead of the shared 30GB: the baked AMI's root snapshot is smaller and
+# every RC instance launched from it gets a smaller (cheaper) gp3 volume. Must be
+# >= the runtime RC volume in main.tf (root_block_device.volume_size, also 16) and
+# leave headroom for the transient build (clone + Go module cache + jars ~7-8GB).
+# A user-provided BUILDER_VOLUME_SIZE still wins (set before sourcing).
+: "${BUILDER_VOLUME_SIZE:=16}"
+
 # shellcheck source=ami_common.sh
 source ./ami_common.sh
 

--- a/aws/last-built-amis.txt
+++ b/aws/last-built-amis.txt
@@ -6,3 +6,4 @@ xdn-ar-20260602-000227	ami-0895cd15a28b707aa	us-east-1
 xdn-ar-20260602-140003	ami-05ab6b5c1b45eb8dd	us-east-1
 xdn-rc-20260602-135957	ami-0281566cb7fdbd374	us-east-1
 xdn-rc-arm64-20260602-181006	ami-0b430939d4943fcbb	us-east-1	arm64
+xdn-ar-arm64-20260602-195718	ami-0c22f54b43a823533	us-east-1	arm64

--- a/aws/last-built-amis.txt
+++ b/aws/last-built-amis.txt
@@ -5,3 +5,4 @@ xdn-ar-20260601-225129	ami-0beb9798e469f1fc7	us-east-1
 xdn-ar-20260602-000227	ami-0895cd15a28b707aa	us-east-1
 xdn-ar-20260602-140003	ami-05ab6b5c1b45eb8dd	us-east-1
 xdn-rc-20260602-135957	ami-0281566cb7fdbd374	us-east-1
+xdn-rc-arm64-20260602-181006	ami-0b430939d4943fcbb	us-east-1	arm64

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -271,9 +271,9 @@ variable "rc_instance_type" {
 }
 
 variable "ar_instance_type" {
-  description = "EC2 instance type for the ActiveReplica (AR) edge nodes (run Docker + stateful apps). Defaults to Graviton t4g.large (~20% cheaper than t3.large); requires an arm64 ar_ami (the default is one) and multi-arch service images."
+  description = "EC2 instance type for the ActiveReplica (AR) edge nodes. Graviton (needs the arm64 ar_ami + multi-arch service images). t4g.small (2GB) suits light services/eval; bump to t4g.medium (4GB) or t4g.large (8GB) for heavy stateful apps (MySQL/Postgres) where 2GB is too tight."
   type        = string
-  default     = "t4g.large" # Graviton, ~$49/mo vs t3.large ~$61/mo (needs arm64 ar_ami)
+  default     = "t4g.small" # Graviton 2GB, ~$12/mo each; use t4g.large for heavy DB apps
 }
 
 # Run the ARs as Spot instances (~60-70% cheaper than on-demand) instead of

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -240,9 +240,9 @@ resource "aws_key_pair" "deployer" {
 # 9. Per-role AMIs (built from the 'main' branch by create_rc_ami.sh /
 #    create_ar_ami.sh; see last-built-amis.txt). Override on the CLI if rebuilt.
 variable "rc_ami" {
-  description = "AMI for the Reconfigurator (RC) + coredns node (includes docker-ce-cli for CREATE-time image validation)."
+  description = "AMI for the Reconfigurator (RC) + coredns node (includes docker-ce-cli for CREATE-time image validation). ARM64/Graviton image (for t4g.* rc_instance_type), built from fork/main by `ARCH=arm64 ./create_rc_ami.sh`."
   type        = string
-  default     = "ami-0281566cb7fdbd374" # IPv6: coredns AAAA + IPv6-consensus jar
+  default     = "ami-0b430939d4943fcbb" # arm64, IPv6 (coredns AAAA + IPv6-consensus jar), 16GB root
 }
 
 variable "ar_ami" {
@@ -255,6 +255,25 @@ variable "ar_count" {
   description = "Number of ActiveReplica nodes (uses subnets 2..N)."
   type        = number
   default     = 3
+}
+
+# Per-role instance sizing. The RC is a lean control-plane node (reconfigurator
+# JVM + coredns; no Docker daemon, no app containers, off the data path), so it
+# runs comfortably on a smaller, cheaper instance than the ARs. The RC JVM sets
+# no -Xmx, so its max heap is ~1/4 of RAM -- downsizing RAM shrinks the heap
+# automatically (t3.medium => ~1 GB heap, ample for a singleton control plane).
+# The ARs run Docker + possibly heavy stateful apps (MySQL/Postgres), so they
+# keep the larger size.
+variable "rc_instance_type" {
+  description = "EC2 instance type for the Reconfigurator (control plane) node. Defaults to a Graviton t4g.micro -- REQUIRES an arm64 rc_ami (build with ARCH=arm64 ./create_rc_ami.sh). t4g.micro has only 1GB RAM, so the RC JVM runs with a small (~256MB) default heap; the userdata adds a swapfile to absorb GC/boot spikes."
+  type        = string
+  default     = "t4g.micro" # Graviton, ~$6/mo in us-east-1 (needs arm64 rc_ami)
+}
+
+variable "ar_instance_type" {
+  description = "EC2 instance type for the ActiveReplica (AR) edge nodes (run Docker + stateful apps)."
+  type        = string
+  default     = "t3.large"
 }
 
 # --- HTTPS / Let's Encrypt (Caddy on the ARs) ---
@@ -325,7 +344,7 @@ locals {
 # 9a. Reconfigurator (control plane) + coredns nameserver. Single node, subnet[0].
 resource "aws_instance" "rc" {
   ami                    = var.rc_ami
-  instance_type          = "t3.large"
+  instance_type          = var.rc_instance_type
   subnet_id              = aws_subnet.ipv6_subnets[0].id
   private_ip             = local.rc_private_ip
   ipv6_addresses         = [local.rc_ipv6] # consensus advertises + binds this
@@ -346,7 +365,7 @@ resource "aws_instance" "rc" {
   })
 
   root_block_device {
-    volume_size = 30
+    volume_size = 16 # lean control-plane node; matches the smaller RC AMI snapshot
     volume_type = "gp3"
   }
 
@@ -357,7 +376,7 @@ resource "aws_instance" "rc" {
 resource "aws_instance" "ar" {
   count                       = var.ar_count
   ami                         = var.ar_ami
-  instance_type               = "t3.large"
+  instance_type               = var.ar_instance_type
   subnet_id                   = aws_subnet.ipv6_subnets[count.index + 1].id
   private_ip                  = local.ar_private_ips[count.index]
   ipv6_addresses              = [local.ar_ipv6s[count.index]] # consensus + frontend bind
@@ -506,8 +525,20 @@ resource "acme_certificate" "wildcard" {
     # region. It writes the TXT into the _acme-challenge.<base_domain> zone (10c).
     config = {
       AWS_REGION = "us-east-1"
+      # Pin the hosted zone id so lego writes the challenge TXT DIRECTLY (and waits
+      # on route53 GetChange -> INSYNC) instead of discovering the zone via a public
+      # SOA walk. On a cold apply that walk runs from the apply host's resolver,
+      # which can SERVFAIL until the xdnapp.com delegation fully propagates and any
+      # negative cache expires -- blocking issuance even though the zone already
+      # exists (it's created in this same apply). Pinning removes that DNS dependency.
+      AWS_HOSTED_ZONE_ID = aws_route53_zone.acme.zone_id
     }
   }
+
+  # The post-present propagation pre-check resolves the TXT before asking the CA to
+  # validate; use public recursive resolvers for it, since the apply host's default
+  # resolver may SERVFAIL on the just-delegated zone.
+  recursive_nameservers = ["8.8.8.8:53", "1.1.1.1:53"]
 
   # Validation resolves _acme-challenge through coredns -> Route53, so the RC
   # (coredns) must be reachable. On a fully cold apply this may need a re-apply

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -246,9 +246,9 @@ variable "rc_ami" {
 }
 
 variable "ar_ami" {
-  description = "AMI for the ActiveReplica (AR) edge nodes."
+  description = "AMI for the ActiveReplica (AR) edge nodes. ARM64/Graviton image (for t4g.* ar_instance_type), built from the xdn-ar-arm64 branch by `ARCH=arm64 ./create_ar_ami.sh`. Requires multi-arch service images."
   type        = string
-  default     = "ami-05ab6b5c1b45eb8dd" # IPv6 + TLS jar
+  default     = "ami-0c22f54b43a823533" # arm64, IPv6 + TLS jar + paxos node-0 fixes
 }
 
 variable "ar_count" {
@@ -271,9 +271,9 @@ variable "rc_instance_type" {
 }
 
 variable "ar_instance_type" {
-  description = "EC2 instance type for the ActiveReplica (AR) edge nodes (run Docker + stateful apps). For Graviton (t4g.*), point ar_ami at an arm64 AR AMI (ARCH=arm64 ./create_ar_ami.sh) and ensure deployed service images are multi-arch."
+  description = "EC2 instance type for the ActiveReplica (AR) edge nodes (run Docker + stateful apps). Defaults to Graviton t4g.large (~20% cheaper than t3.large); requires an arm64 ar_ami (the default is one) and multi-arch service images."
   type        = string
-  default     = "t3.large"
+  default     = "t4g.large" # Graviton, ~$49/mo vs t3.large ~$61/mo (needs arm64 ar_ami)
 }
 
 # Run the ARs as Spot instances (~60-70% cheaper than on-demand) instead of

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -271,9 +271,22 @@ variable "rc_instance_type" {
 }
 
 variable "ar_instance_type" {
-  description = "EC2 instance type for the ActiveReplica (AR) edge nodes (run Docker + stateful apps)."
+  description = "EC2 instance type for the ActiveReplica (AR) edge nodes (run Docker + stateful apps). For Graviton (t4g.*), point ar_ami at an arm64 AR AMI (ARCH=arm64 ./create_ar_ami.sh) and ensure deployed service images are multi-arch."
   type        = string
   default     = "t3.large"
+}
+
+# Run the ARs as Spot instances (~60-70% cheaper than on-demand) instead of
+# on-demand. The 3-way Paxos quorum tolerates losing one AR to a reclaim, so this
+# fits the research/eval cluster -- not stability-critical runs. Spot price is
+# variable and capacity is not guaranteed. Uses PERSISTENT spot with `stop`
+# interruption behavior: a reclaimed AR is STOPPED (EBS + addresses preserved) and
+# auto-restarted by AWS when capacity returns, and cluster_power.sh can still
+# pause/resume it. Best paired with stop-when-idle for long experiment runs.
+variable "ar_use_spot" {
+  description = "Run ActiveReplicas as Spot instances (persistent, stop-on-interruption). ~60-70% cheaper; a reclaim is tolerated by the 3-way quorum. Suitable for the research cluster."
+  type        = bool
+  default     = false
 }
 
 # --- HTTPS / Let's Encrypt (Caddy on the ARs) ---
@@ -386,6 +399,21 @@ resource "aws_instance" "ar" {
 
   # Lets the baked Caddy answer the ACME DNS-01 challenge via Route53 (no keys).
   iam_instance_profile = aws_iam_instance_profile.ar_acme.name
+
+  # Optional Spot pricing for the ARs (var.ar_use_spot). Persistent + stop so a
+  # reclaim stops (not terminates) the AR -- EBS and the static private/IPv6
+  # addresses survive, AWS restarts it when capacity returns, and the quorum only
+  # ever loses one replica transiently. Toggling this forces AR replacement.
+  dynamic "instance_market_options" {
+    for_each = var.ar_use_spot ? [1] : []
+    content {
+      market_type = "spot"
+      spot_options {
+        spot_instance_type             = "persistent"
+        instance_interruption_behavior = "stop"
+      }
+    }
+  }
 
   # Bootstrap: drop config + a unique numeric node id (1..N) so the baked
   # xdn-ar unit starts. The RC is node 0; ARs continue from 1.

--- a/aws/rc-userdata.tftpl
+++ b/aws/rc-userdata.tftpl
@@ -4,6 +4,21 @@
 # systemd units wait for, then starts them.
 set -euo pipefail
 
+# --- swap: the RC may run on a small instance (e.g. t4g.micro, 1GB RAM). The
+#     reconfigurator JVM (default max heap ~1/4 RAM) plus coredns and the OS can
+#     briefly spike past physical RAM at boot/GC; a modest swapfile turns an
+#     OOM-kill into a slow moment. Idempotent: skipped if /swapfile already
+#     exists, and a no-op (|| true) on instances with ample RAM. ---
+( set +e
+  if [ ! -f /swapfile ]; then
+    fallocate -l 1G /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=1024
+    chmod 600 /swapfile
+    mkswap /swapfile
+    swapon /swapfile
+    grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+  fi
+) || true
+
 install -d -m 0755 /opt/xdn/conf
 
 cat > /opt/xdn/conf/gigapaxos.properties <<'PROPS'

--- a/bin/build_xdn_cli.sh
+++ b/bin/build_xdn_cli.sh
@@ -23,12 +23,15 @@ function main() {
 
   local BIN_DIR="${XDN_ROOT}/bin"
   local LINUX_AMD64_BIN="${BIN_DIR}/xdn-linux-amd64"
+  local LINUX_ARM64_BIN="${BIN_DIR}/xdn-linux-arm64"
   local DARWIN_ARM64_BIN="${BIN_DIR}/xdn-darwin-arm64"
   local HOST_OS
   local HOST_ARCH
 
-  # build the xdn cli for linux/amd64 and darwin/arm64
+  # build the xdn cli for linux/{amd64,arm64} and darwin/arm64. linux/arm64 is
+  # needed so the AR AMI builds natively on Graviton (t4g) builders.
   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${LINUX_AMD64_BIN}" .
+  CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o "${LINUX_ARM64_BIN}" .
   CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o "${DARWIN_ARM64_BIN}" .
 
   HOST_OS="$(uname -s)"
@@ -38,6 +41,9 @@ function main() {
   case "${HOST_OS}-${HOST_ARCH}" in
     Linux-x86_64)
       HOST_BIN="${LINUX_AMD64_BIN}"
+      ;;
+    Linux-aarch64 | Linux-arm64)
+      HOST_BIN="${LINUX_ARM64_BIN}"
       ;;
     Darwin-arm64)
       HOST_BIN="${DARWIN_ARM64_BIN}"
@@ -70,6 +76,7 @@ function main() {
 
   echo "Success! binaries generated:"
   echo "  ${LINUX_AMD64_BIN}"
+  echo "  ${LINUX_ARM64_BIN}"
   echo "  ${DARWIN_ARM64_BIN}"
   echo "Alias (if supported) at ${BIN_DIR}/xdn and ${SYSTEM_LINK}"
 }

--- a/src/edu/umass/cs/gigapaxos/PaxosInstanceStateMachine.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosInstanceStateMachine.java
@@ -1788,7 +1788,14 @@ public class PaxosInstanceStateMachine implements Keyable<String>, Pausable {
 							"PISM.execute total={0}ms deser={1}ms exec={2}ms cb={3}ms entry={4} req={5}",
 							new Object[]{totalMs, deserMs, execMs, cbMs,
 									isEntryReplica, request != null ? request.getClass().getSimpleName() : "null"});
-					assert (requestPacket.getEntryReplica() > 0) : requestPacket;
+					// The entry replica only needs to be SET, not strictly positive: node 0 is a
+					// valid id (e.g. the reconfigurator, which is the entry replica for the
+					// RECONFIGURATION_INTENT/COMPLETE requests it drives through paxos). The old
+					// `> 0` spuriously tripped under -ea whenever node 0 was the entry replica,
+					// even though the request had already executed above. Use the same
+					// NULL_INT_NODE guard applied to this field at proposal time (see ~L822).
+					assert (requestPacket.getEntryReplica() != IntegerMap.NULL_INT_NODE)
+							: requestPacket;
 
 					// don't try any more if stopped
 					if (pism != null && pism.isStopped())

--- a/src/edu/umass/cs/gigapaxos/PaxosManager.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosManager.java
@@ -2595,8 +2595,15 @@ public class PaxosManager<NodeIDType> {
         FindReplicaGroupPacket findGroup = new FindReplicaGroupPacket(
                 this.myID, pp); // paxosID and version should be within
         int nodeID = FindReplicaGroupPacket.getNodeID(pp);
-        NodeIDType node = nodeID > 0 ? this.integerMap.get(nodeID) :
-                (pp instanceof RequestPacket && (nodeID = ((RequestPacket) pp).getEntryReplica()) > 0 ?
+        // Treat node 0 as a valid id (e.g. the reconfigurator acting as ballot
+        // coordinator/sender, or as a request's entry replica): compare against the
+        // NULL_INT_NODE (-1) sentinel rather than `> 0`, so a node-0 source resolves
+        // through integerMap instead of spuriously falling through to a null node.
+        // The dispatch below already accepts >= 0, so node 0 was reachable but logged
+        // as null; this makes the lookup consistent. Mirrors the entry-replica guard
+        // relaxed in PaxosInstanceStateMachine (getEntryReplica != NULL_INT_NODE).
+        NodeIDType node = nodeID != IntegerMap.NULL_INT_NODE ? this.integerMap.get(nodeID) :
+                (pp instanceof RequestPacket && (nodeID = ((RequestPacket) pp).getEntryReplica()) != IntegerMap.NULL_INT_NODE ?
                         this.integerMap.get(nodeID)
                         : null);
         if (nodeID >= 0) {


### PR DESCRIPTION
Moves the AWS deployment to Graviton/arm64 and right-sizes each role.

  ## Changes
  - **Sizing:** RC → `t4g.micro` (+swapfile); ARs → `t4g.small` Graviton (override to
    `t4g.medium`/`large` for heavy DB apps). Per-role instance-type/AMI variables.
  - **arm64 build:** `ARCH` knob in `ami_common.sh`; `build_xdn_cli.sh` builds
    `linux/arm64`; Caddy + AWS CLI fetched for the host arch (the hardcoded x86_64 CLI
    broke the AR cert pull → `xdn-ar` never started). FUSE C++ was already arm64-safe.
  - **gigapaxos (general):** relax two `entryReplica > 0` checks to `!= NULL_INT_NODE`
    so node 0 (reconfigurator as entry replica/coordinator) is accepted.
  - **Cost controls:** `cluster_power.sh` (pause/resume), `ar_use_spot` toggle, and
    ACME cold-apply hardening (pin `AWS_HOSTED_ZONE_ID` + `recursive_nameservers`).

  ## Validation
  Full cold bring-up end-to-end: service launch, HTTPS per replica, linearizable write
  replicated across all 3 ARs. RC 0 OOM/0 restarts; t4g.small ARs ~1.1 GB free.

  ## Notes
  Graviton ARs need multi-arch service images. Resizing/pausing clears service
  state — re-launch after.