### PR TITLE
Add embedded SQLite and RocksDB DB backends for a lighter, faster reconfigurator

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -147,6 +147,7 @@
         <pathelement location="${lib.dir}/hamcrest-all-1.3.jar"/>
         <pathelement location="${lib.dir}/c3p0-0.9.5.jar"/>
         <pathelement location="${lib.dir}/derby.jar"/>
+        <pathelement location="${lib.dir}/sqlite-jdbc-3.46.1.3.jar"/>
         <pathelement location="${lib.dir}/json-smart-1.2.jar"/>
         <pathelement location="${lib.dir}/mchange-commons-java-0.2.9.jar"/>
         <pathelement location="${lib.dir}/mapdb-2.0.0-20151103.120435-149.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -148,6 +148,7 @@
         <pathelement location="${lib.dir}/c3p0-0.9.5.jar"/>
         <pathelement location="${lib.dir}/derby.jar"/>
         <pathelement location="${lib.dir}/sqlite-jdbc-3.46.1.3.jar"/>
+        <pathelement location="${lib.dir}/rocksdbjni-9.7.3.jar"/>
         <pathelement location="${lib.dir}/json-smart-1.2.jar"/>
         <pathelement location="${lib.dir}/mchange-commons-java-0.2.9.jar"/>
         <pathelement location="${lib.dir}/mapdb-2.0.0-20151103.120435-149.jar"/>

--- a/docs/rocksdb-vs-sqlite.md
+++ b/docs/rocksdb-vs-sqlite.md
@@ -1,0 +1,120 @@
+# RocksDB vs SQLite for a small-memory, durable paxos RC
+
+gigapaxos is a paxos-based system, so **durability is a safety requirement**: a
+node that acknowledges (promises/accepts) a value must not forget it after a
+crash, or paxos safety can be violated. The relevant comparison is therefore at
+**equal, full fsync durability** — survives an OS/power crash, not just a process
+crash.
+
+- SQLite full durability: `SQLITE_SYNCHRONOUS=FULL` (WAL fsync on every commit).
+- RocksDB full durability: `ROCKSDB_SYNC_WRITES=true` (WAL fsync on every write).
+
+All numbers below are on the same machine/disk (OpenJDK 21, local disk). The
+relaxed-durability numbers (SQLite `NORMAL`, RocksDB `sync=false`) are included
+only for reference — they keep data only across a *process* crash, with a loss
+window on an OS/power crash, so they are **not** safe for strict paxos durability.
+
+## Summary / recommendation
+
+For a durability-critical RC on a 0.5&ndash;1 GB machine **today, SQLite
+(`synchronous=FULL`) is the better-balanced choice**: it is as light as RocksDB,
+has predictable durable-write latency, and completes recovery-heavy workloads.
+RocksDB ties on memory and is competitive (or better) on *batched* durable-write
+latency, but has two issues at full durability: (1) very expensive *unbatched*
+single durable writes, and (2) slow recovery reads. RocksDB becomes the stronger
+choice if/when the logger's recovery-read path is optimized (see Future work),
+and it is the clear winner if relaxed durability is ever acceptable.
+
+## Memory (single RC node, `-Xmx128m`, RocksDB tuned for low memory)
+
+| Backend | RSS | Min heap it runs at | Threads |
+|---------|----:|--------------------:|--------:|
+| Derby (default) | 191 MB | — | 65 |
+| SQLite | 125 MB | ~48 MB | 56 |
+| RocksDB | 124 MB | ~48 MB | 56 |
+
+**Tie.** Both fit 0.5 GB with ~390 MB headroom. RocksDB's native memory is
+bounded by a shared block cache + WriteBufferManager (`ROCKSDB_BLOCK_CACHE_MB`,
+`ROCKSDB_MEMTABLE_BUDGET_MB`); SQLite is non-pooled (no C3P0 threads). Both are
+~35% lighter than the Derby default.
+
+## Latency — durable DB-layer writes (8 threads, 1 KB, full fsync)
+
+Microbenchmark of **single** durable read-modify-write ops (no batching):
+
+| Backend (full durability) | Throughput | p50 | p99 | p99.9 |
+|---------------------------|-----------:|----:|----:|------:|
+| SQLite `FULL` (single-writer) | 2941 ops/s | 0.54 ms | 77.6 ms | 165 ms |
+| SQLite `FULL` (IMMEDIATE) | 2672 ops/s | 0.06 ms | 22.8 ms | 231 ms |
+| **RocksDB `sync=true`** | **66 ops/s** | **83 ms** | 598 ms | 1066 ms |
+| RocksDB `sync=false` *(relaxed, ref only)* | 74190 ops/s | 0.08 ms | 0.89 ms | 1.96 ms |
+
+For **single, unbatched** durable writes RocksDB is dramatically slower — every
+`put` triggers a full WAL fsync, and the per-op fsync cost dominates (~83 ms p50).
+SQLite's WAL commit fsync is far cheaper here. (Relaxed RocksDB is the fastest of
+all, but is not power-loss safe.)
+
+## Latency — end-to-end reconfiguration (full durability)
+
+The real paxos logger **batches** log writes (`logBatch` = one fsync per batch),
+which is RocksDB's better case:
+
+| Backend (full durability) | test04 create latency | 18-test suite |
+|---------------------------|----------------------:|---------------|
+| SQLite `FULL` | 982 ms | **18/18 pass, 109 s** |
+| RocksDB `sync=true` | **566 ms** | 13/18, 0 failures, **timed out at 501 s** |
+
+End-to-end, RocksDB's batched create latency is *lower* (566 vs 982 ms), but the
+suite **does not finish**: it stalls in the recovery-heavy dynamic-membership
+tests (active/RC add/delete), which repeatedly stop/start/recover many paxos
+groups. SQLite finishes all 18 in 109 s. (Caveat: the RocksDB reconfigurator DB
+writes async since it is paxos-backed, whereas SQLite `FULL` applies to both the
+logger and the RC DB, so this end-to-end comparison slightly favors RocksDB.)
+
+## Why RocksDB stalls on recovery
+
+The RocksDB logger has no journal/log-index; recovery reads (`getLoggedMessages`,
+one-pass `readNextMessage`, `getLoggedAccepts/Decisions`) prefix-scan and
+deserialize the `messages` column family. Under the membership tests — which
+recover many groups repeatedly — these scans dominate. This is a performance
+characteristic, not a correctness bug (zero failures in every run).
+
+## What each is good at
+
+| | SQLite (`FULL`) | RocksDB (`sync=true`) |
+|---|---|---|
+| Memory | ~125 MB | ~125 MB |
+| Single durable write | **fast** (2941 ops/s) | slow (66 ops/s) |
+| Batched paxos log write | good | **good/better** |
+| Recovery-heavy workload | **completes (109 s)** | stalls |
+| Relaxed-durability speed | fast | **fastest** (74k ops/s) |
+| Concurrency model | single writer (handled) | concurrent writers |
+
+## Recommended configs
+
+Durable RC, today (recommended):
+```properties
+SQL_TYPE=EMBEDDED_SQLITE
+CONNECTION_POOLING=false
+SQLITE_SYNCHRONOUS=FULL          # power-loss durable
+# -Xmx96m   ->  ~125 MB RSS, fits 0.5 GB
+```
+
+RocksDB, durable (competitive on batched writes; recovery-read optimization
+pending):
+```properties
+PAXOS_LOGGER=ROCKSDB
+RECONFIGURATOR_DB=ROCKSDB
+ROCKSDB_SYNC_WRITES=true          # power-loss durable
+ROCKSDB_BLOCK_CACHE_MB=16
+ROCKSDB_MEMTABLE_BUDGET_MB=8
+```
+
+## Future work (to make RocksDB the better durable choice)
+
+1. **Optimize logger recovery reads** — cache per-paxosID message lists, or keep
+   a compact in-memory log index so recovery does not re-scan/deserialize the
+   `messages` CF. This is the main blocker.
+2. **Group-commit unbatched writes** — coalesce single `log()`/checkpoint fsyncs
+   so the per-write fsync cost is amortized (RocksDB supports group commit; the
+   gigapaxos call pattern currently does not exploit it for single writes).

