### PR TITLE
gitignore: exclude papers/ to keep private papers out of public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ bin/*
 screen_logs
 merge-review
 *-paper/
+# paper projects live in their own private repos (double-blind); never track them here
+papers/
 .claude
 *.tar.gz
 


### PR DESCRIPTION
The `papers/` directory sits inside this repo's working tree but holds paper projects that live in their own **private** repos (double-blind review). This adds an explicit `papers/` rule to `.gitignore` so those projects can never be accidentally committed to this public repo.

The existing `*-paper/` rule only matched the individual paper subfolders by naming convention; `papers/` covers the whole directory regardless of subfolder names.