### PR TITLE
track empty papers/ folder via placeholder README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,10 @@ bin/*
 screen_logs
 merge-review
 *-paper/
-# paper projects live in their own private repos (double-blind); never track them here
-papers/
+# paper projects live in their own private repos (double-blind); never track them here.
+# ignore everything under papers/ EXCEPT the placeholder that keeps the folder in-repo.
+papers/*
+!papers/README.md
 .claude
 *.tar.gz
 

--- a/papers/README.md
+++ b/papers/README.md
@@ -1,0 +1,18 @@
+# papers
+
+This directory is the designated home for XDN paper projects, but it is
+intentionally (almost) empty in this public repository.
+
+Each paper lives in its **own private GitHub repository** because papers are
+submitted under double-blind review and must not be linkable to the authors.
+The public code repo therefore ignores everything under `papers/` except this
+README (see the `papers/*` / `!papers/README.md` rules in the top-level
+`.gitignore`).
+
+To work on a paper, clone its private repo into this folder, for example:
+
+```
+git clone git@github.com:<owner>/<paper>-paper.git papers/<paper>-paper
+```
+
+Its contents stay untracked here and cannot leak into this public repo.


### PR DESCRIPTION
Adds `papers/` to the repo as the designated (empty) home for paper projects, while keeping the actual papers ignored.

- `.gitignore`: changed `papers/` to `papers/*` + `!papers/README.md` so the folder is tracked but its contents are not. Git can't re-include a file under a fully-excluded directory, hence the `papers/*` form.
- `papers/README.md`: documents that each paper lives in its own **private** repo (double-blind) and must never be committed here.

Verified: only `papers/README.md` is tracked; all existing paper projects remain ignored.