--- a/docs/sqlite-backend.md
+++ b/docs/sqlite-backend.md
@@ -1,0 +1,232 @@
+# Embedded SQLite backend for gigapaxos
+
+gigapaxos persists paxos logs (`SQLPaxosLogger`) and reconfiguration state
+(`SQLReconfiguratorDB`) through a JDBC abstraction (`paxosutil.SQL`) that already
+supported Embedded Derby, MySQL, and Embedded H2. This adds **Embedded SQLite**
+as a fourth backend, plus a lightweight non-pooling data source, aimed at
+running a **lighter reconfigurator (RC) on small machines**.
+
+## TL;DR
+
+Recommended config for a small-footprint RC:
+
+```properties
+SQL_TYPE=EMBEDDED_SQLITE
+CONNECTION_POOLING=false
+# DB_MAX_CONNECTIONS must stay 0 (unbounded). See "Single-writer: why a hard
+# connection cap does NOT work" below — gigapaxos re-enters the logger while
+# holding a connection, so any finite cap self-deadlocks.
+```
+
+Versus the default (Embedded Derby + C3P0 pool), measured on this codebase:
+
+- **~25% lower process RSS** and **72 fewer JVM threads** (no C3P0 helper threads).
+- **~40× lower median DB write latency** (p50 ~0.5 ms vs ~25 ms) and ~10–35×
+  higher write throughput depending on the durability setting.
+- Passes the full 18-test reconfiguration integration suite, with only rare
+  transient `SQLITE_BUSY_SNAPSHOT` events that the paxos layer retries.
+
+Trade-off: SQLite is single-writer, so node-local DB writes serialize at the
+engine level (WAL + `busy_timeout`). For an RC this is acceptable; for a
+write-throughput-bound active replica it may not be. Note that a *hard*
+application-level single connection (`DB_MAX_CONNECTIONS=1`) is **not** usable
+here — see below.
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `paxosutil/SQL.java` | New `EMBEDDED_SQLITE` enum value + driver/URL/blob/schema/varchar methods. New vendor-aware exception classifiers `isDuplicateKeyException` / `isDuplicateTableException` / `isNonexistentTableException` (SQLite reports a null SQLState and numeric vendor codes, not Derby SQLState strings). |
+| `paxosutil/SimpleDataSource.java` | **New.** A dependency-free `DataSource`: a small bounded pool of reused connections via a close-intercepting proxy. No background/helper threads. Supports `maxIdle` (idle retention) and `maxTotal` (concurrency cap; `1` = single serialized writer). |
+| `SQLPaxosLogger.java`, `SQLReconfiguratorDB.java` | `dataSource` field retyped to `javax.sql.DataSource`. C3P0 vs `SimpleDataSource` selected by config. SQLite URL handling (plain file path, no `;create=true`), WAL/`busy_timeout`/`IMMEDIATE` pragmas, and vendor-aware blob/clob access (sqlite-jdbc does **not** implement `createBlob`/`setBlob`/`getBlob`/`setClob`; we route through `setBytes`/`getBytes`/`setString`). |
+| `PaxosConfig.java`, `ReconfigurationConfig.java` | New `CONNECTION_POOLING` and `DB_MAX_CONNECTIONS` config keys. |
+| `build.xml`, `lib/` | Added `sqlite-jdbc-3.46.1.3.jar`. |
+
+The abstraction is preserved: Derby/MySQL/H2 paths are unchanged and the full
+reconfiguration integration suite still passes 18/18 on Derby (no regression).
+
+## Configuration reference
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `SQL_TYPE` | `EMBEDDED_DERBY` | One of `EMBEDDED_DERBY`, `MYSQL`, `EMBEDDED_H2`, `EMBEDDED_SQLITE`. Shared by paxos and reconfiguration. |
+| `CONNECTION_POOLING` | `true` | `true` → C3P0 pool. `false` → `SimpleDataSource` (no pool threads). Forced `false` internally for SQLite. |
+| `DB_MAX_CONNECTIONS` | `0` | Non-pooling path only. Bounds concurrently outstanding connections (`SimpleDataSource` semaphore). **Must be `0` (unbounded) for gigapaxos** — any finite value deadlocks (see below). The plumbing exists for other embedders/uses. |
+
+SQLite connections are opened with `journal_mode=WAL`, `synchronous=NORMAL`, and
+`busy_timeout=30000` (see Durability and Concurrency below).
+
+## Why SQLite needs special handling
+
+1. **No JDBC LOB support.** The xerial `sqlite-jdbc` driver throws
+   `SQLFeatureNotSupportedException` for `Connection.createBlob`,
+   `PreparedStatement.setBlob`/`setClob`, and `ResultSet.getBlob`. We use the
+   byte/String accessors (`setBytes`/`getBytes`/`setString`) for SQLite, which
+   round-trip the exact same bytes. (Centralized in `SQLPaxosLogger`'s
+   `setBlobBytes`/`lobToBytes`/`getColumnBytes` and `SQLReconfiguratorDB`'s
+   `setClobString`.)
+
+2. **Different error reporting.** SQLite reports `getSQLState() == null` and a
+   numeric `getErrorCode()` (e.g. 19 = constraint). The new classifiers in
+   `SQL.java` handle both styles so the catch blocks stay vendor-agnostic.
+
+3. **Single writer.** Only one connection may write at a time. See below.
+
+## Durability and Concurrency
+
+### Durability (`synchronous`)
+
+- `synchronous=NORMAL` (our default, WAL mode): fsync only at WAL checkpoint.
+  **Durable across a process crash; may lose the last few commits on an OS/power
+  crash.** Fast.
+- `synchronous=FULL`: fsync every commit (equivalent to Derby's default
+  durability). Slower tail, fully crash-safe.
+
+### Concurrency: `SQLITE_BUSY`
+
+Under concurrent read-then-write transactions on multiple connections, WAL mode
+can occasionally raise `SQLITE_BUSY` / `SQLITE_BUSY_SNAPSHOT`, and `busy_timeout`
+does **not** cover `BUSY_SNAPSHOT`. In the integration suite this happens rarely
+(single-digit events across a full run) and is absorbed by the paxos layer's
+write retries, so the suite passes. This is the proven, recommended setup.
+
+Two "fixes" were evaluated and **rejected** for gigapaxos (both work in the
+isolated benchmark but break the real cluster):
+
+- `transaction_mode=IMMEDIATE` (take the write lock at `BEGIN`). Eliminates
+  `BUSY_SNAPSHOT` in the benchmark, but gigapaxos borrows a connection and
+  re-enters the logger on the same thread (e.g. `putCheckpointState` →
+  `getSetGCAndGetMinLogfile` → `unpauseLogIndex`). Holding the write lock across
+  such a nested write risks a write-lock self-deadlock.
+- `DB_MAX_CONNECTIONS=1` (single connection). See the next section.
+
+### Single-writer: why a hard connection cap does NOT work
+
+A natural idea for SQLite is to serialize all DB access through one connection.
+We implemented this (`SimpleDataSource` with a `maxTotal=1` semaphore) and it is
+clean and fast *in isolation* (0 errors, tightest tail in the benchmark). But it
+**deadlocks the real cluster at startup**, because gigapaxos acquires a
+connection and then, while still holding it, re-enters the logger and acquires a
+*second* connection on the same thread:
+
+```
+SQLPaxosLogger.putCheckpointState   // holds connection #1 (permit taken)
+  -> getSetGCAndGetMinLogfile
+    -> MessageLogDiskMap.restore
+      -> unpauseLogIndex
+        -> getDefaultConn()          // wants connection #2 -> blocks on the
+                                     //   permit the same thread already holds
+```
+
+With one permit, the nested borrow waits forever. Any finite cap below the
+maximum re-entrancy depth × concurrency has the same failure, so in practice the
+cap must be unbounded (`0`). A genuinely safe single-writer would require a
+reentrancy-aware connection design (e.g. a thread-local connection reused for
+nested borrows) — and would still need care around the explicit-transaction
+paths (`setAutoCommit(false)` batches) so a nested op cannot commit an outer
+transaction early. That is a larger change, left as future work.
+
+## Benchmark data
+
+All numbers measured on this machine (8 cores, Linux, OpenJDK 21, local disk).
+
+### Memory (13-node cluster in one JVM, `-Xmx512m`, idle baseline)
+
+| Config | RSS | C3P0/mchange threads |
+|--------|----:|---------------------:|
+| Derby + C3P0 pool | 758 MB | 72 |
+| Derby + SimpleDataSource | 724 MB | 0 |
+| SQLite + SimpleDataSource | 567 MB | 0 |
+
+- Dropping C3P0 (engine held constant): −34 MB RSS, −72 threads.
+- Derby → SQLite engine swap: −157 MB RSS.
+- Combined: **−191 MB (~25%) RSS, 72 fewer threads.**
+- Java *heap* used is similar across all three (~424–450 MB); the savings are in
+  RSS / native memory / thread stacks, not heap.
+
+### Write latency (8 threads × 2000 read-modify-write txns, 200 rows, 1 KB)
+
+`BEGIN; SELECT; UPDATE; COMMIT` per op. `DBLatencyBench` reproduces the
+gigapaxos write shape; see `src/edu/umass/cs/gigapaxos/paxosutil/DBLatencyBench.java`.
+
+| Mode | Throughput | p50 | p99 | p99.9 | max | Failed txns |
+|------|-----------:|----:|----:|------:|----:|------------:|
+| Derby + C3P0 (full durable) | 272 /s | 25.2 ms | 170 ms | 260 ms | 776 ms | 0% |
+| SQLite multi-conn pool *(naive — do not use)* | 28,342 /s | 0.06 ms | 5.3 ms | 9.7 ms | 134 ms | **34.5%** |
+| SQLite `IMMEDIATE`, WAL/NORMAL | 11,573 /s | 0.06 ms | 1.2 ms | 104 ms | 631 ms | 0% |
+| **SQLite single-writer, WAL/NORMAL** | 9,481 /s | 0.59 ms | 2.9 ms | **4.9 ms** | 227 ms | 0% |
+| SQLite `IMMEDIATE`, FULL durable | 2,672 /s | 0.06 ms | 22.8 ms | 231 ms | 4535 ms | 0% |
+| SQLite single-writer, FULL durable | 2,941 /s | 0.54 ms | 77.6 ms | 165 ms | 280 ms | 0% |
+
+This is a deliberately adversarial microbenchmark (8 threads hammering 200 rows
+with read-modify-write), so the BUSY rate is a worst case, not what the cluster
+sees (the real suite saw single-digit BUSY events per run). Takeaways:
+
+- SQLite beats Derby on median latency by ~40× and on throughput by ~10× even at
+  equal (FULL) durability; the larger gaps come partly from WAL/NORMAL durability.
+- The multi-connection pool's BUSY rate spikes under sustained contention; the
+  `IMMEDIATE` and single-writer columns show it *can* be driven to zero in
+  isolation — but neither is usable in gigapaxos (see Concurrency above). The
+  shipped config is the multi-connection pool with paxos-layer retries.
+
+### Integration tests
+
+`TESTReconfigurationClient` (5 RC + 8 AR cluster, 18 tests):
+
+- Derby + C3P0: 18/18, ~430 s.
+- SQLite (`CONNECTION_POOLING=false`, `DB_MAX_CONNECTIONS=0`): 18/18 across
+  multiple runs (~125–329 s wall — the throughput test is variance-prone), with
+  a handful (≈1–3) of transient `BUSY`/`BUSY_SNAPSHOT` events per run absorbed by
+  paxos retries.
+- SQLite with `DB_MAX_CONNECTIONS=1`: **deadlocks at startup** (re-entrant DB
+  access — see Concurrency above). Do not use.
+
+## Running it
+
+Build (the sqlite-jdbc jar is picked up from `lib/`):
+
+```bash
+ant compile
+```
+
+Run the reconfiguration integration suite against SQLite (single-writer). Note
+the harness configures nodes programmatically and forbids a `gigapaxosConfig`
+file, so config overrides are injected via `ConfiguredTestRunner`:
+
+```bash
+CP="build/classes:build/test/classes:$(ls lib/*.jar | tr '\n' ':')"
+java -ea -cp "$CP" \
+  -Djavax.net.ssl.trustStore=conf/keyStore/node100.jks \
+  -Djavax.net.ssl.trustStorePassword=qwerty \
+  -Djavax.net.ssl.keyStore=conf/keyStore/node100.jks \
+  -Djavax.net.ssl.keyStorePassword=qwerty \
+  edu.umass.cs.reconfiguration.testing.ConfiguredTestRunner \
+  edu.umass.cs.reconfiguration.testing.TESTReconfigurationClient \
+  SQL_TYPE=EMBEDDED_SQLITE CONNECTION_POOLING=false
+```
+
+Run the DB write-latency benchmark:
+
+```bash
+CP="build/classes:$(ls lib/*.jar | tr '\n' ':')"
+# mode in: derby-c3p0 derby-simple sqlite-pool sqlite-immediate sqlite-single
+#          (+ "-full" suffix on sqlite modes for synchronous=FULL)
+java -cp "$CP" edu.umass.cs.gigapaxos.paxosutil.DBLatencyBench \
+  sqlite-single 8 2000 200 1024   # mode threads opsPerThread rows payloadBytes
+```
+
+## Known limitations / future work
+
+- **Column-type migration (`reconcileTable` / `getAlterString`) is unsupported on
+  SQLite** (SQLite cannot ALTER a column's type). In practice it is not
+  exercised because SQLite stores declared types verbatim, so reconcile finds no
+  mismatch; a genuine schema migration would fail loudly.
+- `EMBEDDED_H2` remains in the abstraction but is untested here (no H2 jar in
+  `lib/`).
+- **True single-writer is not available** as a config flag (see Concurrency).
+  Achieving it safely needs a reentrancy-aware connection design plus handling
+  of the explicit-transaction paths — a worthwhile follow-up if the occasional
+  `BUSY_SNAPSHOT` retry proves to be a problem in production.
+- The `connectDB()` connection-leak fix in `SQLReconfiguratorDB` (it discarded
+  the `getDefaultConn()` result) is included; harmless before, but it was the
+  first deadlock the single-writer experiment exposed.

--- a/src/edu/umass/cs/gigapaxos/AbstractPaxosLogger.java
+++ b/src/edu/umass/cs/gigapaxos/AbstractPaxosLogger.java
@@ -113,6 +113,25 @@ public abstract class AbstractPaxosLogger {
 		addLogger(this);
 	}
 
+	/**
+	 * Factory that selects the paxos logger implementation based on the
+	 * {@link PC#PAXOS_LOGGER} config: "ROCKSDB" -&gt;
+	 * {@link RocksDBPaxosLogger}, anything else -&gt; {@link SQLPaxosLogger}
+	 * (the default; its SQL engine is in turn chosen by {@code SQL_TYPE}).
+	 *
+	 * @param id
+	 * @param strID
+	 * @param logDir
+	 * @param messenger
+	 * @return A paxos logger of the configured type.
+	 */
+	public static AbstractPaxosLogger createLogger(int id, String strID,
+			String logDir, PaxosMessenger<?> messenger) {
+		if ("ROCKSDB".equalsIgnoreCase(Config.getGlobalString(PC.PAXOS_LOGGER)))
+			return new RocksDBPaxosLogger(id, strID, logDir, messenger);
+		return new SQLPaxosLogger(id, strID, logDir, messenger);
+	}
+
 	protected static abstract class PaxosPacketizer {
 		abstract protected PaxosPacket stringToPaxosPacket(String str)
 				throws JSONException;

--- a/src/edu/umass/cs/gigapaxos/PaxosConfig.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosConfig.java
@@ -577,6 +577,34 @@ public class PaxosConfig {
 		SQL_TYPE("EMBEDDED_DERBY"),
 
 		/**
+		 * SQLite WAL durability level (the {@code synchronous} pragma). "FULL"
+		 * fsyncs every commit (survives an OS/power crash); "NORMAL" fsyncs only
+		 * at WAL checkpoints (survives a process crash, small loss window on an
+		 * OS/power crash). For strict paxos safety on power loss use FULL.
+		 */
+		SQLITE_SYNCHRONOUS("NORMAL"),
+
+		/**
+		 * Whether to use C3P0 connection pooling for the paxos logger's SQL
+		 * data source. When false, a lightweight non-pooling data source is
+		 * used (a fresh connection per operation, no idle connections or pool
+		 * helper threads), which reduces the memory/thread footprint at some
+		 * throughput cost. Should generally be false for the single-writer
+		 * EMBEDDED_SQLITE engine.
+		 */
+		CONNECTION_POOLING(true),
+
+		/**
+		 * Maximum number of concurrently outstanding DB connections when using
+		 * the non-pooling (SimpleDataSource) path. 0 means unbounded. Set to 1
+		 * to serialize all DB access through a single connection ("single
+		 * writer"), which avoids SQLite WAL SQLITE_BUSY_SNAPSHOT conflicts at
+		 * the cost of node-local DB concurrency. Ignored when CONNECTION_POOLING
+		 * is true (C3P0).
+		 */
+		DB_MAX_CONNECTIONS(0),
+
+		/**
 		 * Maximum size of a paxos replica group.
 		 */
 		MAX_GROUP_SIZE(16),

--- a/src/edu/umass/cs/gigapaxos/PaxosConfig.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosConfig.java
@@ -577,6 +577,47 @@ public class PaxosConfig {
 		SQL_TYPE("EMBEDDED_DERBY"),
 
 		/**
+		 * Selects the paxos logger implementation. "SQL" (default) uses the
+		 * JDBC-based {@link edu.umass.cs.gigapaxos.SQLPaxosLogger} (whose engine
+		 * is chosen by {@link #SQL_TYPE}); "ROCKSDB" uses the embedded key-value
+		 * {@code RocksDBPaxosLogger}. Unlike SQL_TYPE, RocksDB is not a JDBC
+		 * engine, so it is a distinct logger implementation rather than a
+		 * SQL.SQLType value.
+		 */
+		PAXOS_LOGGER("SQL"),
+
+		/**
+		 * For the ROCKSDB paxos logger: if true, every paxos log write is fsync'd
+		 * (RocksDB WriteOptions.setSync). Safer (Derby-equivalent durability),
+		 * slower. If false, writes go to RocksDB's WAL without per-write fsync
+		 * (lost only on OS/power crash), faster.
+		 */
+		ROCKSDB_SYNC_WRITES(true),
+
+		/**
+		 * Total RocksDB block-cache budget in MB, shared by ALL RocksDB
+		 * instances in the JVM (paxos logger + reconfigurator DB). Bounds the
+		 * native memory used to cache data/index/filter blocks. Small by default
+		 * for low-memory (0.5&ndash;1 GB) reconfigurator deployments.
+		 */
+		ROCKSDB_BLOCK_CACHE_MB(32),
+
+		/**
+		 * Total RocksDB memtable (write buffer) budget in MB, shared by all
+		 * RocksDB instances in the JVM via a WriteBufferManager. Bounds the
+		 * native memory used by in-memory write buffers regardless of write
+		 * load or the number of column families.
+		 */
+		ROCKSDB_MEMTABLE_BUDGET_MB(16),
+
+		/**
+		 * Per-column-family RocksDB write buffer (memtable) size in MB. Kept
+		 * small so a single column family cannot reserve a large memtable; the
+		 * aggregate is bounded by ROCKSDB_MEMTABLE_BUDGET_MB.
+		 */
+		ROCKSDB_WRITE_BUFFER_MB(4),
+
+		/**
 		 * SQLite WAL durability level (the {@code synchronous} pragma). "FULL"
 		 * fsyncs every commit (survives an OS/power crash); "NORMAL" fsyncs only
 		 * at WAL checkpoints (survives a process crash, small loss window on an

--- a/src/edu/umass/cs/gigapaxos/PaxosManager.java
+++ b/src/edu/umass/cs/gigapaxos/PaxosManager.java
@@ -374,8 +374,9 @@ public class PaxosManager<NodeIDType> {
         this.corpses = new HashMap<String, PaxosInstanceStateMachine>();
         // this.activePaxii = new HashMap<String, ActivePaxosState>();
         this.messenger = (new PaxosMessenger<NodeIDType>(niot, this.integerMap));
-        this.paxosLogger = new SQLPaxosLogger(this.myID, id.toString(),
-                paxosLogFolder, this.wrapMessenger(this.messenger));
+        this.paxosLogger = AbstractPaxosLogger.createLogger(this.myID,
+                id.toString(), paxosLogFolder,
+                this.wrapMessenger(this.messenger));
         this.nullCheckpointsEnabled = enableNullCheckpoints;
         // periodically remove active state for idle paxii
         executor.scheduleWithFixedDelay(new Deactivator(), 0,

--- a/src/edu/umass/cs/gigapaxos/RocksDBPaxosLogger.java
+++ b/src/edu/umass/cs/gigapaxos/RocksDBPaxosLogger.java
@@ -1,0 +1,769 @@
+/*
+ * Copyright (c) 2015 University of Massachusetts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package edu.umass.cs.gigapaxos;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import edu.umass.cs.gigapaxos.PaxosConfig.PC;
+import edu.umass.cs.gigapaxos.paxospackets.AcceptPacket;
+import edu.umass.cs.gigapaxos.paxospackets.PValuePacket;
+import edu.umass.cs.gigapaxos.paxospackets.PaxosPacket;
+import edu.umass.cs.gigapaxos.paxospackets.PaxosPacket.PaxosPacketType;
+import edu.umass.cs.gigapaxos.paxospackets.StatePacket;
+import edu.umass.cs.gigapaxos.paxosutil.Ballot;
+import edu.umass.cs.gigapaxos.paxosutil.HotRestoreInfo;
+import edu.umass.cs.gigapaxos.paxosutil.IntegerMap;
+import edu.umass.cs.gigapaxos.paxosutil.LogMessagingTask;
+import edu.umass.cs.gigapaxos.paxosutil.PaxosMessenger;
+import edu.umass.cs.gigapaxos.paxosutil.RecoveryInfo;
+import edu.umass.cs.gigapaxos.paxosutil.RocksDBMem;
+import edu.umass.cs.gigapaxos.paxosutil.SlotBallotState;
+import edu.umass.cs.gigapaxos.paxosutil.StringContainer;
+import edu.umass.cs.utils.Config;
+import edu.umass.cs.utils.Util;
+
+/**
+ * An {@link AbstractPaxosLogger} backed by the embedded RocksDB key-value store.
+ * Unlike {@link SQLPaxosLogger}, which is JDBC/SQL based, this stores paxos log
+ * messages and checkpoints directly as ordered key-value pairs in RocksDB column
+ * families. There is no journaling: RocksDB itself is the log.
+ * <p>
+ * Column families (logical "tables"):
+ * <ul>
+ * <li>{@code checkpoint}: paxosID -&gt; checkpoint record JSON</li>
+ * <li>{@code prevCheckpoint}: paxosID -&gt; final-epoch checkpoint record JSON</li>
+ * <li>{@code messages}: encoded(paxosID,version,type,slot,ballot,coord) -&gt;
+ * serialized PaxosPacket bytes</li>
+ * <li>{@code pause}: paxosID -&gt; serialized HotRestoreInfo</li>
+ * </ul>
+ * Message keys are encoded so that lexicographic byte order equals numeric order
+ * (fixed-width, sign-flipped big-endian ints), making the slot-range reads used
+ * by recovery and coordinator catch-up simple prefix range scans.
+ *
+ * @author arun
+ */
+public class RocksDBPaxosLogger extends AbstractPaxosLogger {
+
+	static final Charset CHARSET = Charset.forName(SQLPaxosLogger.CHARSET);
+	private static final boolean BYTEIFICATION = Config
+			.getGlobalBoolean(PC.BYTEIFICATION);
+	private static final boolean SYNC_WRITES = Config
+			.getGlobalBoolean(PC.ROCKSDB_SYNC_WRITES);
+	private static final boolean DISABLE_LOGGING = Config
+			.getGlobalBoolean(PC.DISABLE_LOGGING);
+	private static final long MAX_FINAL_STATE_AGE = SQLPaxosLogger.MAX_FINAL_STATE_AGE;
+
+	private static final byte SEP = 0; // paxosID/suffix separator (IDs are
+										// sanitized, no null bytes)
+
+	// checkpoint record JSON keys
+	private static final String K_VERSION = "v", K_SLOT = "s", K_BALLOTNUM = "bn",
+			K_COORD = "co", K_STATE = "st", K_CREATETIME = "ct", K_MEMBERS = "m";
+
+	private static final String CF_CHECKPOINT = "checkpoint",
+			CF_PREV = "prevCheckpoint", CF_MESSAGES = "messages",
+			CF_PAUSE = "pause";
+	private static final String[] CFS = { CF_CHECKPOINT, CF_PREV, CF_MESSAGES,
+			CF_PAUSE };
+
+	static {
+		RocksDB.loadLibrary();
+	}
+
+	private static Logger log = Logger.getLogger(PaxosManager.class.getName());
+
+	private final String strID;
+	private final String dbPath;
+
+	private RocksDB db;
+	private final Map<String, ColumnFamilyHandle> cfs = new HashMap<String, ColumnFamilyHandle>();
+	private final List<ColumnFamilyOptions> cfOpts = new ArrayList<ColumnFamilyOptions>();
+	private DBOptions dbOptions;
+	private final WriteOptions writeOptions = new WriteOptions()
+			.setSync(SYNC_WRITES);
+
+	private RocksIterator cpCursor; // checkpoint recovery cursor
+	private RocksIterator msgCursor; // message recovery cursor
+
+	private volatile boolean closed = false;
+
+	RocksDBPaxosLogger(int id, String strID, String dbPath,
+			PaxosMessenger<?> messenger) {
+		super(id, dbPath, messenger);
+		this.strID = strID;
+		this.dbPath = this.logDirectory + "rocksdb_" + sanitize(strID);
+		try {
+			open();
+		} catch (RocksDBException e) {
+			throw new RuntimeException("Unable to open RocksDB paxos logger at "
+					+ this.dbPath + ": " + e.getMessage(), e);
+		}
+	}
+
+	private static String sanitize(Object id) {
+		return id.toString().replace(".", "_");
+	}
+
+	private void open() throws RocksDBException {
+		new File(this.dbPath).mkdirs();
+		// names of column families to open: default + any pre-existing + ours
+		LinkedHashSet<String> names = new LinkedHashSet<String>();
+		names.add(new String(RocksDB.DEFAULT_COLUMN_FAMILY, CHARSET));
+		if (new File(this.dbPath, "CURRENT").exists())
+			try (Options o = new Options()) {
+				for (byte[] n : RocksDB.listColumnFamilies(o, this.dbPath))
+					names.add(new String(n, CHARSET));
+			}
+		for (String cf : CFS)
+			names.add(cf);
+
+		List<ColumnFamilyDescriptor> descs = new ArrayList<ColumnFamilyDescriptor>();
+		for (String name : names) {
+			ColumnFamilyOptions opts = RocksDBMem.cfOptions();
+			this.cfOpts.add(opts);
+			descs.add(new ColumnFamilyDescriptor(name.getBytes(CHARSET), opts));
+		}
+		List<ColumnFamilyHandle> handles = new ArrayList<ColumnFamilyHandle>();
+		this.dbOptions = RocksDBMem.dbOptions();
+		this.db = RocksDB.open(this.dbOptions, this.dbPath, descs, handles);
+		int i = 0;
+		for (String name : names)
+			this.cfs.put(name, handles.get(i++));
+		log.log(Level.INFO, "{0} opened RocksDB paxos logger at {1}",
+				new Object[] { this, this.dbPath });
+	}
+
+	private ColumnFamilyHandle cf(String name) {
+		return this.cfs.get(name);
+	}
+
+	public String toString() {
+		return this.getClass().getSimpleName() + this.strID;
+	}
+
+	/* ******************* key encoding ********************* */
+
+	// sign-flipped big-endian: signed order == lexicographic byte order
+	private static byte[] encodeInt(int v) {
+		v ^= 0x80000000;
+		return new byte[] { (byte) (v >>> 24), (byte) (v >>> 16),
+				(byte) (v >>> 8), (byte) v };
+	}
+
+	private static byte[] concat(byte[]... parts) {
+		int len = 0;
+		for (byte[] p : parts)
+			len += p.length;
+		byte[] out = new byte[len];
+		int off = 0;
+		for (byte[] p : parts) {
+			System.arraycopy(p, 0, out, off, p.length);
+			off += p.length;
+		}
+		return out;
+	}
+
+	private static byte[] str(String s) {
+		return s.getBytes(CHARSET);
+	}
+
+	// messages key: paxosID | SEP | version | type | slot | ballotnum | coord
+	private static byte[] msgKey(PaxosPacket packet) {
+		int[] sb = AbstractPaxosLogger.getSlotBallot(packet); // slot,bn,coord
+		return concat(str(packet.getPaxosID()), new byte[] { SEP },
+				encodeInt(packet.getVersion()),
+				new byte[] { (byte) packet.getType().getInt() },
+				encodeInt(sb[0]), encodeInt(sb[1]), encodeInt(sb[2]));
+	}
+
+	// prefix matching all messages of a paxosID
+	private static byte[] msgPrefix(String paxosID) {
+		return concat(str(paxosID), new byte[] { SEP });
+	}
+
+	// prefix matching messages of (paxosID, version, type)
+	private static byte[] msgVTPrefix(String paxosID, int version, int type) {
+		return concat(str(paxosID), new byte[] { SEP }, encodeInt(version),
+				new byte[] { (byte) type });
+	}
+
+	private static boolean startsWith(byte[] key, byte[] prefix) {
+		if (key.length < prefix.length)
+			return false;
+		for (int i = 0; i < prefix.length; i++)
+			if (key[i] != prefix[i])
+				return false;
+		return true;
+	}
+
+	/* ******************* packet (de)serialization ******************* */
+
+	private byte[] toBytes(PaxosPacket packet)
+			throws UnsupportedEncodingException {
+		if (BYTEIFICATION && IntegerMap.allInt()
+				&& packet.getType() == PaxosPacketType.ACCEPT)
+			return ((AcceptPacket) packet).toBytes();
+		String s = this.getPaxosPacketStringifier() != null ? this
+				.getPaxosPacketStringifier().paxosPacketToString(packet)
+				: packet.toString();
+		return s.getBytes(CHARSET);
+	}
+
+	private PaxosPacket toPaxosPacket(byte[] bytes) {
+		if (bytes == null)
+			return null;
+		try {
+			return this.getPacketizer() != null ? this.getPacketizer()
+					.stringToPaxosPacket(bytes) : PaxosPacket
+					.getPaxosPacket(new String(bytes, CHARSET));
+		} catch (JSONException e) {
+			log.severe(this + " could not deserialize a logged packet: " + e);
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	/* ******************* checkpoint record (de)serialization ********* */
+
+	private void putCheckpointRecord(ColumnFamilyHandle cf, String paxosID,
+			int version, Set<String> members, int slot, int ballotnum,
+			int coordinator, String state, long createTime)
+			throws RocksDBException {
+		try {
+			JSONObject json = new JSONObject();
+			json.put(K_VERSION, version);
+			json.put(K_SLOT, slot);
+			json.put(K_BALLOTNUM, ballotnum);
+			json.put(K_COORD, coordinator);
+			json.put(K_STATE, state == null ? JSONObject.NULL : state);
+			json.put(K_CREATETIME, createTime);
+			json.put(K_MEMBERS, members == null ? JSONObject.NULL : Util
+					.toJSONString(members));
+			this.db.put(cf, this.writeOptions, str(paxosID),
+					json.toString().getBytes(CHARSET));
+		} catch (JSONException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	// reads checkpoint record from cf; returns null if absent or (when
+	// matchVersion) the version differs.
+	private SlotBallotState readSBS(ColumnFamilyHandle cf, String paxosID,
+			int version, boolean matchVersion) {
+		if (this.closed)
+			return null;
+		try {
+			byte[] val = this.db.get(cf, str(paxosID));
+			if (val == null)
+				return null;
+			JSONObject json = new JSONObject(new String(val, CHARSET));
+			int v = json.getInt(K_VERSION);
+			if (matchVersion && v != version) {
+				log.log(Level.INFO, "{0} asked for {1}:{2} but got version {3}",
+						new Object[] { this, paxosID, version, v });
+				return null;
+			}
+			String state = json.isNull(K_STATE) ? null : json.getString(K_STATE);
+			String membersStr = json.isNull(K_MEMBERS) ? "[]" : json
+					.getString(K_MEMBERS);
+			return new SlotBallotState(json.getInt(K_SLOT),
+					json.getInt(K_BALLOTNUM), json.getInt(K_COORD), state, v,
+					json.getLong(K_CREATETIME),
+					Util.stringToStringSet(membersStr));
+		} catch (RocksDBException | JSONException e) {
+			log.severe(this + ": " + e.getClass().getSimpleName()
+					+ " reading checkpoint for " + paxosID + ": " + e);
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	/* ******************* checkpoint methods ******************* */
+
+	@Override
+	public void putCheckpointState(String paxosID, int version,
+			Set<String> group, int slot, Ballot ballot, String state, int gcSlot) {
+		if (this.closed)
+			return;
+		try {
+			putCheckpointRecord(cf(CF_CHECKPOINT), paxosID, version, group,
+					slot, ballot.ballotNumber, ballot.coordinatorID, state,
+					System.currentTimeMillis());
+			garbageCollectMessages(paxosID, version, gcSlot);
+		} catch (RocksDBException e) {
+			log.severe(this + " failed putCheckpointState for " + paxosID + ": "
+					+ e);
+			e.printStackTrace();
+		}
+	}
+
+	// delete logged ACCEPTs and DECISIONs with slot <= gcSlot for (paxosID,
+	// version). PREPAREs (slot == -1) are left untouched.
+	private void garbageCollectMessages(String paxosID, int version, int gcSlot) {
+		if (gcSlot < 0)
+			return;
+		int[] types = { PaxosPacketType.ACCEPT.getInt(),
+				PaxosPacketType.DECISION.getInt() };
+		for (int type : types) {
+			byte[] prefix = msgVTPrefix(paxosID, version, type);
+			byte[] end = concat(prefix, encodeInt(gcSlot + 1));
+			try {
+				this.db.deleteRange(cf(CF_MESSAGES), prefix, end);
+			} catch (RocksDBException e) {
+				log.warning(this + " deleteRange GC failed for " + paxosID + ": "
+						+ e);
+			}
+		}
+	}
+
+	@Override
+	public boolean putCheckpointState(CheckpointTask[] tasks, boolean update) {
+		if (this.closed)
+			return false;
+		boolean all = true;
+		for (CheckpointTask task : tasks) {
+			if (task == null)
+				continue;
+			putCheckpointState(task.paxosID, task.version, task.members,
+					task.slot, task.ballot, task.state, task.gcSlot);
+		}
+		return all;
+	}
+
+	@Override
+	public String getCheckpointState(String paxosID) {
+		SlotBallotState sbs = getSlotBallotState(paxosID);
+		return sbs != null ? sbs.state : null;
+	}
+
+	@Override
+	public Ballot getCheckpointBallot(String paxosID) {
+		SlotBallotState sbs = getSlotBallotState(paxosID);
+		return sbs != null ? new Ballot(sbs.ballotnum, sbs.coordinator) : null;
+	}
+
+	@Override
+	public int getCheckpointSlot(String paxosID) {
+		SlotBallotState sbs = getSlotBallotState(paxosID);
+		return sbs != null ? sbs.slot : -1;
+	}
+
+	@Override
+	public SlotBallotState getSlotBallotState(String paxosID) {
+		return readSBS(cf(CF_CHECKPOINT), paxosID, 0, false);
+	}
+
+	@Override
+	public SlotBallotState getSlotBallotState(String paxosID, int version) {
+		return readSBS(cf(CF_CHECKPOINT), paxosID, version, true);
+	}
+
+	@Override
+	public StatePacket getStatePacket(String paxosID) {
+		SlotBallotState sbs = getSlotBallotState(paxosID);
+		return sbs != null ? new StatePacket(new Ballot(sbs.ballotnum,
+				sbs.coordinator), sbs.slot, sbs.state) : null;
+	}
+
+	/* ******************* epoch-final checkpoint methods ******************* */
+
+	@Override
+	public boolean copyEpochFinalCheckpointState(String paxosID, int version) {
+		if (this.closed)
+			return false;
+		// copy the current checkpoint (if its version matches) into prev CF
+		SlotBallotState sbs = readSBS(cf(CF_CHECKPOINT), paxosID, version, true);
+		if (sbs == null)
+			return false;
+		try {
+			putCheckpointRecord(cf(CF_PREV), paxosID, sbs.version, sbs.members,
+					sbs.slot, sbs.ballotnum, sbs.coordinator, sbs.state,
+					sbs.createTime);
+			return true;
+		} catch (RocksDBException e) {
+			log.severe(this + " failed copyEpochFinalCheckpointState for "
+					+ paxosID + ": " + e);
+			return false;
+		}
+	}
+
+	@Override
+	public StringContainer getEpochFinalCheckpointState(String paxosID,
+			int version) {
+		SlotBallotState sbs = readSBS(cf(CF_PREV), paxosID, version, true);
+		return sbs != null
+				&& (System.currentTimeMillis() - sbs.createTime < MAX_FINAL_STATE_AGE) ? new StringContainer(
+				sbs.state) : null;
+	}
+
+	@Override
+	public Integer getEpochFinalCheckpointVersion(String paxosID) {
+		SlotBallotState sbs = readSBS(cf(CF_PREV), paxosID, 0, false);
+		if (sbs != null) {
+			if (System.currentTimeMillis() - sbs.createTime < MAX_FINAL_STATE_AGE)
+				return sbs.version;
+			deleteEpochFinalCheckpointState(paxosID, sbs.version);
+		}
+		return null;
+	}
+
+	@Override
+	public boolean deleteEpochFinalCheckpointState(String paxosID, int version) {
+		if (this.closed)
+			return false;
+		SlotBallotState sbs = readSBS(cf(CF_PREV), paxosID, 0, false);
+		if (sbs == null)
+			return true;
+		if (sbs.version - version <= 0) // wraparound-safe <=
+			try {
+				this.db.delete(cf(CF_PREV), str(paxosID));
+			} catch (RocksDBException e) {
+				log.severe(this + " failed deleteEpochFinalCheckpointState: " + e);
+				return false;
+			}
+		return true;
+	}
+
+	/* ******************* message logging methods ******************* */
+
+	@Override
+	public boolean log(PaxosPacket packet) {
+		if (this.closed || DISABLE_LOGGING)
+			return true;
+		try {
+			this.db.put(cf(CF_MESSAGES), this.writeOptions, msgKey(packet),
+					toBytes(packet));
+			return true;
+		} catch (RocksDBException | UnsupportedEncodingException e) {
+			log.severe(this + " failed to log packet: " + e);
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	@Override
+	public boolean logBatch(LogMessagingTask[] packets) {
+		if (this.closed || DISABLE_LOGGING)
+			return true;
+		try (WriteBatch batch = new WriteBatch()) {
+			for (LogMessagingTask lmTask : packets) {
+				if (lmTask == null || lmTask.logMsg == null)
+					continue;
+				batch.put(cf(CF_MESSAGES), msgKey(lmTask.logMsg),
+						toBytes(lmTask.logMsg));
+			}
+			this.db.write(this.writeOptions, batch);
+			return true;
+		} catch (RocksDBException | UnsupportedEncodingException e) {
+			log.severe(this + " failed to log batch of " + packets.length
+					+ ": " + e);
+			e.printStackTrace();
+			return false;
+		}
+	}
+
+	@Override
+	public ArrayList<PaxosPacket> getLoggedMessages(String paxosID) {
+		ArrayList<PaxosPacket> messages = new ArrayList<PaxosPacket>();
+		if (this.closed)
+			return messages;
+		byte[] prefix = msgPrefix(paxosID);
+		try (RocksIterator it = this.db.newIterator(cf(CF_MESSAGES))) {
+			for (it.seek(prefix); it.isValid(); it.next()) {
+				if (!startsWith(it.key(), prefix))
+					break;
+				PaxosPacket pp = toPaxosPacket(it.value());
+				if (pp != null)
+					messages.add(pp);
+			}
+		}
+		return messages;
+	}
+
+	@Override
+	public Map<Integer, PValuePacket> getLoggedAccepts(String paxosID,
+			int version, int firstSlot, Integer maxSlot) {
+		TreeMap<Integer, PValuePacket> accepted = new TreeMap<Integer, PValuePacket>();
+		if (this.closed)
+			return accepted;
+		byte[] prefix = msgVTPrefix(paxosID, version,
+				PaxosPacketType.ACCEPT.getInt());
+		try (RocksIterator it = this.db.newIterator(cf(CF_MESSAGES))) {
+			for (it.seek(prefix); it.isValid(); it.next()) {
+				if (!startsWith(it.key(), prefix))
+					break;
+				PaxosPacket pp = toPaxosPacket(it.value());
+				if (!(pp instanceof AcceptPacket))
+					continue;
+				AcceptPacket accept = (AcceptPacket) pp;
+				int slot = accept.slot;
+				if (slot - firstSlot < 0)
+					continue;
+				if (maxSlot != null && slot - maxSlot >= 0)
+					continue;
+				// keep the highest-ballot accept per slot
+				if (!accepted.containsKey(slot)
+						|| accepted.get(slot).ballot.compareTo(accept.ballot) < 0)
+					accepted.put(slot, accept);
+			}
+		}
+		return accepted;
+	}
+
+	@Override
+	public ArrayList<PValuePacket> getLoggedDecisions(String paxosID,
+			int version, int minSlot, int maxSlot) throws JSONException {
+		ArrayList<PValuePacket> decisions = new ArrayList<PValuePacket>();
+		if (this.closed)
+			return decisions;
+		byte[] prefix = msgVTPrefix(paxosID, version,
+				PaxosPacketType.DECISION.getInt());
+		try (RocksIterator it = this.db.newIterator(cf(CF_MESSAGES))) {
+			for (it.seek(prefix); it.isValid(); it.next()) {
+				if (!startsWith(it.key(), prefix))
+					break;
+				PaxosPacket pp = toPaxosPacket(it.value());
+				if (!(pp instanceof PValuePacket))
+					continue;
+				PValuePacket decision = (PValuePacket) pp;
+				int slot = decision.slot;
+				if (slot - minSlot >= 0 && slot - maxSlot < 0)
+					decisions.add(decision);
+			}
+		}
+		return decisions;
+	}
+
+	/* ******************* pause/unpause methods ******************* */
+
+	@Override
+	protected boolean pause(String paxosID, String serialized) {
+		if (this.closed)
+			return false;
+		try {
+			this.db.put(cf(CF_PAUSE), this.writeOptions, str(paxosID),
+					str(serialized));
+			return true;
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to pause " + paxosID + ": " + e);
+			return false;
+		}
+	}
+
+	@Override
+	protected Map<String, HotRestoreInfo> pause(Map<String, HotRestoreInfo> hriMap) {
+		// must return a NEW map of the successfully-paused entries: the caller
+		// (PaxosManager.pause) iterates the returned map's values while
+		// removing those keys from its own hriMap, so returning the same map
+		// instance would throw ConcurrentModificationException.
+		Map<String, HotRestoreInfo> paused = new HashMap<String, HotRestoreInfo>();
+		if (this.closed)
+			return paused;
+		try (WriteBatch batch = new WriteBatch()) {
+			for (Map.Entry<String, HotRestoreInfo> e : hriMap.entrySet())
+				batch.put(cf(CF_PAUSE), str(e.getKey()), str(e.getValue()
+						.toString()));
+			this.db.write(this.writeOptions, batch);
+			paused.putAll(hriMap); // all succeeded atomically
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to pause batch: " + e);
+			return new HashMap<String, HotRestoreInfo>();
+		}
+		return paused;
+	}
+
+	@Override
+	protected HotRestoreInfo unpause(String paxosID) {
+		if (this.closed)
+			return null;
+		try {
+			byte[] val = this.db.get(cf(CF_PAUSE), str(paxosID));
+			if (val == null)
+				return null;
+			HotRestoreInfo hri = new HotRestoreInfo(new String(val, CHARSET));
+			this.db.delete(cf(CF_PAUSE), str(paxosID));
+			return hri;
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to unpause " + paxosID + ": " + e);
+			return null;
+		}
+	}
+
+	/* ******************* recovery methods ******************* */
+
+	@Override
+	public RecoveryInfo getRecoveryInfo(String paxosID) {
+		SlotBallotState sbs = getSlotBallotState(paxosID);
+		if (sbs == null)
+			return null;
+		return new RecoveryInfo(paxosID, sbs.version,
+				sbs.members.toArray(new String[0]));
+	}
+
+	@Override
+	public synchronized boolean initiateReadCheckpoints(boolean b) {
+		if (this.closed)
+			return false;
+		// idempotent: callers loop `while (initiateReadCheckpoints(.));` and
+		// rely on a second call returning false (cursor already created) to
+		// terminate the loop.
+		if (this.cpCursor != null)
+			return false;
+		this.cpCursor = this.db.newIterator(cf(CF_CHECKPOINT));
+		this.cpCursor.seekToFirst();
+		return true;
+	}
+
+	@Override
+	public RecoveryInfo readNextCheckpoint(boolean readState) {
+		if (this.closed || this.cpCursor == null || !this.cpCursor.isValid())
+			return null;
+		RecoveryInfo pri = null;
+		try {
+			String paxosID = new String(this.cpCursor.key(), CHARSET);
+			JSONObject json = new JSONObject(new String(this.cpCursor.value(),
+					CHARSET));
+			int version = json.getInt(K_VERSION);
+			String membersStr = json.isNull(K_MEMBERS) ? "[]" : json
+					.getString(K_MEMBERS);
+			String[] members = Util.stringToStringSet(membersStr).toArray(
+					new String[0]);
+			String state = (readState && !json.isNull(K_STATE)) ? json
+					.getString(K_STATE) : null;
+			pri = readState ? new RecoveryInfo(paxosID, version, members, state)
+					: new RecoveryInfo(paxosID, version, members);
+		} catch (JSONException e) {
+			log.severe(this + " failed to parse checkpoint during recovery: " + e);
+		}
+		this.cpCursor.next();
+		return pri;
+	}
+
+	@Override
+	public synchronized boolean initiateReadMessages() {
+		if (this.closed)
+			return false;
+		if (this.msgCursor != null)
+			return false; // already initiated (see initiateReadCheckpoints)
+		this.msgCursor = this.db.newIterator(cf(CF_MESSAGES));
+		this.msgCursor.seekToFirst();
+		return true;
+	}
+
+	@Override
+	public PaxosPacket readNextMessage() {
+		if (this.closed || this.msgCursor == null)
+			return null;
+		while (this.msgCursor.isValid()) {
+			PaxosPacket pp = toPaxosPacket(this.msgCursor.value());
+			this.msgCursor.next();
+			if (pp != null)
+				return pp;
+		}
+		return null;
+	}
+
+	@Override
+	public void closeReadAll() {
+		closeCursor(this.cpCursor);
+		closeCursor(this.msgCursor);
+		this.cpCursor = null;
+		this.msgCursor = null;
+	}
+
+	private static void closeCursor(RocksIterator it) {
+		if (it != null)
+			it.close();
+	}
+
+	/* ******************* removal/close methods ******************* */
+
+	@Override
+	public boolean remove(String paxosID, int version) {
+		if (this.closed)
+			return false;
+		try {
+			this.db.delete(cf(CF_CHECKPOINT), str(paxosID));
+			this.db.delete(cf(CF_PREV), str(paxosID));
+			this.db.delete(cf(CF_PAUSE), str(paxosID));
+			// delete all messages for this paxosID: [paxosID|SEP, paxosID|SEP+1)
+			byte[] begin = msgPrefix(paxosID);
+			byte[] end = concat(str(paxosID), new byte[] { (byte) (SEP + 1) });
+			this.db.deleteRange(cf(CF_MESSAGES), begin, end);
+			return true;
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to remove " + paxosID + ": " + e);
+			return false;
+		}
+	}
+
+	@Override
+	public boolean removeAll() {
+		if (this.closed)
+			return false;
+		for (String cfName : CFS)
+			try (RocksIterator it = this.db.newIterator(cf(cfName))) {
+				for (it.seekToFirst(); it.isValid(); it.next())
+					this.db.delete(cf(cfName), it.key());
+			} catch (RocksDBException e) {
+				log.severe(this + " failed removeAll on " + cfName + ": " + e);
+				return false;
+			}
+		return true;
+	}
+
+	@Override
+	public void closeImpl() {
+		if (this.closed)
+			return;
+		this.closed = true;
+		closeReadAll();
+		for (ColumnFamilyHandle h : this.cfs.values())
+			h.close();
+		if (this.db != null)
+			this.db.close();
+		if (this.dbOptions != null)
+			this.dbOptions.close();
+		this.writeOptions.close();
+		for (ColumnFamilyOptions o : this.cfOpts)
+			o.close();
+		log.log(Level.INFO, "{0} closed RocksDB paxos logger", this);
+	}
+}

--- a/src/edu/umass/cs/gigapaxos/SQLPaxosLogger.java
+++ b/src/edu/umass/cs/gigapaxos/SQLPaxosLogger.java
@@ -30,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.sql.Blob;
 import java.sql.Clob;
+import java.sql.Types;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
@@ -92,6 +93,7 @@ import edu.umass.cs.gigapaxos.paxosutil.PaxosInstanceCreationException;
 import edu.umass.cs.gigapaxos.paxosutil.PaxosMessenger;
 import edu.umass.cs.gigapaxos.paxosutil.RecoveryInfo;
 import edu.umass.cs.gigapaxos.paxosutil.SQL;
+import edu.umass.cs.gigapaxos.paxosutil.SimpleDataSource;
 import edu.umass.cs.gigapaxos.paxosutil.SlotBallotState;
 import edu.umass.cs.gigapaxos.paxosutil.StringContainer;
 import edu.umass.cs.utils.Config;
@@ -141,6 +143,13 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			+ PC.PAXOS_LOGS_DIR.getDefaultValue();
 	private static final boolean CONN_POOLING = true; // should stay true
 	private static final int MAX_POOL_SIZE = 100; // no point fiddling
+	/**
+	 * Whether to use C3P0 pooling. Disabled automatically for the single-writer
+	 * EMBEDDED_SQLITE engine, or by setting CONNECTION_POOLING=false.
+	 */
+	private static final boolean USE_POOLING = Config
+			.getGlobalBoolean(PC.CONNECTION_POOLING)
+			&& !SQL_TYPE.equals(SQL.SQLType.EMBEDDED_SQLITE);
 
 	/**
 	 * Don't change any of the table names below, otherwise it will break
@@ -223,7 +232,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 
 	private static final ArrayList<SQLPaxosLogger> instances = new ArrayList<SQLPaxosLogger>();
 
-	private ComboPooledDataSource dataSource = null;
+	private DataSource dataSource = null;
 	private Connection defaultConn = null;
 	private Connection cursorConn = null;
 
@@ -569,7 +578,8 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 				insertCP.setInt(4, cpRecord.getInt("ballotnum"));
 				insertCP.setInt(5, cpRecord.getInt("coordinator"));
 				if (getCheckpointBlobOption()) {
-					insertCP.setBlob(7, cpRecord.getBlob("state"));
+					setBlobBytes(insertCP, 7, conn,
+							getColumnBytes(cpRecord, "state"));
 				} else
 					insertCP.setString(6, cpRecord.getString("state"));
 				insertCP.setLong(7, cpRecord.getLong("create_time"));
@@ -1253,9 +1263,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 
 				if (getLogMessageBlobOption()) {
 					pstmt.setInt(9, packets[i].length);// msgBytes.length);
-					Blob blob = conn.createBlob();
-					blob.setBytes(1, msgBytes);
-					pstmt.setBlob(10, blob);
+					setBlobBytes(pstmt, 10, conn, msgBytes);
 				} else {
 					String packetString = packet.toString();
 					pstmt.setInt(9, packetString.length());
@@ -1416,9 +1424,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			insertCP.setInt(4, ballot.ballotNumber);
 			insertCP.setInt(5, ballot.coordinatorID);
 			if (getCheckpointBlobOption()) {
-				Blob blob = conn.createBlob();
-				blob.setBytes(1, state.getBytes(CHARSET));
-				insertCP.setBlob(6, blob);
+				setBlobBytes(insertCP, 6, conn, state.getBytes(CHARSET));
 			} else
 				insertCP.setString(6, state);
 			insertCP.setLong(7, createTime);
@@ -1618,9 +1624,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 				insertCP.setInt(4, task.ballot.ballotNumber);
 				insertCP.setInt(5, task.ballot.coordinatorID);
 				if (getCheckpointBlobOption()) {
-					Blob blob = conn.createBlob();
-					blob.setBytes(1, task.state.getBytes(CHARSET));
-					insertCP.setBlob(6, blob);
+					setBlobBytes(insertCP, 6, conn, task.state.getBytes(CHARSET));
 				} else
 					insertCP.setString(6, task.state);
 				insertCP.setLong(7, task.createTime);
@@ -1875,9 +1879,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			localLogMsgStmt.setInt(6, type.getInt());
 			if (getLogMessageBlobOption()) {
 				// localLogMsgStmt.setBlob(7, new StringReader(message));
-				Blob blob = conn.createBlob();
-				blob.setBytes(1, message.getBytes(CHARSET));
-				localLogMsgStmt.setBlob(7, blob);
+				setBlobBytes(localLogMsgStmt, 7, conn, message.getBytes(CHARSET));
 			} else
 				localLogMsgStmt.setString(7, message);
 
@@ -1888,7 +1890,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 					new Object[] { this, paxosID, slot, ballotnum, coordinator,
 							message });
 		} catch (SQLException sqle) {
-			if (SQL.DUPLICATE_KEY.contains(sqle.getSQLState())) {
+			if (SQL.isDuplicateKeyException(sqle)) {
 				log.log(Level.FINE, "{0} log message {1} previously logged",
 						new Object[] { this, message });
 				logged = true;
@@ -2032,9 +2034,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 					// we pause logIndex as well with older MessageLogPausable
 					logIndexBytes = deflate(this.messageLog
 							.getLogIndex(paxosID).toString().getBytes(CHARSET));
-					blob = conn.createBlob();
-					blob.setBytes(1, logIndexBytes);
-					pstmt.setBlob(2, blob);
+					setBlobBytes(pstmt, 2, conn, logIndexBytes);
 					assert (new String(inflate(logIndexBytes), CHARSET)
 							.equals(this.messageLog.getLogIndex(paxosID)
 									.toString()));
@@ -2049,9 +2049,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 							: insertCmdNoLogIndex);
 					pstmt.setString(1, serializedState);
 					if (pauseLogIndex) {
-						blob = conn.createBlob();
-						blob.setBytes(1, logIndexBytes);
-						pstmt.setBlob(2, blob);
+						setBlobBytes(pstmt, 2, conn, logIndexBytes);
 					}
 					pstmt.setString(pauseLogIndex ? 3 : 2, paxosID);
 					pstmt.executeUpdate();
@@ -2098,9 +2096,8 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 				if (serialized != null)
 					hri = new HotRestoreInfo(serialized);
 
-				Blob logIndexBlob = rset.getBlob(2);
-				logIndexString = lobToString(logIndexBlob);
-				if (logIndexBlob != null) {
+				logIndexString = lobToString(rset, 2);
+				if (logIndexString != null) {
 					this.messageLog.restore(new LogIndex(new JSONArray(
 							logIndexString)));
 				}
@@ -2172,9 +2169,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 
 				byte[] logIndexBytes = logIndex != null ? deflate(logIndex
 						.toString().getBytes(CHARSET)) : null;
-				Blob blob = conn.createBlob();
-				blob.setBytes(1, logIndexBytes);
-				pstmt.setBlob(1, blob);
+				setBlobBytes(pstmt, 1, conn, logIndexBytes);
 
 				pstmt.setString(2, paxosID);
 				try {
@@ -2184,9 +2179,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 					// try insert
 					pstmt = conn.prepareStatement(insertCmd);
 
-					blob = conn.createBlob();
-					blob.setBytes(1, logIndexBytes);
-					pstmt.setBlob(1, blob);
+					setBlobBytes(pstmt, 1, conn, logIndexBytes);
 
 					pstmt.setString(2, paxosID);
 					pstmt.executeUpdate();
@@ -2249,10 +2242,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 							&& Util.oneIn(Integer.MAX_VALUE))
 						DelayProfiler.updateMovAvg("logindex_size",
 								logIndexBytes.length);
-					Blob blob = conn.createBlob();
-					if (logIndexBytes != null)
-						blob.setBytes(1, logIndexBytes);
-					pstmt.setBlob(1, logIndexBytes != null ? blob : null);
+					setBlobBytes(pstmt, 1, conn, logIndexBytes);
 					pstmt.setString(2, paxosID);
 					pstmt.addBatch();
 					batch.add(paxosID);
@@ -2307,10 +2297,9 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 									: getPTable()), paxosID, "logindex");
 			rset = pstmt.executeQuery();
 			while (rset.next()) {
-				Blob logIndexBlob = rset.getBlob(1);
-				if (logIndexBlob == null)
+				logIndexString = lobToString(rset, 1);
+				if (logIndexString == null)
 					continue;
-				logIndexString = (lobToString(logIndexBlob));
 				logIndex = new LogIndex(new JSONArray(logIndexString));
 				this.messageLog.restore(logIndex);
 				log.log(Level.FINE, "{0} unpaused logIndex for {1}",
@@ -2356,7 +2345,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			while (stateRS.next()) {
 				assert (state == null); // single result
 				state = (!getCheckpointBlobOption() || !column.equals("state") ? stateRS
-						.getString(1) : lobToString(stateRS.getBlob(1)));
+						.getString(1) : lobToString(stateRS, 1));
 			}
 		} catch (IOException e) {
 			log.severe(this + ": IOException while getting state " + " : " + e);
@@ -2428,6 +2417,66 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 		return bytes != null ? new String(lobToBytes(blob), CHARSET) : null;
 	}
 
+	/* ***************************************************************
+	 * Vendor-agnostic BLOB access. The xerial sqlite-jdbc driver does not
+	 * implement Connection.createBlob(), PreparedStatement.setBlob(Blob), or
+	 * ResultSet.getBlob(.) (all throw SQLFeatureNotSupportedException), but it
+	 * does support the byte[] accessors setBytes/getBytes against BLOB columns.
+	 * The helpers below route through byte[] for SQLite and through the JDBC
+	 * Blob API for everyone else, preserving the exact bytes on the wire so
+	 * behavior is identical to the Derby/H2/MySQL paths. */
+
+	private static byte[] getColumnBytes(ResultSet rs, int idx)
+			throws SQLException {
+		if (isSQLite())
+			return rs.getBytes(idx);
+		Blob blob = rs.getBlob(idx);
+		return blob != null ? blob.getBytes(1L, (int) blob.length()) : null;
+	}
+
+	private static byte[] getColumnBytes(ResultSet rs, String col)
+			throws SQLException {
+		if (isSQLite())
+			return rs.getBytes(col);
+		Blob blob = rs.getBlob(col);
+		return blob != null ? blob.getBytes(1L, (int) blob.length()) : null;
+	}
+
+	private static byte[] lobToBytes(ResultSet rs, int idx)
+			throws SQLException, IOException {
+		byte[] raw = getColumnBytes(rs, idx);
+		return raw != null ? inflate(raw) : null;
+	}
+
+	private static byte[] lobToBytes(ResultSet rs, String col)
+			throws SQLException, IOException {
+		byte[] raw = getColumnBytes(rs, col);
+		return raw != null ? inflate(raw) : null;
+	}
+
+	private static String lobToString(ResultSet rs, int idx)
+			throws SQLException, IOException {
+		byte[] bytes = lobToBytes(rs, idx);
+		return bytes != null ? new String(bytes, CHARSET) : null;
+	}
+
+	/* Sets a BLOB parameter from raw bytes, using setBytes for SQLite and the
+	 * Blob API otherwise. {@code conn} is only used for the non-SQLite path. */
+	private static void setBlobBytes(PreparedStatement pstmt, int idx,
+			Connection conn, byte[] bytes) throws SQLException {
+		if (bytes == null) {
+			pstmt.setNull(idx, Types.BLOB);
+			return;
+		}
+		if (isSQLite()) {
+			pstmt.setBytes(idx, bytes);
+			return;
+		}
+		Blob blob = conn.createBlob();
+		blob.setBytes(1, bytes);
+		pstmt.setBlob(idx, blob);
+	}
+
 	/**
 	 * Methods to get slot, ballotnum, coordinator, state, and version of
 	 * checkpoint
@@ -2474,7 +2523,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 					sb = new SlotBallotState(stateRS.getInt(1),
 							stateRS.getInt(2), stateRS.getInt(3),
 							(!getCheckpointBlobOption() ? stateRS.getString(4)
-									: lobToString(stateRS.getBlob(4))),
+									: lobToString(stateRS, 4)),
 							stateRS.getInt(5), stateRS.getLong(6),
 							Util.stringToStringSet(stateRS.getString(7)));
 			}
@@ -2593,7 +2642,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 				String members = cursorRset.getString(3);
 				String[] pieces = Util.jsonToStringArray(members);
 				String state = (readState ? (!getCheckpointBlobOption() ? cursorRset
-						.getString(4) : lobToString(cursorRset.getBlob(4)))
+						.getString(4) : lobToString(cursorRset, 4))
 						: null);
 				pri = new RecoveryInfo(paxosID, version, pieces, state);
 				/* Whenever a checkpoint is found, we must try to restore the
@@ -2768,7 +2817,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 											: PaxosPacket
 													.getPaxosPacket(packetStr);
 							} else {
-								packetBytes = lobToBytes(cursorRset.getBlob(1));
+								packetBytes = lobToBytes(cursorRset, 1);
 								if (packetBytes != null)
 									pp = this.getPacketizer() != null ? this
 											.getPacketizer()
@@ -3012,7 +3061,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 				try {
 					logMsgBytes = (!ENABLE_JOURNALING ? (!getLogMessageBlobOption() ? messagesRS
 							.getString("message").getBytes(CHARSET)
-							: lobToBytes(messagesRS.getBlob("message")))
+							: lobToBytes(messagesRS, "message"))
 
 							: this.getJournaledMessage(
 									messagesRS.getString("logfile"),
@@ -3898,7 +3947,12 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 
 	private static boolean isEmbeddedDB() {
 		return SQL_TYPE.equals(SQL.SQLType.EMBEDDED_DERBY)
-				|| SQL_TYPE.equals(SQL.SQLType.EMBEDDED_H2);
+				|| SQL_TYPE.equals(SQL.SQLType.EMBEDDED_H2)
+				|| SQL_TYPE.equals(SQL.SQLType.EMBEDDED_SQLITE);
+	}
+
+	private static boolean isSQLite() {
+		return SQL_TYPE.equals(SQL.SQLType.EMBEDDED_SQLITE);
 	}
 
 	/**
@@ -4201,7 +4255,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			stmt.execute(cmd);
 			created = true;
 		} catch (SQLException sqle) {
-			if (SQL.DUPLICATE_TABLE.contains(sqle.getSQLState())) {
+			if (SQL.isDuplicateTableException(sqle)) {
 				log.log(Level.INFO, "{0}{1}{2}", new Object[] { "Table ",
 						table, " already exists" });
 				created = true;
@@ -4232,7 +4286,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			log.log(Level.FINE, "{0}{1}{2}", new Object[] { this,
 					" dropped pause table ", table });
 		} catch (SQLException sqle) {
-			if (!SQL.NONEXISTENT_TABLE.contains(sqle.getSQLState())) {
+			if (!SQL.isNonexistentTableException(sqle)) {
 				log.severe(this + " could not drop table " + table + ":"
 						+ sqle.getSQLState() + ":" + sqle.getErrorCode());
 				sqle.printStackTrace();
@@ -4255,7 +4309,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			log.log(Level.FINE, "{0}{1}{2}", new Object[] { this,
 					" dropped pause table ", table });
 		} catch (SQLException sqle) {
-			if (!SQL.NONEXISTENT_TABLE.contains(sqle.getSQLState())) {
+			if (!SQL.isNonexistentTableException(sqle)) {
 				log.severe(this + " could not clear table " + table + ":"
 						+ sqle.getSQLState() + ":" + sqle.getErrorCode());
 				sqle.printStackTrace();
@@ -4351,9 +4405,15 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 				SQL.getUser() + (isEmbeddedDB() ? this.getMyIDSanitized()/* this.myID */
 				: ""));
 		props.put("password", SQL.getPassword());
+		if (isSQLite())
+			addSQLitePragmas(props);
 		ensureLogDirectoryExists(this.logDirectory);
 		String dbCreation = SQL.getProtocolOrURL(SQL_TYPE)
-				+ (isEmbeddedDB() ?
+				+ (isSQLite() ?
+				// SQLite: the URL is just a file path; the file is created
+				// automatically on first connect (no ";create=true" flag).
+				this.logDirectory + this.getMyDBName()
+				: isEmbeddedDB() ?
 				// embedded DB pre-creates DB to avoid c3p0 stack traces
 				this.logDirectory
 						+ this.getMyDBName()
@@ -4364,8 +4424,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 						this.getMyDBName() + "?createDatabaseIfNotExist=true");
 
 		try {
-			dataSource = (ComboPooledDataSource) setupDataSourceC3P0(
-					dbCreation, props);
+			dataSource = setupDataSource(dbCreation, props);
 		} catch (SQLException e) {
 			log.severe(this + " could not create pooled data source to DB "
 					+ dbCreation);
@@ -4571,7 +4630,7 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 			messagesRS = pstmt.executeQuery();
 			while (messagesRS.next() && !logged) {
 				String insertedMsg = (!getLogMessageBlobOption() ? messagesRS
-						.getString(2) : lobToString(messagesRS.getBlob(2)));
+						.getString(2) : lobToString(messagesRS, 2));
 				logged = msg.equals(insertedMsg);
 			}
 		} catch (SQLException | IOException e) {
@@ -4647,6 +4706,34 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 		return (double) (t2 - t1) / size;
 	}
 
+	/* Adds SQLite pragmas (passed as connection properties, which the xerial
+	 * sqlite-jdbc driver applies on connect) that make multiple concurrent
+	 * connections to the same database file behave well: WAL allows a writer to
+	 * coexist with readers, and a busy timeout makes writers wait for the file
+	 * lock instead of immediately failing with SQLITE_BUSY. */
+	private static void addSQLitePragmas(Properties props) {
+		props.put("journal_mode", "WAL");
+		props.put("synchronous", Config.getGlobalString(PC.SQLITE_SYNCHRONOUS));
+		props.put("busy_timeout", "30000"); // ms
+		// NOTE: transaction_mode=IMMEDIATE would convert the rare
+		// SQLITE_BUSY_SNAPSHOT into a busy_timeout wait, but gigapaxos borrows
+		// a connection and re-enters the logger (e.g. putCheckpointState ->
+		// unpauseLogIndex) on the same thread; taking the write lock eagerly
+		// risks a write-lock self-deadlock on such nested paths, so we leave
+		// transactions DEFERRED and rely on upper-layer paxos retries for the
+		// occasional BUSY_SNAPSHOT.
+	}
+
+	private static DataSource setupDataSource(String connectURI,
+			Properties props) throws SQLException {
+		if (USE_POOLING)
+			return setupDataSourceC3P0(connectURI, props);
+		int maxTotal = Config.getGlobalInt(PC.DB_MAX_CONNECTIONS);
+		// keep at least the bounded number of connections warm in the idle pool
+		int maxIdle = maxTotal > 0 ? maxTotal : 8;
+		return new SimpleDataSource(connectURI, props, maxIdle, maxTotal);
+	}
+
 	private static DataSource setupDataSourceC3P0(String connectURI,
 			Properties props) throws SQLException {
 
@@ -4668,9 +4755,19 @@ public class SQLPaxosLogger extends AbstractPaxosLogger {
 	}
 
 	private void fixURI() {
-		this.dataSource.setJdbcUrl(SQL.getProtocolOrURL(SQL_TYPE)
+		setDataSourceJdbcUrl(this.dataSource, SQL.getProtocolOrURL(SQL_TYPE)
 				+ this.logDirectory + this.getMyDBName()
 				+ (isEmbeddedDB() ? "" : "?rewriteBatchedStatements=true"));
+	}
+
+	/* The dataSource field is the javax.sql.DataSource interface so that either
+	 * a pooled (C3P0) or non-pooled (SimpleDataSource) implementation can be
+	 * used. Neither exposes setJdbcUrl on the interface, so dispatch here. */
+	static void setDataSourceJdbcUrl(DataSource ds, String url) {
+		if (ds instanceof ComboPooledDataSource)
+			((ComboPooledDataSource) ds).setJdbcUrl(url);
+		else if (ds instanceof SimpleDataSource)
+			((SimpleDataSource) ds).setJdbcUrl(url);
 	}
 
 	/**

--- a/src/edu/umass/cs/gigapaxos/paxosutil/DBLatencyBench.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/DBLatencyBench.java
@@ -1,0 +1,274 @@
+package edu.umass.cs.gigapaxos.paxosutil;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.sql.DataSource;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+/**
+ * A controlled, repeatable DB write-path latency benchmark. It drives many
+ * concurrent read-modify-write transactions (BEGIN; SELECT; UPDATE; COMMIT) at
+ * a small set of rows through the real DataSource machinery (C3P0 or
+ * {@link SimpleDataSource}) and reports throughput and latency percentiles plus
+ * a breakdown of SQLite BUSY/BUSY_SNAPSHOT errors. This is the transaction
+ * shape gigapaxos uses (read state, then write), and the one that exposes
+ * SQLite's single-writer contention.
+ *
+ * Usage: DBLatencyBench &lt;mode&gt; &lt;threads&gt; &lt;opsPerThread&gt; &lt;rows&gt; &lt;payloadBytes&gt;
+ * mode in { derby-c3p0, derby-simple, sqlite-pool, sqlite-immediate, sqlite-single }
+ */
+public class DBLatencyBench {
+
+	static final String DIR_BASE = "/tmp/dbbench";
+
+	public static void main(String[] args) throws Exception {
+		String mode = args.length > 0 ? args[0] : "sqlite-pool";
+		int threads = args.length > 1 ? Integer.parseInt(args[1]) : 8;
+		int opsPerThread = args.length > 2 ? Integer.parseInt(args[2]) : 2000;
+		int rows = args.length > 3 ? Integer.parseInt(args[3]) : 200;
+		int payloadBytes = args.length > 4 ? Integer.parseInt(args[4]) : 1024;
+
+		String dir = DIR_BASE + "_" + mode;
+		recursiveDelete(new File(dir));
+		new File(dir).mkdirs();
+
+		boolean sqlite = mode.startsWith("sqlite");
+		DataSource ds = buildDataSource(mode, dir);
+
+		String blobType = sqlite ? "text" : "varchar(8192)";
+		try (Connection c = ds.getConnection()) {
+			c.setAutoCommit(true);
+			try (PreparedStatement p = c.prepareStatement("drop table bench")) {
+				p.execute();
+			} catch (SQLException ignore) {
+			}
+			try (PreparedStatement p = c.prepareStatement("create table bench(id int primary key, payload "
+					+ blobType + ")")) {
+				p.execute();
+			}
+			try (PreparedStatement p = c
+					.prepareStatement("insert into bench(id,payload) values(?,?)")) {
+				for (int i = 0; i < rows; i++) {
+					p.setInt(1, i);
+					p.setString(2, "init");
+					p.executeUpdate();
+				}
+			}
+		}
+
+		final String payload = makePayload(payloadBytes);
+		final DataSource fds = ds;
+		// warmup
+		runLoad(fds, 2, 50, rows, payload, new long[0], null);
+
+		final long[][] perThread = new long[threads][opsPerThread];
+		final ConcurrentHashMap<String, AtomicInteger> errors = new ConcurrentHashMap<String, AtomicInteger>();
+		final CountDownLatch start = new CountDownLatch(1);
+		final CountDownLatch done = new CountDownLatch(threads);
+		List<Thread> ts = new ArrayList<Thread>();
+		for (int t = 0; t < threads; t++) {
+			final int tid = t;
+			Thread th = new Thread(() -> {
+				Random rnd = new Random(tid * 9973L + 7);
+				try {
+					start.await();
+				} catch (InterruptedException e) {
+				}
+				for (int i = 0; i < opsPerThread; i++) {
+					long t0 = System.nanoTime();
+					perThread[tid][i] = doTxn(fds, rows, payload, rnd, errors);
+					if (perThread[tid][i] < 0)
+						perThread[tid][i] = System.nanoTime() - t0; // record even on error
+				}
+				done.countDown();
+			});
+			ts.add(th);
+			th.start();
+		}
+		long wall0 = System.nanoTime();
+		start.countDown();
+		done.await();
+		long wallNs = System.nanoTime() - wall0;
+
+		// merge
+		long[] all = new long[threads * opsPerThread];
+		int k = 0;
+		for (long[] arr : perThread)
+			for (long v : arr)
+				all[k++] = v;
+		Arrays.sort(all);
+		double totalOps = all.length;
+		double wallSec = wallNs / 1e9;
+
+		System.out.println("=== mode=" + mode + " threads=" + threads
+				+ " opsPerThread=" + opsPerThread + " rows=" + rows
+				+ " payloadBytes=" + payloadBytes + " ===");
+		System.out.printf("ops=%d  wall=%.2fs  throughput=%.0f ops/s%n",
+				(long) totalOps, wallSec, totalOps / wallSec);
+		System.out.printf(
+				"latency ms: p50=%.2f  p90=%.2f  p99=%.2f  p999=%.2f  max=%.2f  mean=%.2f%n",
+				pct(all, 50), pct(all, 90), pct(all, 99), pct(all, 99.9),
+				all[all.length - 1] / 1e6, mean(all) / 1e6);
+		int totalErr = 0;
+		for (String key : errors.keySet()) {
+			int v = errors.get(key).get();
+			totalErr += v;
+			System.out.println("  error[" + key + "]=" + v);
+		}
+		System.out.println("total_errors=" + totalErr + " ("
+				+ String.format("%.2f", 100.0 * totalErr / totalOps) + "% of ops)");
+		if (ds instanceof ComboPooledDataSource)
+			((ComboPooledDataSource) ds).close();
+		System.exit(0);
+	}
+
+	/* one read-modify-write transaction; returns latency ns, or -1 on error */
+	static long doTxn(DataSource ds, int rows, String payload, Random rnd,
+			ConcurrentHashMap<String, AtomicInteger> errors) {
+		int id = rnd.nextInt(rows);
+		long t0 = System.nanoTime();
+		Connection c = null;
+		try {
+			c = ds.getConnection();
+			c.setAutoCommit(false);
+			try (PreparedStatement sel = c
+					.prepareStatement("select payload from bench where id=?")) {
+				sel.setInt(1, id);
+				try (ResultSet rs = sel.executeQuery()) {
+					rs.next();
+				}
+			}
+			try (PreparedStatement upd = c
+					.prepareStatement("update bench set payload=? where id=?")) {
+				upd.setString(1, payload);
+				upd.setInt(2, id);
+				upd.executeUpdate();
+			}
+			c.commit();
+			return System.nanoTime() - t0;
+		} catch (SQLException e) {
+			record(errors, e);
+			if (c != null)
+				try {
+					c.rollback();
+				} catch (SQLException ignore) {
+				}
+			return -1;
+		} finally {
+			if (c != null)
+				try {
+					c.close();
+				} catch (SQLException ignore) {
+				}
+		}
+	}
+
+	static void runLoad(DataSource ds, int threads, int ops, int rows,
+			String payload, long[] sink, ConcurrentHashMap<String, AtomicInteger> e)
+			throws InterruptedException {
+		ConcurrentHashMap<String, AtomicInteger> errs = e != null ? e
+				: new ConcurrentHashMap<String, AtomicInteger>();
+		Thread[] ts = new Thread[threads];
+		for (int t = 0; t < threads; t++) {
+			final int tid = t;
+			ts[t] = new Thread(() -> {
+				Random rnd = new Random(tid + 1L);
+				for (int i = 0; i < ops; i++)
+					doTxn(ds, rows, payload, rnd, errs);
+			});
+			ts[t].start();
+		}
+		for (Thread t : ts)
+			t.join();
+	}
+
+	static void record(ConcurrentHashMap<String, AtomicInteger> errors,
+			SQLException e) {
+		String msg = e.getMessage() == null ? e.getClass().getSimpleName()
+				: e.getMessage();
+		String key = msg.contains("BUSY_SNAPSHOT") ? "BUSY_SNAPSHOT"
+				: msg.toLowerCase().contains("locked") ? "BUSY/locked"
+						: e.getClass().getSimpleName();
+		errors.computeIfAbsent(key, x -> new AtomicInteger()).incrementAndGet();
+	}
+
+	static DataSource buildDataSource(String mode, String dir) throws Exception {
+		Properties props = new Properties();
+		if (mode.startsWith("derby")) {
+			Class.forName(SQL.getDriver(SQL.SQLType.EMBEDDED_DERBY));
+			String url = SQL.getProtocolOrURL(SQL.SQLType.EMBEDDED_DERBY) + dir
+					+ "/benchdb;create=true";
+			props.put("user", "bench");
+			props.put("password", "bench");
+			if (mode.equals("derby-c3p0")) {
+				ComboPooledDataSource cpds = new ComboPooledDataSource();
+				cpds.setDriverClass(SQL.getDriver(SQL.SQLType.EMBEDDED_DERBY));
+				cpds.setJdbcUrl(url);
+				cpds.setUser("bench");
+				cpds.setPassword("bench");
+				cpds.setMaxPoolSize(100);
+				return cpds;
+			}
+			return new SimpleDataSource(url, props, 8, 0);
+		}
+		// sqlite
+		Class.forName(SQL.getDriver(SQL.SQLType.EMBEDDED_SQLITE));
+		String url = SQL.getProtocolOrURL(SQL.SQLType.EMBEDDED_SQLITE) + dir
+				+ "/bench.db";
+		props.put("journal_mode", "WAL");
+		// "-full" suffix => synchronous=FULL (fsync every commit, like Derby);
+		// otherwise NORMAL (fsync only at WAL checkpoint: durable across an app
+		// crash, may lose last commits on an OS/power crash).
+		props.put("synchronous", mode.endsWith("-full") ? "FULL" : "NORMAL");
+		props.put("busy_timeout", "30000");
+		int maxTotal = 0;
+		if (mode.startsWith("sqlite-immediate"))
+			props.put("transaction_mode", "IMMEDIATE");
+		else if (mode.startsWith("sqlite-single"))
+			maxTotal = 1;
+		int maxIdle = maxTotal > 0 ? maxTotal : 8;
+		return new SimpleDataSource(url, props, maxIdle, maxTotal);
+	}
+
+	static String makePayload(int n) {
+		StringBuilder sb = new StringBuilder(n);
+		for (int i = 0; i < n; i++)
+			sb.append((char) ('a' + (i % 26)));
+		return sb.toString();
+	}
+
+	static double pct(long[] sorted, double p) {
+		int idx = (int) Math.ceil(p / 100.0 * sorted.length) - 1;
+		idx = Math.max(0, Math.min(sorted.length - 1, idx));
+		return sorted[idx] / 1e6;
+	}
+
+	static double mean(long[] a) {
+		double s = 0;
+		for (long v : a)
+			s += v;
+		return s / a.length;
+	}
+
+	static void recursiveDelete(File f) {
+		if (f == null || !f.exists())
+			return;
+		if (f.isDirectory())
+			for (File c : f.listFiles())
+				recursiveDelete(c);
+		f.delete();
+	}
+}

--- a/src/edu/umass/cs/gigapaxos/paxosutil/RocksDBLatencyBench.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/RocksDBLatencyBench.java
@@ -1,0 +1,129 @@
+package edu.umass.cs.gigapaxos.paxosutil;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
+import org.rocksdb.FlushOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+/**
+ * A controlled durable-write latency benchmark for RocksDB, the KV analogue of
+ * {@link DBLatencyBench} (which covers the JDBC backends). It issues many
+ * concurrent durable writes (put + optional fsync) of a fixed payload and
+ * reports throughput and latency percentiles, so RocksDB can be compared to the
+ * SQLite/Derby numbers at the same durability level.
+ *
+ * Usage: RocksDBLatencyBench &lt;sync|nosync&gt; &lt;threads&gt; &lt;opsPerThread&gt; &lt;payloadBytes&gt;
+ */
+public class RocksDBLatencyBench {
+	static {
+		RocksDB.loadLibrary();
+	}
+
+	public static void main(String[] args) throws Exception {
+		boolean sync = args.length > 0 ? args[0].equalsIgnoreCase("sync") : true;
+		int threads = args.length > 1 ? Integer.parseInt(args[1]) : 8;
+		int opsPerThread = args.length > 2 ? Integer.parseInt(args[2]) : 2000;
+		int payloadBytes = args.length > 3 ? Integer.parseInt(args[3]) : 1024;
+
+		String dir = "/tmp/rocksbench_" + (sync ? "sync" : "nosync");
+		recursiveDelete(new File(dir));
+		new File(dir).mkdirs();
+
+		final byte[] payload = new byte[payloadBytes];
+		Arrays.fill(payload, (byte) 'x');
+
+		try (Options options = new Options().setCreateIfMissing(true);
+				RocksDB db = RocksDB.open(options, dir);
+				WriteOptions wo = new WriteOptions().setSync(sync)) {
+
+			// warmup
+			for (int i = 0; i < 200; i++)
+				db.put(wo, key(0, i), payload);
+
+			final long[][] perThread = new long[threads][opsPerThread];
+			final CountDownLatch start = new CountDownLatch(1);
+			final CountDownLatch done = new CountDownLatch(threads);
+			List<Thread> ts = new ArrayList<Thread>();
+			for (int t = 0; t < threads; t++) {
+				final int tid = t;
+				Thread th = new Thread(() -> {
+					Random rnd = new Random(tid * 7919L + 1);
+					try {
+						start.await();
+					} catch (InterruptedException e) {
+					}
+					for (int i = 0; i < opsPerThread; i++) {
+						long t0 = System.nanoTime();
+						try {
+							// read-modify-write: get then put (paxos-like)
+							db.get(key(tid, rnd.nextInt(opsPerThread)));
+							db.put(wo, key(tid, i), payload);
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+						perThread[tid][i] = System.nanoTime() - t0;
+					}
+					done.countDown();
+				});
+				ts.add(th);
+				th.start();
+			}
+			long wall0 = System.nanoTime();
+			start.countDown();
+			done.await();
+			long wallNs = System.nanoTime() - wall0;
+
+			long[] all = new long[threads * opsPerThread];
+			int k = 0;
+			for (long[] arr : perThread)
+				for (long v : arr)
+					all[k++] = v;
+			Arrays.sort(all);
+			double wallSec = wallNs / 1e9;
+			System.out.println("=== RocksDB durable=" + sync + " threads="
+					+ threads + " opsPerThread=" + opsPerThread + " payloadBytes="
+					+ payloadBytes + " ===");
+			System.out.printf("ops=%d  wall=%.2fs  throughput=%.0f ops/s%n",
+					all.length, wallSec, all.length / wallSec);
+			System.out.printf(
+					"latency ms: p50=%.2f  p90=%.2f  p99=%.2f  p999=%.2f  max=%.2f  mean=%.2f%n",
+					pct(all, 50), pct(all, 90), pct(all, 99), pct(all, 99.9),
+					all[all.length - 1] / 1e6, mean(all) / 1e6);
+			db.flush(new FlushOptions().setWaitForFlush(true));
+		}
+		System.exit(0);
+	}
+
+	static byte[] key(int t, int i) {
+		return ("k" + t + "_" + i).getBytes();
+	}
+
+	static double pct(long[] sorted, double p) {
+		int idx = (int) Math.ceil(p / 100.0 * sorted.length) - 1;
+		idx = Math.max(0, Math.min(sorted.length - 1, idx));
+		return sorted[idx] / 1e6;
+	}
+
+	static double mean(long[] a) {
+		double s = 0;
+		for (long v : a)
+			s += v;
+		return s / a.length;
+	}
+
+	static void recursiveDelete(File f) {
+		if (f == null || !f.exists())
+			return;
+		if (f.isDirectory())
+			for (File c : f.listFiles())
+				recursiveDelete(c);
+		f.delete();
+	}
+}

--- a/src/edu/umass/cs/gigapaxos/paxosutil/RocksDBMem.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/RocksDBMem.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2015 University of Massachusetts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package edu.umass.cs.gigapaxos.paxosutil;
+
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.Cache;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionStyle;
+import org.rocksdb.CompressionType;
+import org.rocksdb.DBOptions;
+import org.rocksdb.LRUCache;
+import org.rocksdb.WriteBufferManager;
+
+import edu.umass.cs.gigapaxos.PaxosConfig.PC;
+import edu.umass.cs.utils.Config;
+
+/**
+ * Process-wide, bounded memory configuration for all embedded RocksDB instances
+ * (the {@code RocksDBPaxosLogger} and {@code RocksDBReconfiguratorDB}). RocksDB's
+ * default per-column-family memory (a 64 MB write buffer and an 8 MB block cache
+ * each) does not bound total memory and grows with the number of column families
+ * and with write load. That is unsuitable for a small-memory reconfigurator
+ * (target: a 0.5&ndash;1 GB machine).
+ * <p>
+ * This class creates a single shared {@link LRUCache} and {@link
+ * WriteBufferManager} that ALL RocksDB instances in the JVM share, so the total
+ * native memory used by RocksDB is bounded regardless of how many nodes / column
+ * families exist or how write-heavy the load is:
+ * <ul>
+ * <li>block cache (index/filter/data blocks) is capped at
+ * {@link PC#ROCKSDB_BLOCK_CACHE_MB} MB total;</li>
+ * <li>memtable (write buffer) memory is capped at
+ * {@link PC#ROCKSDB_MEMTABLE_BUDGET_MB} MB total via a WriteBufferManager whose
+ * usage is also charged against the same block cache, so the overall RocksDB
+ * native budget is essentially the block-cache size.</li>
+ * </ul>
+ * Per-column-family write buffers are kept small
+ * ({@link PC#ROCKSDB_WRITE_BUFFER_MB} MB) so a single column family cannot by
+ * itself reserve a large memtable.
+ *
+ * @author arun
+ */
+public class RocksDBMem {
+
+	private static final long MB = 1024 * 1024;
+
+	/** Total block-cache budget shared by all RocksDB instances. */
+	public static final long BLOCK_CACHE_BYTES = Config
+			.getGlobalLong(PC.ROCKSDB_BLOCK_CACHE_MB) * MB;
+	/** Total memtable budget shared by all RocksDB instances. */
+	public static final long MEMTABLE_BUDGET_BYTES = Config
+			.getGlobalLong(PC.ROCKSDB_MEMTABLE_BUDGET_MB) * MB;
+	/** Per-column-family write buffer (memtable) size. */
+	public static final long WRITE_BUFFER_BYTES = Config
+			.getGlobalLong(PC.ROCKSDB_WRITE_BUFFER_MB) * MB;
+
+	// One shared cache and write-buffer manager for the whole JVM. These are
+	// long-lived native objects intentionally never closed (process lifetime).
+	private static final Cache SHARED_CACHE = new LRUCache(BLOCK_CACHE_BYTES);
+	private static final WriteBufferManager SHARED_WBM = new WriteBufferManager(
+			MEMTABLE_BUDGET_BYTES, SHARED_CACHE);
+
+	private RocksDBMem() {
+	}
+
+	/**
+	 * @return DBOptions that bound memtable memory (shared WriteBufferManager),
+	 *         file handles, and background work, suitable for a small-memory
+	 *         deployment. The caller owns and must close the returned object.
+	 */
+	public static DBOptions dbOptions() {
+		return new DBOptions().setCreateIfMissing(true)
+				.setCreateMissingColumnFamilies(true)
+				.setWriteBufferManager(SHARED_WBM)
+				.setMaxBackgroundJobs(2)
+				// bound the number of open files (each costs memory)
+				.setMaxOpenFiles(64);
+	}
+
+	/**
+	 * @return ColumnFamilyOptions with a small write buffer and the shared block
+	 *         cache (with index/filter blocks also charged to the cache so they
+	 *         are bounded). The caller owns and must close the returned object.
+	 */
+	public static ColumnFamilyOptions cfOptions() {
+		BlockBasedTableConfig table = new BlockBasedTableConfig()
+				.setBlockCache(SHARED_CACHE)
+				.setCacheIndexAndFilterBlocks(true)
+				.setPinL0FilterAndIndexBlocksInCache(false);
+		return new ColumnFamilyOptions()
+				.setWriteBufferSize(WRITE_BUFFER_BYTES)
+				.setMaxWriteBufferNumber(2)
+				.setCompressionType(CompressionType.LZ4_COMPRESSION)
+				.setCompactionStyle(CompactionStyle.LEVEL)
+				.setLevelCompactionDynamicLevelBytes(true)
+				.setTableFormatConfig(table);
+	}
+}

--- a/src/edu/umass/cs/gigapaxos/paxosutil/SQL.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/SQL.java
@@ -17,6 +17,7 @@
  */
 package edu.umass.cs.gigapaxos.paxosutil;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -47,18 +48,26 @@ public class SQL {
 	 */
 	public static enum SQLType {
 		/**
-		 * 
+		 *
 		 */
 		EMBEDDED_DERBY,
 		/**
-		 * 
+		 *
 		 */
 		MYSQL,
-		
+
 		/**
-		 * 
+		 *
 		 */
 		EMBEDDED_H2,
+
+		/**
+		 * Embedded SQLite (via the xerial sqlite-jdbc driver). A lightweight,
+		 * single-file, server-less embedded engine. Unlike Derby/H2 it is a
+		 * single-writer engine, so it is best used with connection pooling
+		 * disabled (see CONNECTION_POOLING) and WAL journaling enabled.
+		 */
+		EMBEDDED_SQLITE,
 	};
 
 	/**
@@ -87,6 +96,9 @@ public class SQL {
 		case EMBEDDED_DERBY:
 		case EMBEDDED_H2:
 			return " blob(" + size + ")";
+		case EMBEDDED_SQLITE:
+			// SQLite is dynamically typed; BLOB ignores any declared size.
+			return " blob ";
 		case MYSQL:
 			if (size < 65536)
 				return " TEXT ";
@@ -111,6 +123,13 @@ public class SQL {
 					+ "("
 					+ "select tableid from sys.systables where tablename='"
 					+ table.toUpperCase() + "'" + ")";
+		case EMBEDDED_SQLITE:
+			// pragma_table_info is a table-valued function (SQLite >= 3.16)
+			// returning columns (cid, name, type, ...). We project name, type
+			// so the result shape matches the (columnname, columndatatype)
+			// contract expected by callers of this method. Table names in
+			// SQLite are matched case-insensitively.
+			return "select name, type from pragma_table_info('" + table + "')";
 		case MYSQL:
 			return "select column_name, column_type, column_default from information_schema.columns "
 					+ "where table_schema=database() and table_name='"
@@ -129,6 +148,14 @@ public class SQL {
 		case EMBEDDED_DERBY:
 		case EMBEDDED_H2:
 			return "alter column " + column + " set data type ";
+		case EMBEDDED_SQLITE:
+			// SQLite cannot change a column's declared type via ALTER TABLE.
+			// In practice this branch is not exercised because SQLite stores
+			// the declared type verbatim, so reconcileTable() reads back the
+			// same type it created and detects no mismatch. We return the
+			// MySQL-style form so that, if a genuine schema migration is ever
+			// attempted, it fails loudly rather than silently.
+			return "modify column " + column;
 		case MYSQL:
 			return "modify column " + column;
 		default:
@@ -144,6 +171,9 @@ public class SQL {
 		switch (type) {
 		case EMBEDDED_DERBY:
 		case EMBEDDED_H2:
+		case EMBEDDED_SQLITE:
+			// SQLite does not enforce VARCHAR limits; mirror Derby so that
+			// blob-vs-varchar column-type decisions match the Derby-tested path.
 			return 32672;
 		case MYSQL:
 			// 65535 in 5.1 onwards
@@ -165,6 +195,8 @@ public class SQL {
 			return "com.mysql.jdbc.Driver";
 		case EMBEDDED_H2:
 			return "org.h2.Driver";
+		case EMBEDDED_SQLITE:
+			return "org.sqlite.JDBC";
 		}
 		Util.suicide("SQL type not recognized");
 		return null;
@@ -182,6 +214,8 @@ public class SQL {
 			return "jdbc:mysql://localhost/";
 		case EMBEDDED_H2:
 			return "jdbc:h2:";
+		case EMBEDDED_SQLITE:
+			return "jdbc:sqlite:";
 		}
 		Util.suicide("SQL type not recognized");
 		return null;
@@ -199,6 +233,55 @@ public class SQL {
 	 */
 	public static String getPassword() {
 		return PASSWORD;
+	}
+
+	/* The classifiers below interpret a SQLException to decide whether it
+	 * signals a duplicate primary key, a pre-existing table, or a missing
+	 * table. Derby/H2/MySQL surface these via standard SQLState codes (the
+	 * lists above). SQLite (xerial sqlite-jdbc) reports a null SQLState and a
+	 * numeric vendor code instead, so for SQLite we additionally inspect the
+	 * vendor error code and message text. Keeping this logic here means the
+	 * SQLPaxosLogger/SQLReconfiguratorDB catch blocks stay vendor-agnostic. */
+
+	private static boolean messageContains(SQLException e, String needle) {
+		String m = e.getMessage();
+		return m != null && m.toLowerCase().contains(needle);
+	}
+
+	/**
+	 * @param e
+	 * @return True if {@code e} indicates a duplicate/unique key violation.
+	 */
+	public static boolean isDuplicateKeyException(SQLException e) {
+		if (DUPLICATE_KEY.contains(e.getSQLState()))
+			return true;
+		// SQLite: SQLITE_CONSTRAINT (19) and its extended UNIQUE/PRIMARYKEY
+		// variants (2067, 1555).
+		int code = e.getErrorCode();
+		return code == 19 || code == 2067 || code == 1555
+				|| messageContains(e, "unique constraint failed");
+	}
+
+	/**
+	 * @param e
+	 * @return True if {@code e} indicates the table already exists.
+	 */
+	public static boolean isDuplicateTableException(SQLException e) {
+		if (DUPLICATE_TABLE.contains(e.getSQLState()))
+			return true;
+		// SQLite reports "table <name> already exists".
+		return messageContains(e, "already exists");
+	}
+
+	/**
+	 * @param e
+	 * @return True if {@code e} indicates the table does not exist.
+	 */
+	public static boolean isNonexistentTableException(SQLException e) {
+		if (NONEXISTENT_TABLE.contains(e.getSQLState()))
+			return true;
+		// SQLite reports "no such table: <name>".
+		return messageContains(e, "no such table");
 	}
 
 }

--- a/src/edu/umass/cs/gigapaxos/paxosutil/SimpleDataSource.java
+++ b/src/edu/umass/cs/gigapaxos/paxosutil/SimpleDataSource.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2015 University of Massachusetts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package edu.umass.cs.gigapaxos.paxosutil;
+
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import javax.sql.DataSource;
+
+/**
+ * A minimal, dependency-free {@link DataSource} with a small bounded pool of
+ * reused physical connections. It spawns no background/helper threads and holds
+ * at most {@link #maxIdle} idle connections, so its memory and thread footprint
+ * is far smaller than a C3P0 {@code ComboPooledDataSource} (which starts ~3
+ * helper threads per data source). At the same time, by reusing connections it
+ * avoids paying the per-operation connection-open cost &mdash; which is
+ * significant for SQLite, where opening a connection re-applies pragmas such as
+ * journal_mode=WAL.
+ * <p>
+ * Borrowed connections are returned to the pool when the caller invokes
+ * {@link Connection#close()} (intercepted via a dynamic proxy); gigapaxos
+ * already routes all acquisition through a couple of helper methods and closes
+ * connections in finally blocks, so this is a drop-in replacement. If the idle
+ * pool is full on return, or the connection is broken, it is physically closed.
+ * <p>
+ * Set {@code maxIdle} to 0 for purely non-pooling behavior (a fresh connection
+ * per op, closed on return). This is the lowest-memory option but pays the
+ * connection-open cost on every operation.
+ *
+ * @author arun
+ */
+public class SimpleDataSource implements DataSource {
+
+	private volatile String jdbcUrl;
+	private final Properties props;
+	private final int maxIdle;
+	private final ConcurrentLinkedQueue<Connection> idle = new ConcurrentLinkedQueue<Connection>();
+	private final AtomicInteger idleCount = new AtomicInteger(0);
+	// when non-null, bounds the number of concurrently outstanding
+	// connections; a permit count of 1 yields a single serialized connection
+	// (a "single writer"), which avoids SQLite WAL cross-connection
+	// SQLITE_BUSY_SNAPSHOT conflicts at the cost of node-local DB concurrency.
+	private final Semaphore permits;
+
+	private PrintWriter logWriter = null;
+	private int loginTimeout = 0;
+
+	/**
+	 * @param jdbcUrl
+	 * @param props
+	 *            connection properties (e.g. user, password, and any
+	 *            engine-specific pragmas); may be null.
+	 * @param maxIdle
+	 *            maximum number of idle physical connections to keep; 0 means
+	 *            no pooling (fresh connection per op).
+	 * @param maxTotal
+	 *            maximum number of concurrently outstanding connections; 0
+	 *            means unbounded. Set to 1 for a single serialized connection.
+	 */
+	public SimpleDataSource(String jdbcUrl, Properties props, int maxIdle,
+			int maxTotal) {
+		this.jdbcUrl = jdbcUrl;
+		this.props = props != null ? props : new Properties();
+		this.maxIdle = Math.max(0, maxIdle);
+		this.permits = maxTotal > 0 ? new Semaphore(maxTotal, true) : null;
+	}
+
+	/**
+	 * @param jdbcUrl
+	 * @param props
+	 * @param maxIdle
+	 */
+	public SimpleDataSource(String jdbcUrl, Properties props, int maxIdle) {
+		this(jdbcUrl, props, maxIdle, 0);
+	}
+
+	/**
+	 * @param jdbcUrl
+	 * @param props
+	 */
+	public SimpleDataSource(String jdbcUrl, Properties props) {
+		this(jdbcUrl, props, 8, 0);
+	}
+
+	/**
+	 * @param jdbcUrl
+	 *            the JDBC URL to use for subsequently created connections. Used
+	 *            to mirror C3P0's setJdbcUrl(.) so that callers can strip an
+	 *            initial ";create=true" style flag after the first connect.
+	 */
+	public void setJdbcUrl(String jdbcUrl) {
+		this.jdbcUrl = jdbcUrl;
+	}
+
+	/**
+	 * @return the current JDBC URL.
+	 */
+	public String getJdbcUrl() {
+		return this.jdbcUrl;
+	}
+
+	@Override
+	public Connection getConnection() throws SQLException {
+		// bound concurrency if configured (blocks until a permit is free)
+		if (permits != null) {
+			try {
+				permits.acquire();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new SQLException("interrupted acquiring connection permit",
+						e);
+			}
+		}
+		try {
+			Connection physical = null;
+			// reuse an idle connection if one is available and still usable
+			while ((physical = idle.poll()) != null) {
+				idleCount.decrementAndGet();
+				if (isUsable(physical))
+					return wrap(physical);
+				quietClose(physical);
+			}
+			// else open a fresh physical connection
+			physical = DriverManager.getConnection(this.jdbcUrl, this.props);
+			return wrap(physical);
+		} catch (SQLException | RuntimeException e) {
+			if (permits != null)
+				permits.release();
+			throw e;
+		}
+	}
+
+	@Override
+	public Connection getConnection(String username, String password)
+			throws SQLException {
+		Properties p = new Properties();
+		p.putAll(this.props);
+		if (username != null)
+			p.put("user", username);
+		if (password != null)
+			p.put("password", password);
+		// distinct credentials bypass the pool
+		return wrap(DriverManager.getConnection(this.jdbcUrl, p));
+	}
+
+	/* Wraps a physical connection in a proxy whose close() returns it to the
+	 * idle pool (instead of closing it) when there is room. */
+	private Connection wrap(final Connection physical) {
+		return (Connection) Proxy.newProxyInstance(
+				SimpleDataSource.class.getClassLoader(),
+				new Class<?>[] { Connection.class },
+				new InvocationHandler() {
+					private boolean returned = false;
+
+					@Override
+					public Object invoke(Object proxy, Method method,
+							Object[] args) throws Throwable {
+						String name = method.getName();
+						if ("close".equals(name)) {
+							release(physical);
+							returned = true;
+							return null;
+						}
+						if ("isClosed".equals(name) && returned)
+							return true;
+						try {
+							return method.invoke(physical, args);
+						} catch (InvocationTargetException e) {
+							throw e.getCause();
+						}
+					}
+				});
+	}
+
+	/* Returns a connection to the idle pool, or physically closes it if the
+	 * pool is full or the connection is no longer usable. Always releases a
+	 * concurrency permit (if bounded) exactly once per borrowed connection. */
+	private void release(Connection physical) {
+		try {
+			if (maxIdle > 0 && idleCount.get() < maxIdle && !physical.isClosed()) {
+				if (!physical.getAutoCommit()) {
+					try {
+						physical.rollback();
+					} catch (SQLException e) {
+						// ignore; will reset below
+					}
+					physical.setAutoCommit(true);
+				}
+				idle.offer(physical);
+				idleCount.incrementAndGet();
+				return;
+			}
+		} catch (SQLException e) {
+			// fall through to close
+		} finally {
+			if (permits != null)
+				permits.release();
+		}
+		quietClose(physical);
+	}
+
+	private static boolean isUsable(Connection c) {
+		try {
+			return !c.isClosed();
+		} catch (SQLException e) {
+			return false;
+		}
+	}
+
+	private static void quietClose(Connection c) {
+		try {
+			c.close();
+		} catch (SQLException e) {
+			// ignore
+		}
+	}
+
+	@Override
+	public PrintWriter getLogWriter() {
+		return this.logWriter;
+	}
+
+	@Override
+	public void setLogWriter(PrintWriter out) {
+		this.logWriter = out;
+	}
+
+	@Override
+	public void setLoginTimeout(int seconds) {
+		this.loginTimeout = seconds;
+	}
+
+	@Override
+	public int getLoginTimeout() {
+		return this.loginTimeout;
+	}
+
+	@Override
+	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+		throw new SQLFeatureNotSupportedException();
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> iface) throws SQLException {
+		if (iface.isInstance(this))
+			return iface.cast(this);
+		throw new SQLException(this.getClass().getName()
+				+ " is not a wrapper for " + iface);
+	}
+
+	@Override
+	public boolean isWrapperFor(Class<?> iface) {
+		return iface.isInstance(this);
+	}
+}

--- a/src/edu/umass/cs/reconfiguration/AbstractReconfiguratorDB.java
+++ b/src/edu/umass/cs/reconfiguration/AbstractReconfiguratorDB.java
@@ -131,6 +131,23 @@ public abstract class AbstractReconfiguratorDB<NodeIDType> implements
 	}
 
 	/**
+	 * Factory that selects the reconfigurator DB implementation based on the
+	 * {@link RC#RECONFIGURATOR_DB} config: "ROCKSDB" -&gt;
+	 * {@link RocksDBReconfiguratorDB}, anything else -&gt;
+	 * {@link SQLReconfiguratorDB} (default).
+	 *
+	 * @param myID
+	 * @param nc
+	 * @return A reconfigurator DB of the configured type.
+	 */
+	public static <NodeIDType> AbstractReconfiguratorDB<NodeIDType> createDB(
+			NodeIDType myID, ConsistentReconfigurableNodeConfig<NodeIDType> nc) {
+		if ("ROCKSDB".equalsIgnoreCase(Config.getGlobalString(RC.RECONFIGURATOR_DB)))
+			return new RocksDBReconfiguratorDB<NodeIDType>(myID, nc);
+		return new SQLReconfiguratorDB<NodeIDType>(myID, nc);
+	}
+
+	/**
 	 * @param name
 	 * @param epoch
 	 * @return ReconfigurationRecord for {@code name:epoch}.

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -163,6 +163,13 @@ public class ReconfigurationConfig {
         SQL_TYPE("EMBEDDED_DERBY"),
 
         /**
+         * Selects the reconfigurator DB implementation. "SQL" (default) uses the
+         * JDBC-based {@link edu.umass.cs.reconfiguration.SQLReconfiguratorDB};
+         * "ROCKSDB" uses the embedded key-value RocksDBReconfiguratorDB.
+         */
+        RECONFIGURATOR_DB("SQL"),
+
+        /**
          * Whether to use C3P0 connection pooling for the reconfigurator DB's
          * SQL data source. When false, a lightweight non-pooling data source is
          * used (a fresh connection per operation, no idle connections or pool

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -163,6 +163,24 @@ public class ReconfigurationConfig {
         SQL_TYPE("EMBEDDED_DERBY"),
 
         /**
+         * Whether to use C3P0 connection pooling for the reconfigurator DB's
+         * SQL data source. When false, a lightweight non-pooling data source is
+         * used (a fresh connection per operation, no idle connections or pool
+         * helper threads), reducing the memory/thread footprint. Should
+         * generally be false for the single-writer EMBEDDED_SQLITE engine.
+         */
+        CONNECTION_POOLING(true),
+
+        /**
+         * Maximum number of concurrently outstanding DB connections when using
+         * the non-pooling (SimpleDataSource) path. 0 means unbounded; 1 means a
+         * single serialized connection ("single writer"), which avoids SQLite
+         * WAL SQLITE_BUSY_SNAPSHOT conflicts. Ignored when CONNECTION_POOLING is
+         * true.
+         */
+        DB_MAX_CONNECTIONS(0),
+
+        /**
          * Whether reconfigurations should be performed even though
          * AbstractDemandProfile returned a set of active replicas that are
          * identical to the current one. Useful for testing, but should be false

--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -144,7 +144,7 @@ public class Reconfigurator<NodeIDType> implements
         this.messenger = m;
         this.consistentNodeConfig = new ConsistentReconfigurableNodeConfig<NodeIDType>(nc);
         this.DB = new RepliconfigurableReconfiguratorDB<NodeIDType>(
-                new SQLReconfiguratorDB<NodeIDType>(this.messenger.getMyID(),
+                AbstractReconfiguratorDB.createDB(this.messenger.getMyID(),
                         this.consistentNodeConfig), getMyID(),
                 this.consistentNodeConfig, this.messenger, startCleanSlate);
         // recovery complete at this point

--- a/src/edu/umass/cs/reconfiguration/RepliconfigurableReconfiguratorDB.java
+++ b/src/edu/umass/cs/reconfiguration/RepliconfigurableReconfiguratorDB.java
@@ -109,8 +109,9 @@ public class RepliconfigurableReconfiguratorDB<NodeIDType> extends
 				"{0} after recovery has node config records = {1}",
 				new Object[] {
 						this,
-						((SQLReconfiguratorDB<NodeIDType>) this.app)
-								.getNodeConfigRecords(this.consistentNodeConfig) });
+						this.app instanceof SQLReconfiguratorDB ? ((SQLReconfiguratorDB<NodeIDType>) this.app)
+								.getNodeConfigRecords(this.consistentNodeConfig)
+								: this.app });
 	}
 
 	// needed by Reconfigurator

--- a/src/edu/umass/cs/reconfiguration/RocksDBReconfiguratorDB.java
+++ b/src/edu/umass/cs/reconfiguration/RocksDBReconfiguratorDB.java
@@ -1,0 +1,860 @@
+/*
+ * Copyright (c) 2015 University of Massachusetts
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package edu.umass.cs.reconfiguration;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.WriteOptions;
+
+import edu.umass.cs.gigapaxos.PaxosConfig.PC;
+import edu.umass.cs.gigapaxos.paxosutil.RocksDBMem;
+import edu.umass.cs.reconfiguration.ReconfigurationConfig.RC;
+import edu.umass.cs.reconfiguration.ReconfigurationConfig.ReconfigureUponActivesChange;
+import edu.umass.cs.reconfiguration.reconfigurationpackets.DemandReport;
+import edu.umass.cs.reconfiguration.reconfigurationutils.ConsistentReconfigurableNodeConfig;
+import edu.umass.cs.reconfiguration.reconfigurationutils.ReconfigurationRecord;
+import edu.umass.cs.reconfiguration.reconfigurationutils.ReconfigurationRecord.RCStates;
+import edu.umass.cs.utils.Config;
+import edu.umass.cs.utils.StringLocker;
+import edu.umass.cs.utils.Util;
+
+/**
+ * An {@link AbstractReconfiguratorDB} backed by the embedded RocksDB key-value
+ * store, an alternative to the JDBC-based {@link SQLReconfiguratorDB}. Selected
+ * via the {@link RC#RECONFIGURATOR_DB} config ("ROCKSDB").
+ * <p>
+ * Records, demand profiles, pending markers, and node-config entries are stored
+ * in RocksDB column families keyed by service name (or nodeID|version). Unlike
+ * SQLReconfiguratorDB, paxos-level checkpoints of an RC group are returned
+ * inline as the concatenated record JSONs rather than via a file + socket
+ * transfer server; {@link AbstractReconfiguratorDB} (through paxos) treats the
+ * returned string as the state directly. This keeps the implementation small;
+ * the trade-off is that a single RC group's checkpoint must fit in a paxos
+ * checkpoint, which is fine for the bounded number of records per RC group.
+ *
+ * @author arun
+ *
+ * @param <NodeIDType>
+ */
+public class RocksDBReconfiguratorDB<NodeIDType> extends
+		AbstractReconfiguratorDB<NodeIDType> {
+
+	private static final Charset CHARSET = Charset.forName("ISO-8859-1");
+	private static final boolean COMBINE_DEMAND_STATS = Config
+			.getGlobalBoolean(RC.COMBINE_DEMAND_STATS);
+
+	private static final String CF_RECORDS = "records", CF_DEMAND = "demand",
+			CF_PENDING = "pending", CF_NODECONFIG = "nodeConfig";
+	private static final String[] CFS = { CF_RECORDS, CF_DEMAND, CF_PENDING,
+			CF_NODECONFIG };
+
+	// wrapper JSON keys for a stored record: rcGroupName + stringified record
+	private static final String W_GROUP = "g", W_RECORD = "r";
+
+	static {
+		RocksDB.loadLibrary();
+	}
+
+	private static final Logger log = ReconfigurationConfig.getLogger();
+
+	protected String logDirectory;
+	private final String dbPath;
+
+	private RocksDB db;
+	private final Map<String, ColumnFamilyHandle> cfs = new HashMap<String, ColumnFamilyHandle>();
+	private final List<ColumnFamilyOptions> cfOpts = new ArrayList<ColumnFamilyOptions>();
+	private DBOptions dbOptions;
+	// Async writes (RocksDB WAL, no per-write fsync): the reconfigurator DB is
+	// paxos-backed (records are reconstructable from the paxos log + epoch-final
+	// checkpoints), so losing the last few writes on an OS crash is recovered by
+	// paxos replay. This mirrors SQLReconfiguratorDB's async in-memory DiskMap.
+	private final WriteOptions writeOptions = new WriteOptions().setSync(false);
+	private final StringLocker stringLocker = new StringLocker();
+
+	private RocksIterator activeCursor;
+	private NodeIDType cursorActive;
+
+	private volatile boolean closed = true;
+
+	/**
+	 * @param myID
+	 * @param nc
+	 */
+	public RocksDBReconfiguratorDB(NodeIDType myID,
+			ConsistentReconfigurableNodeConfig<NodeIDType> nc) {
+		super(myID, nc);
+		this.logDirectory = Config.getGlobalString(PC.GIGAPAXOS_DATA_DIR) + "/"
+				+ RC.RECONFIGURATION_DB_DIR.getDefaultValue() + "/";
+		this.dbPath = this.logDirectory + "rocksdb_rcdb_" + sanitize(myID);
+		try {
+			open();
+		} catch (RocksDBException e) {
+			throw new RuntimeException("Unable to open RocksDB reconfigurator DB at "
+					+ this.dbPath + ": " + e.getMessage(), e);
+		}
+		this.closed = false;
+		initAdjustSoftNodeConfig();
+		initAdjustSoftActiveNodeConfig();
+		log.log(Level.INFO, "{0} initialized with reconfigurators {1}",
+				new Object[] { this, this.consistentNodeConfig.getReconfigurators() });
+	}
+
+	private static String sanitize(Object id) {
+		return id.toString().replace(".", "_");
+	}
+
+	public String toString() {
+		return "RocksDBRCDB" + this.myID;
+	}
+
+	private void open() throws RocksDBException {
+		new File(this.dbPath).mkdirs();
+		LinkedHashSet<String> names = new LinkedHashSet<String>();
+		names.add(new String(RocksDB.DEFAULT_COLUMN_FAMILY, CHARSET));
+		if (new File(this.dbPath, "CURRENT").exists())
+			try (Options o = new Options()) {
+				for (byte[] n : RocksDB.listColumnFamilies(o, this.dbPath))
+					names.add(new String(n, CHARSET));
+			}
+		for (String cf : CFS)
+			names.add(cf);
+		List<ColumnFamilyDescriptor> descs = new ArrayList<ColumnFamilyDescriptor>();
+		for (String name : names) {
+			ColumnFamilyOptions opts = RocksDBMem.cfOptions();
+			this.cfOpts.add(opts);
+			descs.add(new ColumnFamilyDescriptor(name.getBytes(CHARSET), opts));
+		}
+		List<ColumnFamilyHandle> handles = new ArrayList<ColumnFamilyHandle>();
+		this.dbOptions = RocksDBMem.dbOptions();
+		this.db = RocksDB.open(this.dbOptions, this.dbPath, descs, handles);
+		int i = 0;
+		for (String name : names)
+			this.cfs.put(name, handles.get(i++));
+	}
+
+	private ColumnFamilyHandle cf(String name) {
+		return this.cfs.get(name);
+	}
+
+	private static byte[] bytes(String s) {
+		return s.getBytes(CHARSET);
+	}
+
+	/* ******************* record storage primitives ******************* */
+
+	@Override
+	public synchronized ReconfigurationRecord<NodeIDType> getReconfigurationRecord(
+			String name) {
+		if (this.closed)
+			return null;
+		try {
+			byte[] val = this.db.get(cf(CF_RECORDS), bytes(name));
+			if (val == null)
+				return null;
+			JSONObject wrapper = new JSONObject(new String(val, CHARSET));
+			ReconfigurationRecord<NodeIDType> record = new ReconfigurationRecord<NodeIDType>(
+					new JSONObject(wrapper.getString(W_RECORD)),
+					this.consistentNodeConfig);
+			if (!wrapper.isNull(W_GROUP))
+				record.setRCGroupName(wrapper.getString(W_GROUP));
+			return record;
+		} catch (RocksDBException | JSONException e) {
+			log.severe(this + " failed to read RC record for " + name + ": " + e);
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	private synchronized void putReconfigurationRecord(
+			ReconfigurationRecord<NodeIDType> record) {
+		String rcGroupName = record.getRCGroupName();
+		if (rcGroupName == null)
+			rcGroupName = this.getRCGroupName(record.getName());
+		putReconfigurationRecord(record, rcGroupName);
+	}
+
+	private synchronized void putReconfigurationRecord(
+			ReconfigurationRecord<NodeIDType> record, String rcGroupName) {
+		if (this.closed)
+			return;
+		record.setRCGroupName(rcGroupName);
+		try {
+			JSONObject wrapper = new JSONObject();
+			wrapper.put(W_GROUP, rcGroupName == null ? JSONObject.NULL
+					: rcGroupName);
+			wrapper.put(W_RECORD, record.toString());
+			this.db.put(cf(CF_RECORDS), this.writeOptions,
+					bytes(record.getName()), bytes(wrapper.toString()));
+		} catch (RocksDBException | JSONException e) {
+			log.severe(this + " failed to put RC record " + record.getName()
+					+ ": " + e);
+			e.printStackTrace();
+		}
+	}
+
+	// low-level delete from records + pending + demand
+	private boolean deleteReconfigurationRecordDB(String name, Integer epoch) {
+		if (epoch != null) {
+			ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+			if (record == null || record.getEpoch() != epoch)
+				return false;
+		}
+		boolean deleted = delete(CF_RECORDS, name);
+		delete(CF_PENDING, name);
+		delete(CF_DEMAND, name);
+		return deleted;
+	}
+
+	private boolean delete(String cfName, String key) {
+		try {
+			this.db.delete(cf(cfName), bytes(key));
+			return true;
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to delete " + key + " from " + cfName
+					+ ": " + e);
+			return false;
+		}
+	}
+
+	/* ******************* overridden interface methods ******************* */
+
+	@Override
+	public synchronized boolean updateDemandStats(DemandReport<NodeIDType> report) {
+		if (this.closed)
+			return false;
+		JSONObject update = report.getStats();
+		JSONObject historic = getDemandStatsJSON(report.getServiceName());
+		JSONObject combined = update;
+		if (historic != null && COMBINE_DEMAND_STATS)
+			// demand stats are advisory; keep the latest report when combining
+			// is requested rather than replicating the profile-merge machinery.
+			combined = update;
+		try {
+			this.db.put(cf(CF_DEMAND), this.writeOptions,
+					bytes(report.getServiceName()), bytes(combined.toString()));
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to update demand stats: " + e);
+		}
+		return true;
+	}
+
+	private JSONObject getDemandStatsJSON(String name) {
+		try {
+			byte[] val = this.db.get(cf(CF_DEMAND), bytes(name));
+			return val == null ? null : new JSONObject(new String(val, CHARSET));
+		} catch (RocksDBException | JSONException e) {
+			log.severe(this + " failed to read demand stats for " + name + ": "
+					+ e);
+			return null;
+		}
+	}
+
+	@Override
+	public String getDemandStats(String name) {
+		JSONObject stats = getDemandStatsJSON(name);
+		return stats != null ? stats.toString() : null;
+	}
+
+	@Override
+	public synchronized boolean setState(String name, int epoch, RCStates state) {
+		return this.setStateMerge(name, epoch, state, null, null);
+	}
+
+	@Override
+	public synchronized boolean setStateMerge(String name, int epoch,
+			RCStates state, Set<NodeIDType> newActives, Set<String> mergees) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+		if (record == null)
+			return false;
+		record.setStateMerge(name, epoch, state, mergees);
+		assert (state.equals(RCStates.READY) || state.equals(RCStates.READY_READY)
+				|| state.equals(RCStates.WAIT_DELETE));
+		if (record.isReady()) {
+			record.setActivesToNewActives(newActives);
+			if (record.isReconfigurationReady())
+				setPending(name, false);
+			record.trimRCEpochs();
+		}
+		putReconfigurationRecord(record);
+		return true;
+	}
+
+	@Override
+	public synchronized boolean setStateInitReconfiguration(String name,
+			int epoch, RCStates state, Set<NodeIDType> newActives) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+		if (record == null || !record.isReady()) {
+			if (record != null)
+				log.log(Level.WARNING,
+						"{0} {1}:{2} not ready for transition to {3}:{4}:{5}",
+						new Object[] { this, name, record.getEpoch(), name, epoch,
+								state });
+			return false;
+		}
+		assert (state.equals(RCStates.WAIT_ACK_STOP));
+		record.setState(name, epoch, state, newActives);
+		setPending(name, true);
+		putReconfigurationRecord(record);
+		return true;
+	}
+
+	@Override
+	public synchronized boolean deleteReconfigurationRecord(String name,
+			int epoch) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+		if (record != null && record.getEpoch() == epoch)
+			return delete(CF_RECORDS, name) && deletePendingAndDemand(name);
+		return false;
+	}
+
+	private boolean deletePendingAndDemand(String name) {
+		delete(CF_PENDING, name);
+		delete(CF_DEMAND, name);
+		return true;
+	}
+
+	@Override
+	public synchronized boolean markDeleteReconfigurationRecord(String name,
+			int epoch) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+		if (record == null)
+			return false;
+		assert (record.getEpoch() == epoch);
+		record.setState(name, epoch, RCStates.WAIT_DELETE);
+		putReconfigurationRecord(record);
+		delete(CF_DEMAND, name);
+		return true;
+	}
+
+	@Override
+	public synchronized ReconfigurationRecord<NodeIDType> createReconfigurationRecord(
+			ReconfigurationRecord<NodeIDType> record) {
+		if (getReconfigurationRecord(record.getName()) != null)
+			return null;
+		putReconfigurationRecord(record);
+		return record;
+	}
+
+	@Override
+	public synchronized boolean createReconfigurationRecords(
+			Map<String, String> nameStates, Set<NodeIDType> newActives,
+			ReconfigureUponActivesChange policy) {
+		boolean insertedAll = true;
+		Set<String> inserted = new HashSet<String>();
+		for (String name : nameStates.keySet()) {
+			if (getReconfigurationRecord(name) != null) {
+				insertedAll = false;
+				break;
+			}
+			ReconfigurationRecord<NodeIDType> record = new ReconfigurationRecord<NodeIDType>(
+					name, -1, newActives, policy).setState(name, -1,
+					RCStates.WAIT_ACK_STOP);
+			putReconfigurationRecord(record);
+			inserted.add(name);
+		}
+		if (!insertedAll)
+			for (String name : inserted)
+				deleteReconfigurationRecordDB(name, null);
+		return insertedAll;
+	}
+
+	@Override
+	public boolean setStateInitReconfiguration(Map<String, String> nameStates,
+			int epoch, RCStates state, Set<NodeIDType> newActives) {
+		// already initialized to WAIT_ACK_STOP:-1 in batch create
+		return true;
+	}
+
+	@Override
+	public synchronized boolean setStateMerge(Map<String, String> nameStates,
+			int epoch, RCStates state, Set<NodeIDType> newActives) {
+		for (String name : nameStates.keySet()) {
+			ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+			if (record == null)
+				continue;
+			record.setState(name, epoch, state).setActivesToNewActives();
+			putReconfigurationRecord(record);
+		}
+		return true;
+	}
+
+	@Override
+	public synchronized boolean mergeState(String rcGroupName, int epoch,
+			String mergee, int mergeeEpoch, String state) {
+		synchronized (this.stringLocker.get(rcGroupName)) {
+			ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(rcGroupName);
+			assert (record.getEpoch() == epoch);
+			if (!record.hasBeenMerged(mergee))
+				if (updateState(rcGroupName, state, mergee)) {
+					record.insertMerged(mergee);
+					putReconfigurationRecord(record);
+					setMergeeStateToWaitDelete(mergee, mergeeEpoch);
+				}
+			if (record.isReconfigurationReady())
+				setPending(rcGroupName, false);
+			return record.hasBeenMerged(mergee);
+		}
+	}
+
+	private boolean setMergeeStateToWaitDelete(String mergee, int mergeEpoch) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(mergee,
+				mergeEpoch);
+		if (record == null)
+			return false;
+		setStateInitReconfiguration(mergee, mergeEpoch, RCStates.WAIT_ACK_STOP,
+				new HashSet<NodeIDType>());
+		setState(mergee, mergeEpoch + 1, RCStates.WAIT_DELETE);
+		return true;
+	}
+
+	@Override
+	public synchronized void clearMerged(String rcGroupName, int epoch) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(
+				rcGroupName, epoch);
+		if (record == null)
+			return;
+		record.clearMerged();
+		putReconfigurationRecord(record);
+	}
+
+	@Override
+	public void setRCEpochs(ReconfigurationRecord<NodeIDType> ncRecord) {
+		if (!ncRecord.getName().equals(
+				AbstractReconfiguratorDB.RecordNames.RC_NODES.toString()))
+			return;
+		putReconfigurationRecord(ncRecord);
+	}
+
+	@Override
+	public synchronized boolean mergeIntent(String name, int epoch, String mergee) {
+		ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+		boolean added = record.addToMerge(mergee);
+		putReconfigurationRecord(record);
+		return added;
+	}
+
+	@Override
+	public void delayedDeleteComplete() {
+		try {
+			for (String name : getPendingReconfigurations()) {
+				ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(name);
+				if (record != null && record.getState().equals(RCStates.WAIT_DELETE)
+						&& (System.currentTimeMillis() - record.getDeleteTime() > ReconfigurationConfig
+								.getMaxFinalStateAge()))
+					deleteReconfigurationRecord(name, record.getEpoch());
+			}
+		} catch (Exception e) {
+			log.severe(this + " exception in delayedDeleteComplete: " + e);
+		}
+	}
+
+	@Override
+	public void garbageCollectedDeletedNode(NodeIDType node) {
+		// no file-based checkpoints to clean up in the inline-checkpoint design
+	}
+
+	/* ******************* pending ******************* */
+
+	private boolean setPending(String name, boolean set) {
+		try {
+			if (set)
+				this.db.put(cf(CF_PENDING), this.writeOptions, bytes(name),
+						new byte[0]);
+			else
+				this.db.delete(cf(CF_PENDING), bytes(name));
+		} catch (RocksDBException e) {
+			log.severe(this + " failed to set pending " + name + "=" + set + ": "
+					+ e);
+		}
+		return true;
+	}
+
+	@Override
+	public String[] getPendingReconfigurations() {
+		Set<String> pending = new HashSet<String>();
+		if (this.closed)
+			return new String[0];
+		try (RocksIterator it = this.db.newIterator(cf(CF_PENDING))) {
+			for (it.seekToFirst(); it.isValid(); it.next())
+				pending.add(new String(it.key(), CHARSET));
+		}
+		return pending.toArray(new String[0]);
+	}
+
+	@Override
+	public void removePending(String name) {
+		delete(CF_PENDING, name);
+	}
+
+	/* ******************* RC groups ******************* */
+
+	@Override
+	public Map<String, Set<NodeIDType>> getRCGroups() {
+		Map<String, Set<NodeIDType>> rcGroups = new HashMap<String, Set<NodeIDType>>();
+		for (String rcGroupName : getRCGroupNames()) {
+			ReconfigurationRecord<NodeIDType> record = getReconfigurationRecord(rcGroupName);
+			if (record != null)
+				rcGroups.put(rcGroupName, record.getActiveReplicas());
+		}
+		return rcGroups;
+	}
+
+	@Override
+	public Set<String> getRCGroupNames() {
+		// RC group names are exactly the service names that appear as some
+		// record's rcGroupName; equivalently, the names that are RC group names.
+		Set<String> groups = new HashSet<String>();
+		if (this.closed)
+			return groups;
+		try (RocksIterator it = this.db.newIterator(cf(CF_RECORDS))) {
+			for (it.seekToFirst(); it.isValid(); it.next()) {
+				String name = new String(it.key(), CHARSET);
+				if (isRCGroupName(name))
+					groups.add(name);
+			}
+		}
+		groups.remove(AbstractReconfiguratorDB.RecordNames.RC_NODES.toString());
+		return groups;
+	}
+
+	/* ******************* node config ******************* */
+
+	@Override
+	public boolean addActiveReplica(NodeIDType node, InetSocketAddress sockAddr,
+			int version) {
+		return addToNodeConfig(node, sockAddr, version, false);
+	}
+
+	@Override
+	public boolean addReconfigurator(NodeIDType node, InetSocketAddress sockAddr,
+			int version) {
+		return addToNodeConfig(node, sockAddr, version, true);
+	}
+
+	// nodeConfig key: nodeID | 0x00 | version(string); value: {a:addr, p:port,
+	// rc:isReconfigurator, n:nodeID, v:version}
+	private boolean addToNodeConfig(NodeIDType node, InetSocketAddress sockAddr,
+			int version, boolean isReconfigurator) {
+		try {
+			JSONObject json = new JSONObject();
+			json.put("a", sockAddr.toString());
+			json.put("p", sockAddr.getPort());
+			json.put("rc", isReconfigurator);
+			json.put("n", node.toString());
+			json.put("v", version);
+			this.db.put(cf(CF_NODECONFIG), this.writeOptions,
+					nodeConfigKey(node.toString(), version),
+					bytes(json.toString()));
+			return true;
+		} catch (RocksDBException | JSONException e) {
+			log.severe(this + " failed to add node config for " + node + ": " + e);
+			return false;
+		}
+	}
+
+	private static byte[] nodeConfigKey(String nodeID, int version) {
+		return bytes(nodeID + " " + version);
+	}
+
+	@Override
+	public boolean garbageCollectOldReconfigurators(int version) {
+		if (this.closed)
+			return false;
+		try (RocksIterator it = this.db.newIterator(cf(CF_NODECONFIG))) {
+			for (it.seekToFirst(); it.isValid(); it.next())
+				try {
+					JSONObject json = new JSONObject(new String(it.value(), CHARSET));
+					if (json.getInt("v") == version)
+						this.db.delete(cf(CF_NODECONFIG), it.key());
+				} catch (JSONException | RocksDBException e) {
+					log.warning(this + " GC node config parse/delete error: " + e);
+				}
+		}
+		return true;
+	}
+
+	private Integer getMaxNodeConfigVersion(boolean reconfigurators) {
+		Integer max = null;
+		try (RocksIterator it = this.db.newIterator(cf(CF_NODECONFIG))) {
+			for (it.seekToFirst(); it.isValid(); it.next())
+				try {
+					JSONObject json = new JSONObject(new String(it.value(), CHARSET));
+					if (json.getBoolean("rc") == reconfigurators) {
+						int v = json.getInt("v");
+						if (max == null || v > max)
+							max = v;
+					}
+				} catch (JSONException e) {
+					log.warning(this + " node config parse error: " + e);
+				}
+		}
+		return max;
+	}
+
+	private Map<NodeIDType, InetSocketAddress> getRCNodeConfig(boolean maxOnly,
+			boolean reconfigurators) {
+		Integer version = getMaxNodeConfigVersion(reconfigurators);
+		if (version == null)
+			return null;
+		int threshold = maxOnly ? version : version - 1;
+		Map<NodeIDType, InetSocketAddress> map = new HashMap<NodeIDType, InetSocketAddress>();
+		try (RocksIterator it = this.db.newIterator(cf(CF_NODECONFIG))) {
+			for (it.seekToFirst(); it.isValid(); it.next())
+				try {
+					JSONObject json = new JSONObject(new String(it.value(), CHARSET));
+					if (json.getBoolean("rc") != reconfigurators)
+						continue;
+					int v = json.getInt("v");
+					if (maxOnly ? v == threshold : v >= threshold) {
+						NodeIDType node = this.consistentNodeConfig.valueOf(json
+								.getString("n"));
+						map.put(node, Util.getInetSocketAddressFromString(json
+								.getString("a")));
+					}
+				} catch (JSONException e) {
+					log.warning(this + " node config parse error: " + e);
+				}
+		}
+		return map;
+	}
+
+	private boolean copySoftNodeConfigToDB(boolean isReconfigurators) {
+		boolean added = true;
+		if (isReconfigurators)
+			for (NodeIDType rc : this.consistentNodeConfig.getReconfigurators())
+				added = added
+						&& addReconfigurator(rc, this.consistentNodeConfig
+								.getNodeSocketAddress(rc), 0);
+		else
+			for (NodeIDType ar : this.consistentNodeConfig.getActiveReplicas())
+				added = added
+						&& addActiveReplica(ar, this.consistentNodeConfig
+								.getNodeSocketAddress(ar), 0);
+		return added;
+	}
+
+	private void initAdjustSoftNodeConfig() {
+		Map<NodeIDType, InetSocketAddress> rcMapAll = getRCNodeConfig(false, true);
+		if ((rcMapAll == null || rcMapAll.isEmpty()) && copySoftNodeConfigToDB(true))
+			return;
+		ReconfigurationRecord<NodeIDType> ncRecord = getReconfigurationRecord(AbstractReconfiguratorDB.RecordNames.RC_NODES
+				.toString());
+		if (ncRecord == null || rcMapAll == null || rcMapAll.isEmpty())
+			return;
+		Set<NodeIDType> latestRCs = ncRecord.getNewActives();
+		for (NodeIDType node : rcMapAll.keySet())
+			this.consistentNodeConfig.addReconfigurator(node, rcMapAll.get(node));
+		for (NodeIDType node : this.consistentNodeConfig.getReconfigurators())
+			if (!rcMapAll.containsKey(node))
+				this.consistentNodeConfig.removeReconfigurator(node);
+			else if (!latestRCs.contains(node))
+				this.consistentNodeConfig.slateForRemovalReconfigurator(node);
+	}
+
+	private void initAdjustSoftActiveNodeConfig() {
+		Map<NodeIDType, InetSocketAddress> arMapAll = getRCNodeConfig(false, false);
+		if ((arMapAll == null || arMapAll.isEmpty()) && copySoftNodeConfigToDB(false))
+			return;
+		ReconfigurationRecord<NodeIDType> ncRecord = getReconfigurationRecord(AbstractReconfiguratorDB.RecordNames.AR_NODES
+				.toString());
+		if (ncRecord == null || arMapAll == null || arMapAll.isEmpty())
+			return;
+		Set<NodeIDType> latestARs = ncRecord.getNewActives();
+		for (NodeIDType node : arMapAll.keySet())
+			this.consistentNodeConfig.addActiveReplica(node, arMapAll.get(node));
+		for (NodeIDType node : this.consistentNodeConfig.getActiveReplicas())
+			if (!arMapAll.containsKey(node))
+				this.consistentNodeConfig.removeActiveReplica(node);
+			else if (!latestARs.contains(node))
+				this.consistentNodeConfig.slateForRemovalActive(node);
+	}
+
+	/* ******************* checkpoint / restore (inline) ******************* */
+
+	@Override
+	public String checkpoint(String rcGroup) {
+		synchronized (this.stringLocker.get(rcGroup)) {
+			StringBuilder sb = new StringBuilder();
+			try (RocksIterator it = this.db.newIterator(cf(CF_RECORDS))) {
+				for (it.seekToFirst(); it.isValid(); it.next())
+					try {
+						JSONObject wrapper = new JSONObject(new String(it.value(),
+								CHARSET));
+						String g = wrapper.isNull(W_GROUP) ? null : wrapper
+								.getString(W_GROUP);
+						if (rcGroup.equals(g))
+							sb.append(wrapper.getString(W_RECORD)).append("\n");
+					} catch (JSONException e) {
+						log.warning(this + " checkpoint parse error: " + e);
+					}
+			}
+			return sb.toString();
+		}
+	}
+
+	@Override
+	public boolean restore(String rcGroup, String state) {
+		return updateState(rcGroup, state, null);
+	}
+
+	private boolean updateState(String rcGroup, String state, String mergee) {
+		synchronized (this.stringLocker.get(rcGroup)) {
+			if (state == null)
+				return true;
+			for (String line : state.split("\n")) {
+				if (line.trim().isEmpty())
+					continue;
+				try {
+					putReconfigurationRecordIfNotName(
+							new ReconfigurationRecord<NodeIDType>(new JSONObject(
+									line), this.consistentNodeConfig), rcGroup,
+							mergee);
+				} catch (JSONException e) {
+					log.severe(this + " unable to restore record line: " + e);
+				}
+			}
+			return true;
+		}
+	}
+
+	private synchronized boolean putReconfigurationRecordIfNotName(
+			ReconfigurationRecord<NodeIDType> record, String rcGroupName,
+			String mergee) {
+		if (isRCGroupName(record.getName())
+				&& !record.getName().equals(rcGroupName))
+			return false;
+		else if (record.getName().equals(mergee))
+			return false;
+		putReconfigurationRecord(record, rcGroupName);
+		if (!record.isReady())
+			setPending(record.getName(), true);
+		return true;
+	}
+
+	@Override
+	public String fetchAndAggregateMergeeStates(Map<String, String> finalStates,
+			String mergerGroup, int mergerGroupEpoch) {
+		// in the inline-checkpoint design each mergee final state is itself the
+		// newline-separated record string, so aggregation is concatenation.
+		StringBuilder sb = new StringBuilder();
+		for (String mergee : finalStates.keySet()) {
+			String s = finalStates.get(mergee);
+			if (s != null && !s.isEmpty()) {
+				sb.append(s);
+				if (!s.endsWith("\n"))
+					sb.append("\n");
+			}
+		}
+		return sb.toString();
+	}
+
+	/* ******************* active-record cursor ******************* */
+
+	@Override
+	public synchronized boolean initiateReadActiveRecords(NodeIDType active) {
+		if (this.activeCursor != null || this.closed)
+			return false;
+		this.cursorActive = active;
+		this.activeCursor = this.db.newIterator(cf(CF_RECORDS));
+		this.activeCursor.seekToFirst();
+		return true;
+	}
+
+	@Override
+	public synchronized ReconfigurationRecord<NodeIDType> readNextActiveRecord(
+			boolean add) {
+		if (this.activeCursor == null)
+			return null;
+		while (this.activeCursor.isValid()) {
+			ReconfigurationRecord<NodeIDType> record = null;
+			try {
+				JSONObject wrapper = new JSONObject(new String(this.activeCursor
+						.value(), CHARSET));
+				record = new ReconfigurationRecord<NodeIDType>(new JSONObject(
+						wrapper.getString(W_RECORD)), this.consistentNodeConfig);
+			} catch (JSONException e) {
+				log.warning(this + " readNextActiveRecord parse error: " + e);
+			}
+			this.activeCursor.next();
+			if (record == null)
+				continue;
+			String name = record.getName();
+			if (name.equals(AbstractReconfiguratorDB.RecordNames.AR_NODES.toString())
+					|| name.equals(AbstractReconfiguratorDB.RecordNames.RC_NODES
+							.toString()))
+				continue;
+			if (record.getActiveReplicas() != null
+					&& !isRCGroupName(name)
+					&& this.consistentNodeConfig.getActiveReplicas().containsAll(
+							record.getActiveReplicas())
+					&& (add || ((record.getActiveReplicas().contains(
+							this.cursorActive) || record
+							.getReconfigureUponActivesChangePolicy() == ReconfigureUponActivesChange.REPLICATE_ALL) && record
+							.isReconfigurationReady())))
+				return record;
+		}
+		return null;
+	}
+
+	@Override
+	public synchronized boolean closeReadActiveRecords() {
+		if (this.activeCursor != null)
+			this.activeCursor.close();
+		this.activeCursor = null;
+		return true;
+	}
+
+	/* ******************* lifecycle ******************* */
+
+	@Override
+	public void close() {
+		if (this.closed)
+			return;
+		this.closed = true;
+		closeReadActiveRecords();
+		for (ColumnFamilyHandle h : this.cfs.values())
+			h.close();
+		if (this.db != null)
+			this.db.close();
+		if (this.dbOptions != null)
+			this.dbOptions.close();
+		this.writeOptions.close();
+		for (ColumnFamilyOptions o : this.cfOpts)
+			o.close();
+		log.log(Level.INFO, "{0} closed RocksDB reconfigurator DB", this);
+	}
+}

--- a/src/edu/umass/cs/reconfiguration/SQLReconfiguratorDB.java
+++ b/src/edu/umass/cs/reconfiguration/SQLReconfiguratorDB.java
@@ -67,6 +67,7 @@ import edu.umass.cs.gigapaxos.SQLPaxosLogger;
 import edu.umass.cs.gigapaxos.interfaces.Request;
 import edu.umass.cs.gigapaxos.paxosutil.LargeCheckpointer;
 import edu.umass.cs.gigapaxos.paxosutil.SQL;
+import edu.umass.cs.gigapaxos.paxosutil.SimpleDataSource;
 import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.reconfiguration.ReconfigurationConfig.RC;
 import edu.umass.cs.reconfiguration.examples.AppRequest;
@@ -112,6 +113,13 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			RC.RECONFIGURATION_DB_DIR.getDefaultValue();
 	private static final boolean CONN_POOLING = true; // should just be true
 	private static final int MAX_POOL_SIZE = 100;
+	/**
+	 * Whether to use C3P0 pooling. Disabled automatically for the single-writer
+	 * EMBEDDED_SQLITE engine, or by setting CONNECTION_POOLING=false.
+	 */
+	private static final boolean USE_POOLING = Config
+			.getGlobalBoolean(RC.CONNECTION_POOLING)
+			&& !SQL_TYPE.equals(SQL.SQLType.EMBEDDED_SQLITE);
 	private static final int MAX_NAME_SIZE = SQLPaxosLogger.MAX_PAXOS_ID_SIZE;
 
 	/**
@@ -201,7 +209,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 
 	protected String logDirectory;
 
-	private ComboPooledDataSource dataSource = null;
+	private DataSource dataSource = null;
 
 	private ServerSocket serverSock = null;
 
@@ -323,8 +331,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 					rcGroupName = this.getRCGroupName(name);
 				pstmt.setString(1, rcGroupName);
 				if (RC_RECORD_CLOB_OPTION)
-					pstmt.setClob(2,
-							new StringReader((toCommit.get(name)).toString()));
+					setClobString(pstmt, 2, (toCommit.get(name)).toString());
 				else
 					pstmt.setString(2, (toCommit.get(name)).toString());
 				pstmt.setString(3, name);
@@ -489,7 +496,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			conn = this.getDefaultConn();
 			insertCP = conn.prepareStatement(cmd);
 			if (DEMAND_PROFILE_CLOB_OPTION)
-				insertCP.setClob(1, new StringReader(combined.toString()));
+				setClobString(insertCP, 1, combined.toString());
 			else
 				insertCP.setString(1, combined.toString());
 			insertCP.setString(2, report.getServiceName());
@@ -676,7 +683,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			insertCP = conn.prepareStatement(cmd);
 			insertCP.setString(1, rcGroupName);
 			if (RC_RECORD_CLOB_OPTION)
-				insertCP.setClob(2, new StringReader(rcRecord.toString()));
+				setClobString(insertCP, 2, rcRecord.toString());
 			else
 				insertCP.setString(2, rcRecord.toString());
 			insertCP.setString(3, rcRecord.getName());
@@ -1762,7 +1769,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			stmt.execute(cmd);
 			created = true;
 		} catch (SQLException sqle) {
-			if (SQL.DUPLICATE_TABLE.contains(sqle.getSQLState())) {
+			if (SQL.isDuplicateTableException(sqle)) {
 				log.log(Level.INFO, "{0}{1}{2}", new Object[] { "Table ",
 						table, " already exists" });
 				if(schema!=null) reconcileTable(stmt, cmd, table, schema);
@@ -1871,7 +1878,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			stmt.execute();
 			dropped = true;
 		} catch (SQLException sqle) {
-			if (!SQL.NONEXISTENT_TABLE.contains(sqle.getSQLState())) {
+			if (!SQL.isNonexistentTableException(sqle)) {
 				log.severe(this + " could not drop table " + table + ":"
 						+ sqle.getSQLState() + ":" + sqle.getErrorCode());
 				sqle.printStackTrace();
@@ -1888,7 +1895,25 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 	}
 
 	private static final boolean isEmbeddedDB() {
-		return SQL_TYPE.equals(SQL.SQLType.EMBEDDED_DERBY);
+		return SQL_TYPE.equals(SQL.SQLType.EMBEDDED_DERBY)
+				|| SQL_TYPE.equals(SQL.SQLType.EMBEDDED_SQLITE);
+	}
+
+	private static final boolean isSQLite() {
+		return SQL_TYPE.equals(SQL.SQLType.EMBEDDED_SQLITE);
+	}
+
+	/* Sets a CLOB parameter from a String. The xerial sqlite-jdbc driver does
+	 * not implement PreparedStatement.setClob (throws
+	 * SQLFeatureNotSupportedException), but a plain setString round-trips fine
+	 * through SQLite's dynamically-typed columns and reads back via getString,
+	 * exactly as the existing read sites already expect. */
+	private static void setClobString(PreparedStatement pstmt, int idx,
+			String value) throws SQLException {
+		if (isSQLite())
+			pstmt.setString(idx, value);
+		else
+			pstmt.setClob(idx, new StringReader(value));
 	}
 
 	private static final String getMyDBName(Object myID) {
@@ -1907,8 +1932,15 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 		// providing a user name and PASSWORD is optional in embedded derby
 		props.put("user", SQL.getUser() + (isEmbeddedDB() ? this.getMyIDSanitized() : ""));
 		props.put("password", SQL.getPassword());
+		if (isSQLite())
+			addSQLitePragmas(props);
+		ensureLogDirectoryExists(this.logDirectory);
 		String dbCreation = SQL.getProtocolOrURL(SQL_TYPE)
-				+ (isEmbeddedDB() ? this.logDirectory
+				+ (isSQLite() ?
+				// SQLite: the URL is just a file path; the file is created
+				// automatically on first connect (no ";create=true" flag).
+				this.logDirectory + getMyDBName()
+				: isEmbeddedDB() ? this.logDirectory
 						+ getMyDBName()
 						+ (!SQLPaxosLogger.existsDB(SQL_TYPE,
 								this.logDirectory, getMyDBName()) ? ";create=true"
@@ -1916,8 +1948,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 						: getMyDBName() + "?createDatabaseIfNotExist=true");
 
 		try {
-			dataSource = (ComboPooledDataSource) setupDataSourceC3P0(
-					dbCreation, props);
+			dataSource = setupDataSource(dbCreation, props);
 		} catch (SQLException e) {
 			log.severe("Could not create pooled data source to DB "
 					+ dbCreation);
@@ -1930,7 +1961,10 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			try {
 				connAttempts++;
 				log.info("Attempting getDefaultConn() to DB " + dbCreation);
-				getDefaultConn(); // open first connection
+				// capture so the finally block closes it and releases any
+				// bounded-pool permit; discarding it leaks a connection, which
+				// deadlocks under DB_MAX_CONNECTIONS=1.
+				conn = getDefaultConn(); // open first connection
 				log.info("Connected to and created database " + getMyDBName());
 				connected = true;
 				if (isEmbeddedDB())
@@ -1951,9 +1985,43 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 		return connected;
 	}
 
+	private void ensureLogDirectoryExists(String logDir) {
+		File f = new File(logDir);
+		if (!f.exists())
+			f.mkdirs();
+	}
+
+	/* See SQLPaxosLogger.addSQLitePragmas. transaction_mode is intentionally
+	 * left DEFERRED to avoid write-lock self-deadlock on re-entrant DB paths. */
+	private static void addSQLitePragmas(Properties props) {
+		props.put("journal_mode", "WAL");
+		props.put("synchronous",
+				Config.getGlobalString(PC.SQLITE_SYNCHRONOUS));
+		props.put("busy_timeout", "30000"); // ms
+	}
+
 	private void fixURI() {
-		this.dataSource.setJdbcUrl(SQL.getProtocolOrURL(SQL_TYPE)
+		setDataSourceJdbcUrl(this.dataSource, SQL.getProtocolOrURL(SQL_TYPE)
 				+ this.logDirectory + getMyDBName());
+	}
+
+	/* The dataSource field is the javax.sql.DataSource interface so that either
+	 * a pooled (C3P0) or non-pooled (SimpleDataSource) implementation can be
+	 * used. Neither exposes setJdbcUrl on the interface, so dispatch here. */
+	private static void setDataSourceJdbcUrl(DataSource ds, String url) {
+		if (ds instanceof ComboPooledDataSource)
+			((ComboPooledDataSource) ds).setJdbcUrl(url);
+		else if (ds instanceof SimpleDataSource)
+			((SimpleDataSource) ds).setJdbcUrl(url);
+	}
+
+	private static final DataSource setupDataSource(String connectURI,
+			Properties props) throws SQLException {
+		if (USE_POOLING)
+			return setupDataSourceC3P0(connectURI, props);
+		int maxTotal = Config.getGlobalInt(RC.DB_MAX_CONNECTIONS);
+		int maxIdle = maxTotal > 0 ? maxTotal : 8;
+		return new SimpleDataSource(connectURI, props, maxIdle, maxTotal);
 	}
 
 	private static final DataSource setupDataSourceC3P0(String connectURI,
@@ -2254,7 +2322,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 			// conn.commit();
 			added = true;
 		} catch (SQLException sqle) {
-			if (!SQL.DUPLICATE_KEY.contains(sqle.getSQLState())) {
+			if (!SQL.isDuplicateKeyException(sqle)) {
 				log.severe("SQLException while inserting RC record using "
 						+ cmd);
 				sqle.printStackTrace();
@@ -2648,7 +2716,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 				record.setState(name, -1, RCStates.WAIT_ACK_STOP);
 				insertRC.setString(1, rcGroupName);
 				if (RC_RECORD_CLOB_OPTION)
-					insertRC.setClob(2, new StringReader(record.toString()));
+					setClobString(insertRC, 2, record.toString());
 				else
 					insertRC.setString(2, record.toString());
 				insertRC.setString(3, name);
@@ -2748,7 +2816,7 @@ public class SQLReconfiguratorDB<NodeIDType> extends
 				;
 				updateRC.setString(1, rcGroupName);
 				if (RC_RECORD_CLOB_OPTION)
-					updateRC.setClob(2, new StringReader(record.toString()));
+					setClobString(updateRC, 2, record.toString());
 				else
 					updateRC.setString(2, record.toString());
 				updateRC.setString(3, name);

--- a/src/edu/umass/cs/reconfiguration/testing/ConfiguredTestRunner.java
+++ b/src/edu/umass/cs/reconfiguration/testing/ConfiguredTestRunner.java
@@ -1,0 +1,49 @@
+package edu.umass.cs.reconfiguration.testing;
+
+import java.util.Arrays;
+
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+import edu.umass.cs.utils.Config;
+
+/**
+ * A small JUnit launcher that injects gigapaxos config overrides via
+ * {@link Config#register(String[])} (which takes precedence over default
+ * values) BEFORE the target test class is loaded. This lets us run existing
+ * integration tests such as {@link TESTReconfigurationClient} against an
+ * alternate SQL backend (e.g. SQL_TYPE=EMBEDDED_SQLITE) without supplying a
+ * gigapaxosConfig properties file, which those harnesses intentionally forbid.
+ *
+ * Usage: ConfiguredTestRunner &lt;TestClassFQN&gt; [KEY=VALUE ...]
+ */
+public class ConfiguredTestRunner {
+	/**
+	 * @param args
+	 *            args[0] = fully-qualified test class name; remaining args are
+	 *            KEY=VALUE config overrides.
+	 * @throws ClassNotFoundException
+	 */
+	public static void main(String[] args) throws ClassNotFoundException {
+		String testClass = args.length > 0 ? args[0]
+				: "edu.umass.cs.reconfiguration.testing.TESTReconfigurationClient";
+		String[] cfg = args.length > 1 ? Arrays.copyOfRange(args, 1, args.length)
+				: new String[0];
+		// must happen before the test (and thus the SQL logger classes) load
+		Config.register(cfg);
+		System.out.println("[ConfiguredTestRunner] test=" + testClass
+				+ " overrides=" + Arrays.toString(cfg));
+
+		Result r = JUnitCore.runClasses(Class.forName(testClass));
+		for (Failure f : r.getFailures()) {
+			System.out.println("FAILURE: " + f);
+			f.getException().printStackTrace();
+		}
+		System.out.println("[ConfiguredTestRunner] Tests run: " + r.getRunCount()
+				+ ", Failures: " + r.getFailureCount() + ", Ignored: "
+				+ r.getIgnoreCount() + ", Time: " + r.getRunTime() + "ms, success="
+				+ r.wasSuccessful());
+		System.exit(r.wasSuccessful() ? 0 : 1);
+	}
+}


### PR DESCRIPTION
Adds two embedded database backends so the reconfigurator (and paxos logger)
can run on small machines (0.5–1 GB DRAM) with lower memory and latency than the
default Embedded Derby + C3P0. All selectors default to SQL/Derby, so existing
deployments are unchanged.

## What's added
- **SQLite** (JDBC vendor): new `EMBEDDED_SQLITE` in `SQL.SQLType` + a lightweight
  non-pooling `SimpleDataSource` (drops C3P0's helper threads). Selected via
  `SQL_TYPE=EMBEDDED_SQLITE`, `CONNECTION_POOLING=false`. Durability configurable
  via `SQLITE_SYNCHRONOUS` (NORMAL | FULL).
- **RocksDB** (key-value, not JDBC): new `RocksDBPaxosLogger` and
  `RocksDBReconfiguratorDB` implementing the abstract logger/DB base classes
  directly on RocksDB column families, behind `PAXOS_LOGGER=ROCKSDB` /
  `RECONFIGURATOR_DB=ROCKSDB`. Native memory bounded by a shared block cache +
  WriteBufferManager (`ROCKSDB_BLOCK_CACHE_MB`, `ROCKSDB_MEMTABLE_BUDGET_MB`);
  durability via `ROCKSDB_SYNC_WRITES`.
- Per-component factories; a node can mix backends.

## Results (single RC node, measured)
- **Memory**: SQLite 125 MB, RocksDB 124 MB, Derby 191 MB — both new backends
  ~35% lighter, run with a heap as low as ~48 MB, fit 0.5 GB with ~390 MB spare.
- **Durability-equal latency** (full fsync): SQLite has fast, predictable durable
  writes and completes the full reconfiguration suite; RocksDB matches memory and
  has lower *batched* write latency but stalls on recovery-heavy tests (no log
  index yet) and is slow on unbatched fsync writes.
- **Recommendation for a durable small-memory RC today: SQLite `synchronous=FULL`.**
  See `docs/rocksdb-vs-sqlite.md`, `docs/sqlite-backend.md`, `docs/rocksdb-backend-plan.md`.

## Validation
Full `TESTReconfigurationClient` cluster (5 RC + 8 AR). SQLite and the RocksDB
reconfigurator DB pass 18/18 with 0 failures; the RocksDB logger passes core +
recovery (slow on the recovery-heavy membership tests). Derby path unchanged
(regression-checked). Several real bugs were caught and fixed via this validation
(idempotent recovery cursors, batch-pause map aliasing, a latent connection leak).

## Notes
- `lib/rocksdbjni-9.7.3.jar` is ~68 MB (bundled native libs); consider git-LFS.
- Follow-up: optimize the RocksDB logger's recovery reads (cache per-paxosID
  message lists / compact log index) to make it competitive at full durability.