### PR TITLE
Frontier-based anti-entropy for eventual consistency (LazyReplicaCoordinator)

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -121,6 +121,7 @@ jobs:
       matrix:
         test_class:
           - XdnEventualConsistencyBatchingTest
+          - XdnEventualConvergenceTest
           - XdnGetReplicaInfoTest
           - XdnMultiServiceTest
           - XdnPerReplicaRequestTest
@@ -140,12 +141,13 @@ jobs:
       uses: docker-practice/actions-setup-docker@master
       timeout-minutes: 12
 
-    - name: 📦 Verify Docker and pre-pull bookcatalog image
+    - name: 📦 Verify Docker and pre-pull test images
       run: |
         set -x
         docker version
         docker run --rm hello-world
         docker pull fadhilkurnia/xdn-bookcatalog
+        docker pull fadhilkurnia/xdn-randstate
 
     - name: 🔄 Set up Rsync
       uses: GuillaumeFalourd/setup-rsync@v1.2

--- a/build.xml
+++ b/build.xml
@@ -382,7 +382,7 @@
         <mkdir dir="build/test-classes"/>
         <javac srcdir="test"
                destdir="build/test-classes"
-               includeantruntime="false">
+               includeantruntime="false" release="21">
             <classpath>
                 <pathelement path="build/classes"/>
                 <path refid="classpath.test"/>

--- a/src/edu/umass/cs/eventual/LazyReplicaCoordinator.java
+++ b/src/edu/umass/cs/eventual/LazyReplicaCoordinator.java
@@ -1,7 +1,11 @@
 package edu.umass.cs.eventual;
 
+import edu.umass.cs.clientcentric.VectorTimestamp;
+import edu.umass.cs.eventual.interfaces.CheckpointableApplication;
+import edu.umass.cs.eventual.packets.LazyCheckpointPacket;
 import edu.umass.cs.eventual.packets.LazyPacket;
 import edu.umass.cs.eventual.packets.LazyPacketType;
+import edu.umass.cs.eventual.packets.LazySyncPacket;
 import edu.umass.cs.eventual.packets.LazyWriteAfterPacket;
 import edu.umass.cs.gigapaxos.interfaces.ClientRequest;
 import edu.umass.cs.gigapaxos.interfaces.ExecutedCallback;
@@ -12,44 +16,73 @@ import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.nio.interfaces.Messenger;
 import edu.umass.cs.nio.interfaces.Stringifiable;
 import edu.umass.cs.reconfiguration.AbstractReplicaCoordinator;
+import edu.umass.cs.reconfiguration.ReconfigurationConfig;
 import edu.umass.cs.reconfiguration.interfaces.ReconfigurableRequest;
 import edu.umass.cs.reconfiguration.reconfigurationpackets.ReplicableClientRequest;
 import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
+import edu.umass.cs.utils.Config;
 import edu.umass.cs.xdn.interfaces.behavior.BehavioralRequest;
-import edu.umass.cs.xdn.request.XdnHttpRequest;
-import edu.umass.cs.xdn.request.XdnHttpRequestBatch;
-import io.netty.buffer.ByteBuf;
-import io.netty.util.ReferenceCountUtil;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
+/**
+ * LazyReplicaCoordinator implements eventual consistency with frontier-based anti-entropy.
+ *
+ * <p>Every replica accepts client requests: reads execute locally; writes execute locally, are
+ * acknowledged immediately, increment the replica's own component of a per-service vector clock,
+ * and are broadcast to peers as a best-effort {@link LazyWriteAfterPacket} fast path (peers apply
+ * a write-after only when contiguous with their clock, otherwise drop it).
+ *
+ * <p>Convergence is guaranteed by periodic anti-entropy: every
+ * {@code XDN_EVENTUAL_ANTI_ENTROPY_INTERVAL_MS} each replica broadcasts its vector clock and a
+ * digest of its state ({@link LazySyncPacket}). A replica that detects itself as the
+ * <em>frontier</em> relative to a peer (larger applied-write set, i.e., larger clock sum, with
+ * ties broken by node ID) captures a checkpoint of its whole service state and ships it to that
+ * peer ({@link LazyCheckpointPacket}). The receiver installs the checkpoint, then re-applies its
+ * own writes the checkpoint lacks; each replica therefore retains its own executed writes until
+ * every peer's clock covers them. Once writes stop, every write reaches the frontier and its
+ * final checkpoint propagates unchanged, leaving all replicas byte-identical, regardless of
+ * service determinism or request commutativity/monotonicity.
+ *
+ * <p>Known limitations: protocol state (vector clock and own-write log) is in-memory, so a
+ * replica process restart rejoins with a zeroed clock and re-adopts its own component from the
+ * first checkpoint it installs; a membership/epoch change resets protocol state (packets carry
+ * the epoch and mismatches are dropped); convergence liveness assumes replicas eventually
+ * communicate.
+ */
 public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinator<NodeIDType> {
 
     private final NodeIDType myNodeId;
+    private final String myNodeIdStr;
     private final Replicable app;
+    private final CheckpointableApplication checkpointableApp; // null if app is not checkpointable
     private final Set<IntegerPacketType> packetTypes;
     private final Messenger<NodeIDType, JSONObject> messenger;
+    private final Stringifiable<NodeIDType> nodeIdDeserializer;
 
-    private record LazyReplicaInstance<NodeIDType>(String serviceName,
-                                                   int currEpoch,
-                                                   String initStateSnapshot,
-                                                   Set<NodeIDType> nodes) {
-    }
+    private final ConcurrentMap<String, LazyServiceState<NodeIDType>> currentInstances;
 
-    private final ConcurrentMap<String, LazyReplicaInstance<NodeIDType>> currentInstances;
-    private final ExecutorService executePool;
+    private final ScheduledExecutorService antiEntropyScheduler;
+    private final long antiEntropyIntervalMs;
+    private final long checkpointInlineMaxBytes;
 
     private final Logger logger = Logger.getLogger(LazyReplicaCoordinator.class.getSimpleName());
 
@@ -59,8 +92,11 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
                                   Messenger<NodeIDType, JSONObject> messenger) {
         super(app, messenger);
         this.myNodeId = myId;
+        this.myNodeIdStr = myId.toString();
         this.messenger = messenger;
         this.app = app;
+        this.nodeIdDeserializer = nodeIdDeserializer;
+        this.checkpointableApp = (app instanceof CheckpointableApplication ca) ? ca : null;
 
         // validate the nodeIdDeserializer
         assert messenger.getMyID().equals(myId) : "Invalid node ID given in the messenger";
@@ -73,15 +109,24 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
 
         this.currentInstances = new ConcurrentHashMap<>();
 
-        int nWorkers = Integer.getInteger("LAZY_N_EXECUTE_WORKERS",
-                Math.max(32, Runtime.getRuntime().availableProcessors() * 4));
-        this.executePool = Executors.newFixedThreadPool(nWorkers, r -> {
-            Thread t = new Thread(r, "lazy-exec-" + myNodeId);
+        this.antiEntropyIntervalMs = Config.getGlobalLong(
+                ReconfigurationConfig.RC.XDN_EVENTUAL_ANTI_ENTROPY_INTERVAL_MS);
+        this.checkpointInlineMaxBytes = Config.getGlobalLong(
+                ReconfigurationConfig.RC.XDN_EVENTUAL_CHECKPOINT_INLINE_MAX_BYTES);
+
+        // Periodic anti-entropy round with a randomized initial delay so replicas
+        // de-synchronize their rounds (same pattern as gigapaxos' FailureDetection).
+        this.antiEntropyScheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread t = new Thread(r, "lazy-anti-entropy-" + myNodeId);
             t.setDaemon(true);
             return t;
         });
+        long initialDelayMs = antiEntropyIntervalMs
+                + new Random().nextLong(Math.max(1, antiEntropyIntervalMs / 2));
+        this.antiEntropyScheduler.scheduleAtFixedRate(this::runAntiEntropyRound,
+                initialDelayMs, antiEntropyIntervalMs, TimeUnit.MILLISECONDS);
 
-        // add packet demultiplexer for LaztPacket that will invoke
+        // add packet demultiplexer for LazyPacket that will invoke
         // the coordinateRequest() method.
         LazyPacketDemultiplexer packetDemultiplexer =
                 new LazyPacketDemultiplexer(this, app);
@@ -106,11 +151,11 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
 
         // validate that service exists
         String serviceName = request.getServiceName();
-        if (!this.currentInstances.containsKey(serviceName)) {
+        LazyServiceState<NodeIDType> state = this.currentInstances.get(serviceName);
+        if (state == null) {
             logger.log(Level.WARNING, "Ignoring request for unknown service=" + serviceName);
             return true;
         }
-        LazyReplicaInstance<NodeIDType> currInstance = this.currentInstances.get(serviceName);
 
         // unwrap the request if needed
         Request currRequestOrPacket = request;
@@ -126,82 +171,487 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
             return true;
         }
 
-        // handle client-initiated request
+        // handle client-initiated request: reads execute locally; every other request
+        // (write-only, read-modify-write, batches, or undeclared behavior) is treated as
+        // a write, executed locally, and propagated lazily.
         if (currRequestOrPacket instanceof ClientRequest clientRequest) {
-            // validates that request is either ReadOnly or (WriteOnly and Monotonic).
-            if (!(clientRequest instanceof BehavioralRequest br)) {
-                throw new RuntimeException("Expecting BehavioralRequest for LazyReplicaCoordinator");
-            }
-            boolean isReadOnly = br.isReadOnlyRequest();
-            boolean isMonotonic = br.isMonotonicRequest();
-            boolean isWriteOnly = br.isWriteOnlyRequest();
-            if (!(isReadOnly || (isMonotonic && isWriteOnly))) {
-                throw new RuntimeException(
-                        "Expecting ReadOnly request or (Monotonic and WriteOnly) request " +
-                                "for LazyReplicaCoordinator");
-            }
-
-            // Read-only requests need no coordination — execute inline on the
-            // caller thread to avoid thread-pool dispatch overhead.
+            boolean isReadOnly = (clientRequest instanceof BehavioralRequest br)
+                    && br.isReadOnlyRequest();
             if (isReadOnly) {
-                boolean isExecSuccess = this.app.execute(clientRequest);
+                ReentrantReadWriteLock.ReadLock readLock = state.lock.readLock();
+                readLock.lock();
+                boolean isExecSuccess;
+                try {
+                    isExecSuccess = this.app.execute(clientRequest);
+                } finally {
+                    readLock.unlock();
+                }
                 callback.executed(clientRequest, isExecSuccess);
                 return true;
             }
-
-            // Write requests are fire-and-forget — execute inline, respond,
-            // then asynchronously broadcast WRITE_AFTER on a virtual thread.
-            boolean isExecSuccess = this.app.execute(clientRequest);
-            if (!isExecSuccess) {
-                if (logger.isLoggable(Level.WARNING)) {
-                    logger.log(Level.WARNING, "Failed to execute request: " + clientRequest);
-                }
-                callback.executed(clientRequest, false);
-                return true;
-            }
-            callback.executed(clientRequest, true);
-
-            retainRequestContent(clientRequest);
-            Thread.ofVirtual().start(() -> {
-                try {
-                    LazyPacket writeAfterPacket = new LazyWriteAfterPacket(
-                            myNodeId.toString(), clientRequest);
-                    Set<NodeIDType> myPeers = new HashSet<>(currInstance.nodes());
-                    myPeers.remove(myNodeId);
-                    GenericMessagingTask<NodeIDType, LazyPacket> m =
-                            new GenericMessagingTask<>(myPeers.toArray(), writeAfterPacket);
-                    if (logger.isLoggable(Level.FINE)) {
-                        logger.log(Level.FINE, "Sending WRITE_AFTER packet ...");
-                    }
-                    messenger.send(m);
-                } catch (Exception e) {
-                    logger.log(Level.WARNING, "Failed to send WRITE_AFTER", e);
-                } finally {
-                    releaseRequestContent(clientRequest);
-                }
-            });
-            return true;
+            return handleClientWrite(state, clientRequest, callback);
         }
 
-        // handle peer-initiated packet (i.e., write-after)
-        if (currRequestOrPacket instanceof LazyPacket lp &&
-                lp instanceof LazyWriteAfterPacket writeAfterPacket) {
-            Request clientRequest = writeAfterPacket.getClientWriteOnlyRequest();
-            boolean isWriteOnly = (clientRequest instanceof BehavioralRequest br) &&
-                    br.isWriteOnlyRequest();
-            boolean isMonotonic = (clientRequest instanceof BehavioralRequest br) &&
-                    br.isMonotonicRequest();
-            if (!isWriteOnly || !isMonotonic) {
-                throw new RuntimeException(
-                        "Expecting (Monotonic and WriteOnly) request for LazyReplicaCoordinator");
-            }
-
-            // LazyWriteAfterPacket#toBytes strips the sender's response from
-            // the wire, so app.execute() sees a response-less request.
-            return this.app.execute(clientRequest, true);
+        // handle peer-initiated packets
+        if (currRequestOrPacket instanceof LazyWriteAfterPacket writeAfterPacket) {
+            return handleWriteAfterPacket(state, writeAfterPacket);
+        }
+        if (currRequestOrPacket instanceof LazySyncPacket syncPacket) {
+            return handleSyncPacket(state, syncPacket);
+        }
+        if (currRequestOrPacket instanceof LazyCheckpointPacket checkpointPacket) {
+            return handleCheckpointPacket(state, checkpointPacket);
         }
 
         throw new IllegalStateException("Unexpected LazyPacket/Request: " + request.getRequestType());
+    }
+
+    private boolean handleClientWrite(LazyServiceState<NodeIDType> state,
+                                      ClientRequest clientRequest,
+                                      ExecutedCallback callback) {
+        boolean isExecSuccess;
+        long seqNum = -1;
+        byte[] encodedRequest = null;
+        ReentrantReadWriteLock.WriteLock writeLock = state.lock.writeLock();
+        writeLock.lock();
+        try {
+            isExecSuccess = this.app.execute(clientRequest);
+            if (isExecSuccess) {
+                // Encode synchronously, while the request content buffers are guaranteed
+                // alive, so the write can be retained for later re-application and shipped
+                // to peers without reference-count juggling.
+                encodedRequest = clientRequest.toBytes();
+                seqNum = state.vc.getNodeTimestamp(myNodeIdStr) + 1;
+                state.vc.updateNodeTimestamp(myNodeIdStr, seqNum);
+                state.ownLog.add(encodedRequest);
+                state.digestCache = null;
+            }
+        } finally {
+            writeLock.unlock();
+        }
+
+        if (!isExecSuccess) {
+            if (logger.isLoggable(Level.WARNING)) {
+                logger.log(Level.WARNING, "Failed to execute request: " + clientRequest);
+            }
+            callback.executed(clientRequest, false);
+            return true;
+        }
+        callback.executed(clientRequest, true);
+
+        // Best-effort fast path: broadcast the write to peers on a virtual thread.
+        final long finalSeqNum = seqNum;
+        final byte[] finalEncodedRequest = encodedRequest;
+        Thread.ofVirtual().start(() -> {
+            try {
+                LazyPacket writeAfterPacket = new LazyWriteAfterPacket(
+                        myNodeIdStr, finalSeqNum, state.epoch, clientRequest, finalEncodedRequest);
+                Set<NodeIDType> myPeers = new HashSet<>(state.nodes);
+                myPeers.remove(myNodeId);
+                if (myPeers.isEmpty()) return;
+                GenericMessagingTask<NodeIDType, LazyPacket> m =
+                        new GenericMessagingTask<>(myPeers.toArray(), writeAfterPacket);
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, "Sending WRITE_AFTER packet ...");
+                }
+                messenger.send(m);
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Failed to send WRITE_AFTER", e);
+            }
+        });
+        return true;
+    }
+
+    private boolean handleWriteAfterPacket(LazyServiceState<NodeIDType> state,
+                                           LazyWriteAfterPacket packet) {
+        if (packet.getEpoch() != state.epoch) {
+            logger.log(Level.FINE, "Dropping WRITE_AFTER with mismatched epoch");
+            return true;
+        }
+        String sender = packet.getSenderId();
+        // Never block the shared NIO demultiplexer thread behind a long checkpoint
+        // install: the fast path is best-effort, so drop on lock contention and let
+        // anti-entropy recover the write.
+        ReentrantReadWriteLock.WriteLock writeLock = state.lock.writeLock();
+        if (!writeLock.tryLock()) {
+            logger.log(Level.FINE, "Dropping WRITE_AFTER due to lock contention");
+            return true;
+        }
+        try {
+            long expectedSeq = state.vc.getNodeTimestamp(sender) + 1;
+            if (packet.getSenderSeqNum() != expectedSeq) {
+                // Duplicate or gapped fast-path write: drop it; the periodic anti-entropy
+                // checkpoint transfer delivers the sender's writes in bulk instead.
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE, String.format(
+                            "%s: dropping WRITE_AFTER from %s seq=%d expected=%d",
+                            myNodeIdStr, sender, packet.getSenderSeqNum(), expectedSeq));
+                }
+                return true;
+            }
+            boolean isExecSuccess = this.app.execute(packet.getClientRequest(), true);
+            if (isExecSuccess) {
+                state.vc.updateNodeTimestamp(sender, expectedSeq);
+                state.digestCache = null;
+            }
+            return true;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /** One periodic anti-entropy tick: advertise (vector clock, state digest) to all peers. */
+    private void runAntiEntropyRound() {
+        for (LazyServiceState<NodeIDType> state : this.currentInstances.values()) {
+            try {
+                VectorTimestamp vcSnapshot;
+                byte[] digest;
+                ReentrantReadWriteLock.ReadLock readLock = state.lock.readLock();
+                // Skip this service for a round if an install holds the write lock.
+                if (!readLock.tryLock(antiEntropyIntervalMs / 2, TimeUnit.MILLISECONDS)) {
+                    continue;
+                }
+                try {
+                    vcSnapshot = VectorClockCodec.copy(state.vc);
+                    digest = getOrComputeDigest(state);
+                } finally {
+                    readLock.unlock();
+                }
+
+                Set<NodeIDType> myPeers = new HashSet<>(state.nodes);
+                myPeers.remove(myNodeId);
+                if (myPeers.isEmpty()) continue;
+
+                LazySyncPacket syncPacket = new LazySyncPacket(
+                        myNodeIdStr, state.serviceName, vcSnapshot, digest, state.epoch);
+                GenericMessagingTask<NodeIDType, LazyPacket> m =
+                        new GenericMessagingTask<>(myPeers.toArray(), syncPacket);
+                messenger.send(m);
+            } catch (Exception e) {
+                logger.log(Level.WARNING, "Anti-entropy round failed for service="
+                        + state.serviceName, e);
+            }
+        }
+    }
+
+    // Must be called while holding state.lock (read or write).
+    private byte[] getOrComputeDigest(LazyServiceState<NodeIDType> state) {
+        if (state.digestCache != null) return state.digestCache;
+        byte[] digest = this.checkpointableApp != null
+                ? this.checkpointableApp.getStateDigest(state.serviceName)
+                : fallbackDigest(state.serviceName);
+        state.digestCache = digest;
+        return digest;
+    }
+
+    // Digest fallback for plain Replicable apps without CheckpointableApplication.
+    private byte[] fallbackDigest(String serviceName) {
+        String checkpoint = this.app.checkpoint(serviceName);
+        if (checkpoint == null) return null;
+        try {
+            return MessageDigest.getInstance("SHA-256")
+                    .digest(checkpoint.getBytes(StandardCharsets.ISO_8859_1));
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+
+    private boolean handleSyncPacket(LazyServiceState<NodeIDType> state, LazySyncPacket packet) {
+        if (packet.getEpoch() != state.epoch) {
+            logger.log(Level.FINE, "Dropping SYNC with mismatched epoch");
+            return true;
+        }
+        String sender = packet.getSenderId();
+        VectorTimestamp theirVc = packet.getVectorClock();
+        if (!theirVc.isComparableWith(state.vc)) {
+            logger.log(Level.WARNING, "Dropping SYNC with incomparable vector clock from "
+                    + sender);
+            return true;
+        }
+
+        boolean shouldShip;
+        VectorTimestamp myVcSnapshot;
+        byte[] myDigest;
+        // Runs on the shared NIO demultiplexer thread: skip this round on lock
+        // contention (e.g., an install in progress) instead of blocking the pipeline.
+        ReentrantReadWriteLock.ReadLock readLock = state.lock.readLock();
+        if (!readLock.tryLock()) {
+            logger.log(Level.FINE, "Skipping SYNC handling due to lock contention");
+            return true;
+        }
+        try {
+            synchronized (state.latestReport) {
+                state.latestReport.put(sender, new LazyServiceState.PeerReport(
+                        theirVc, packet.getStateDigest(), System.currentTimeMillis()));
+                VectorTimestamp floor = state.peerVcFloor.get(sender);
+                if (floor == null) {
+                    state.peerVcFloor.put(sender, VectorClockCodec.copy(theirVc));
+                } else {
+                    VectorClockCodec.maxMergeInto(floor, theirVc);
+                }
+            }
+            myVcSnapshot = VectorClockCodec.copy(state.vc);
+            myDigest = getOrComputeDigest(state);
+            shouldShip = evaluateShipDecision(state, sender, theirVc, packet.getStateDigest(),
+                    myVcSnapshot, myDigest);
+        } finally {
+            readLock.unlock();
+        }
+
+        pruneOwnLog(state);
+
+        if (shouldShip) {
+            shipCheckpointAsync(state, sender);
+        }
+        return true;
+    }
+
+    // Must be called while holding state.lock (read or write).
+    private boolean evaluateShipDecision(LazyServiceState<NodeIDType> state, String peer,
+                                         VectorTimestamp theirVc, byte[] theirDigest,
+                                         VectorTimestamp myVc, byte[] myDigest) {
+        long mySum = VectorClockCodec.sum(myVc);
+        long theirSum = VectorClockCodec.sum(theirVc);
+        boolean frontierWins = VectorClockCodec.frontierWins(mySum, myNodeIdStr, theirSum, peer);
+        if (!frontierWins) return false;
+
+        boolean peerLags = false;
+        for (String nodeId : myVc.getNodeIds()) {
+            if (theirVc.getNodeTimestamp(nodeId) < myVc.getNodeTimestamp(nodeId)) {
+                peerLags = true;
+                break;
+            }
+        }
+        // At equal clocks, replicas of a non-deterministic service may still hold different
+        // bytes (fast-path re-execution diverges); the digest comparison forces one final
+        // verbatim state transfer from the tie-break frontier.
+        boolean tieDiverged = theirVc.isEqualTo(myVc)
+                && theirDigest != null && myDigest != null
+                && !Arrays.equals(theirDigest, myDigest);
+        if (!peerLags && !tieDiverged) return false;
+
+        // Dedup/backoff: skip if we already shipped this exact (clock, digest) to this peer
+        // recently; a re-ship is allowed after 3 intervals in case the checkpoint was lost.
+        synchronized (state.lastShip) {
+            LazyServiceState.ShipRecord last = state.lastShip.get(peer);
+            if (last != null && last.vc().isEqualTo(myVc)
+                    && Arrays.equals(last.digest(), myDigest)
+                    && System.currentTimeMillis() - last.timeMs() < 3 * antiEntropyIntervalMs) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void shipCheckpointAsync(LazyServiceState<NodeIDType> state, String peer) {
+        if (!state.shipInFlight.compareAndSet(false, true)) return;
+        Thread.ofVirtual().start(() -> {
+            try {
+                VectorTimestamp vcAtCapture;
+                byte[] checkpointBytes = null;
+                String checkpointHandle = null;
+                byte[] digest;
+                ReentrantReadWriteLock.ReadLock readLock = state.lock.readLock();
+                readLock.lock();
+                try {
+                    vcAtCapture = VectorClockCodec.copy(state.vc);
+                    digest = getOrComputeDigest(state);
+                    if (this.checkpointableApp != null) {
+                        checkpointBytes = this.checkpointableApp
+                                .captureCheckpoint(state.serviceName);
+                        if (checkpointBytes != null
+                                && checkpointBytes.length > checkpointInlineMaxBytes) {
+                            checkpointBytes = null;
+                            checkpointHandle = this.checkpointableApp
+                                    .captureCheckpointHandle(state.serviceName);
+                        }
+                    } else {
+                        String checkpoint = this.app.checkpoint(state.serviceName);
+                        checkpointBytes = checkpoint != null
+                                ? checkpoint.getBytes(StandardCharsets.ISO_8859_1) : null;
+                    }
+                } finally {
+                    readLock.unlock();
+                }
+
+                if (checkpointBytes == null && checkpointHandle == null) {
+                    logger.log(Level.SEVERE, String.format(
+                            "%s: failed to capture checkpoint of service=%s for peer=%s",
+                            myNodeIdStr, state.serviceName, peer));
+                    return;
+                }
+
+                LazyCheckpointPacket packet = checkpointBytes != null
+                        ? LazyCheckpointPacket.createInline(myNodeIdStr, state.serviceName,
+                        vcAtCapture, digest, state.epoch, checkpointBytes)
+                        : LazyCheckpointPacket.createWithHandle(myNodeIdStr, state.serviceName,
+                        vcAtCapture, digest, state.epoch, checkpointHandle);
+
+                NodeIDType peerNodeId = nodeIdDeserializer.valueOf(peer);
+                GenericMessagingTask<NodeIDType, LazyPacket> m =
+                        new GenericMessagingTask<>(peerNodeId, packet);
+                messenger.send(m);
+                synchronized (state.lastShip) {
+                    state.lastShip.put(peer, new LazyServiceState.ShipRecord(
+                            vcAtCapture, digest, System.currentTimeMillis()));
+                }
+                logger.log(Level.INFO, String.format(
+                        "%s: shipped checkpoint of service=%s to lagging peer=%s vc=%s bytes=%d",
+                        myNodeIdStr, state.serviceName, peer, vcAtCapture,
+                        checkpointBytes != null ? checkpointBytes.length : -1));
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Failed to ship checkpoint of service="
+                        + state.serviceName + " to peer=" + peer, e);
+            } finally {
+                state.shipInFlight.set(false);
+            }
+        });
+    }
+
+    private boolean handleCheckpointPacket(LazyServiceState<NodeIDType> state,
+                                           LazyCheckpointPacket packet) {
+        if (packet.getEpoch() != state.epoch) {
+            logger.log(Level.FINE, "Dropping CHECKPOINT with mismatched epoch");
+            return true;
+        }
+        if (!packet.getVectorClock().isComparableWith(state.vc)) {
+            logger.log(Level.WARNING, "Dropping CHECKPOINT with incomparable vector clock from "
+                    + packet.getSenderId());
+            return true;
+        }
+        // Installs stop the container and restart it, taking seconds: run them on the
+        // per-service serial executor, off the NIO demultiplexer thread.
+        state.installExecutor.execute(() -> installCheckpoint(state, packet));
+        return true;
+    }
+
+    private void installCheckpoint(LazyServiceState<NodeIDType> state,
+                                   LazyCheckpointPacket packet) {
+        String sender = packet.getSenderId();
+        VectorTimestamp vcK = packet.getVectorClock();
+        ReentrantReadWriteLock.WriteLock writeLock = state.lock.writeLock();
+        writeLock.lock();
+        try {
+            // Strict install rule, re-checked against the current clock:
+            // (a) never regress a foreign component (would silently lose foreign writes
+            //     this state already reflects, and would break pruning monotonicity);
+            // (b) the checkpoint must cover our pruned prefix, so the own-write suffix
+            //     can bridge the gap;
+            // (c) install only a strictly newer checkpoint, or an equal-clock one from a
+            //     tie-break winner (byte reconciliation for non-deterministic services).
+            for (String nodeId : state.vc.getNodeIds()) {
+                if (nodeId.equals(myNodeIdStr)) continue;
+                if (vcK.getNodeTimestamp(nodeId) < state.vc.getNodeTimestamp(nodeId)) {
+                    logger.log(Level.FINE, myNodeIdStr
+                            + ": dropping checkpoint that regresses component " + nodeId);
+                    return;
+                }
+            }
+            if (vcK.getNodeTimestamp(myNodeIdStr) < state.firstSeq - 1) {
+                logger.log(Level.WARNING, myNodeIdStr
+                        + ": dropping checkpoint older than the pruned own-write log");
+                return;
+            }
+            boolean strictlyNewer = false;
+            for (String nodeId : state.vc.getNodeIds()) {
+                if (vcK.getNodeTimestamp(nodeId) > state.vc.getNodeTimestamp(nodeId)) {
+                    strictlyNewer = true;
+                    break;
+                }
+            }
+            boolean tieInstall = vcK.isEqualTo(state.vc)
+                    && VectorClockCodec.frontierWins(
+                    VectorClockCodec.sum(vcK), sender,
+                    VectorClockCodec.sum(state.vc), myNodeIdStr);
+            if (!strictlyNewer && !tieInstall) {
+                logger.log(Level.FINE, myNodeIdStr + ": dropping dominated/duplicate checkpoint");
+                return;
+            }
+
+            // Install the checkpoint state.
+            boolean isApplied;
+            if (this.checkpointableApp != null) {
+                isApplied = packet.getMode() == LazyCheckpointPacket.MODE_INLINE
+                        ? this.checkpointableApp.applyCheckpoint(
+                        state.serviceName, packet.getCheckpointData())
+                        : this.checkpointableApp.applyCheckpointHandle(
+                        state.serviceName, packet.getCheckpointHandle());
+            } else {
+                isApplied = packet.getMode() == LazyCheckpointPacket.MODE_INLINE
+                        && this.app.restore(state.serviceName, new String(
+                        packet.getCheckpointData(), StandardCharsets.ISO_8859_1));
+            }
+            if (!isApplied) {
+                // Leave the clock untouched: it now underclaims at worst, which is the safe
+                // direction; a later anti-entropy round re-ships and re-installs.
+                logger.log(Level.SEVERE, String.format(
+                        "%s: failed to install checkpoint of service=%s from %s",
+                        myNodeIdStr, state.serviceName, sender));
+                return;
+            }
+
+            // Advance the clock to the checkpoint, keeping our own component monotone.
+            long ownCovered = vcK.getNodeTimestamp(myNodeIdStr);
+            long myOwnCount = state.vc.getNodeTimestamp(myNodeIdStr);
+            for (String nodeId : state.vc.getNodeIds()) {
+                if (nodeId.equals(myNodeIdStr)) continue;
+                state.vc.updateNodeTimestamp(nodeId, vcK.getNodeTimestamp(nodeId));
+            }
+            state.vc.updateNodeTimestamp(myNodeIdStr, Math.max(myOwnCount, ownCovered));
+
+            // Re-apply our own writes the checkpoint lacks, in sequence order.
+            int reapplied = 0;
+            for (long seq = ownCovered + 1; seq <= state.vc.getNodeTimestamp(myNodeIdStr); seq++) {
+                int index = (int) (seq - state.firstSeq);
+                if (index < 0 || index >= state.ownLog.size()) break;
+                byte[] encodedRequest = state.ownLog.get(index);
+                try {
+                    Request ownWrite = this.app.getRequest(
+                            new String(encodedRequest, StandardCharsets.ISO_8859_1));
+                    boolean ok = this.app.execute(ownWrite, true);
+                    if (!ok) {
+                        logger.log(Level.SEVERE, myNodeIdStr
+                                + ": failed to re-apply own write seq=" + seq);
+                    }
+                    reapplied++;
+                } catch (RequestParseException e) {
+                    logger.log(Level.SEVERE, myNodeIdStr
+                            + ": failed to decode own write seq=" + seq, e);
+                }
+            }
+            state.digestCache = null;
+
+            logger.log(Level.INFO, String.format(
+                    "%s: installed checkpoint of service=%s from %s vc=%s reappliedOwnWrites=%d",
+                    myNodeIdStr, state.serviceName, sender, vcK, reapplied));
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /** Drops own writes that every peer's clock is known to cover (classic vector-clock GC). */
+    private void pruneOwnLog(LazyServiceState<NodeIDType> state) {
+        ReentrantReadWriteLock.WriteLock writeLock = state.lock.writeLock();
+        if (!writeLock.tryLock()) return; // opportunistic; retried on the next sync
+        try {
+            long minCovered = Long.MAX_VALUE;
+            synchronized (state.latestReport) {
+                for (NodeIDType node : state.nodes) {
+                    String nodeId = node.toString();
+                    if (nodeId.equals(myNodeIdStr)) continue;
+                    VectorTimestamp floor = state.peerVcFloor.get(nodeId);
+                    long covered = floor != null ? floor.getNodeTimestamp(myNodeIdStr) : 0;
+                    minCovered = Math.min(minCovered, covered);
+                }
+            }
+            if (minCovered == Long.MAX_VALUE) return; // no peers
+            while (!state.ownLog.isEmpty() && state.firstSeq <= minCovered) {
+                state.ownLog.remove(0);
+                state.firstSeq++;
+            }
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     @Override
@@ -211,9 +661,14 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
                             "createReplicaGroup name=%s nodes=%s epoch=%d state=%s",
                     myNodeId, serviceName, nodes, epoch, state));
         }
-        LazyReplicaInstance<NodeIDType> replicaInstance =
-                new LazyReplicaInstance<>(serviceName, epoch, state, nodes);
-        this.currentInstances.put(serviceName, replicaInstance);
+        LazyServiceState<NodeIDType> serviceState =
+                new LazyServiceState<>(serviceName, epoch, nodes);
+        serviceState.firstSeq = 1;
+        LazyServiceState<NodeIDType> previous =
+                this.currentInstances.put(serviceName, serviceState);
+        if (previous != null) {
+            previous.shutdown();
+        }
 
         // Creating a replica group is a special case for reconfiguration where we reconfigure
         // from nothing to something. In that case, we call app.restore(.) with initialState.
@@ -222,10 +677,11 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
 
     @Override
     public boolean deleteReplicaGroup(String serviceName, int epoch) {
-        if (!this.currentInstances.containsKey(serviceName)) return true;
-        LazyReplicaInstance<NodeIDType> replicaInstance = this.currentInstances.get(serviceName);
-        if (replicaInstance.currEpoch != epoch) return true;
+        LazyServiceState<NodeIDType> state = this.currentInstances.get(serviceName);
+        if (state == null) return true;
+        if (state.epoch != epoch) return true;
         this.currentInstances.remove(serviceName);
+        state.shutdown();
 
         // Deleting a replica group is a special case for reconfiguration where we reconfigure
         // from something into nothing. In that case, we call app.restore(.) with null state.
@@ -234,45 +690,7 @@ public class LazyReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinat
 
     @Override
     public Set<NodeIDType> getReplicaGroup(String serviceName) {
-        LazyReplicaInstance<NodeIDType> replicaInstance = this.currentInstances.get(serviceName);
-        return replicaInstance != null ? replicaInstance.nodes() : null;
-    }
-
-    private void retainRequestContent(ClientRequest request) {
-        if (request instanceof XdnHttpRequestBatch batch) {
-            for (XdnHttpRequest xhr : batch.getRequestList()) {
-                retainSingleRequestContent(xhr);
-            }
-        } else if (request instanceof XdnHttpRequest xhr) {
-            retainSingleRequestContent(xhr);
-        }
-    }
-
-    private void retainSingleRequestContent(XdnHttpRequest xhr) {
-        if (xhr.getHttpRequestContent() != null) {
-            ByteBuf content = xhr.getHttpRequestContent().content();
-            if (content != null && content.refCnt() > 0) {
-                ReferenceCountUtil.retain(content);
-            }
-        }
-    }
-
-    private void releaseRequestContent(ClientRequest request) {
-        if (request instanceof XdnHttpRequestBatch batch) {
-            for (XdnHttpRequest xhr : batch.getRequestList()) {
-                releaseSingleRequestContent(xhr);
-            }
-        } else if (request instanceof XdnHttpRequest xhr) {
-            releaseSingleRequestContent(xhr);
-        }
-    }
-
-    private void releaseSingleRequestContent(XdnHttpRequest xhr) {
-        if (xhr.getHttpRequestContent() != null) {
-            ByteBuf content = xhr.getHttpRequestContent().content();
-            if (content != null && content.refCnt() > 0) {
-                ReferenceCountUtil.release(content);
-            }
-        }
+        LazyServiceState<NodeIDType> state = this.currentInstances.get(serviceName);
+        return state != null ? state.nodes : null;
     }
 }

--- a/src/edu/umass/cs/eventual/LazyServiceState.java
+++ b/src/edu/umass/cs/eventual/LazyServiceState.java
@@ -1,0 +1,89 @@
+package edu.umass.cs.eventual;
+
+import edu.umass.cs.clientcentric.VectorTimestamp;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Mutable per-service protocol state for {@link LazyReplicaCoordinator}'s frontier-based
+ * anti-entropy. All fields except the executors are guarded by {@link #lock}: read lock for
+ * client reads, digest computation, and checkpoint capture (none of which mutate state); write
+ * lock for client writes, write-after application, and checkpoint installation.
+ *
+ * <p>Vector clock invariant: {@code vc[self]} counts this replica's own client writes, each
+ * retained in {@link #ownLog} until globally covered; {@code vc[j]} for a peer j counts
+ * j-sourced writes reflected in local state, advanced contiguously by the write-after fast path
+ * or in bulk by a checkpoint install.
+ */
+class LazyServiceState<NodeIDType> {
+
+    final String serviceName;
+    final int epoch;
+    final Set<NodeIDType> nodes;
+
+    final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    /** This replica's applied-write vector clock, keyed by nodeId string. */
+    final VectorTimestamp vc;
+
+    /**
+     * This replica's own executed writes, encoded with {@code ClientRequest.toBytes()}; index i
+     * holds the write with sequence number {@code firstSeq + i}. Pruned once globally covered.
+     */
+    final List<byte[]> ownLog = new ArrayList<>();
+
+    /** Sequence number of {@code ownLog.get(0)}; when the log is empty, {@code vc[self] + 1}. */
+    long firstSeq = 1;
+
+    /** Component-wise max of every vector clock ever heard from each peer (pruning floor). */
+    final Map<String, VectorTimestamp> peerVcFloor = new HashMap<>();
+
+    /** The most recent sync report (clock and state digest) received from each peer. */
+    final Map<String, PeerReport> latestReport = new HashMap<>();
+
+    /** The last checkpoint shipped to each peer, for dedup/backoff. */
+    final Map<String, ShipRecord> lastShip = new HashMap<>();
+
+    /** Cached state digest, invalidated on every state mutation; null = must recompute. */
+    volatile byte[] digestCache = null;
+
+    /** Guards against concurrent checkpoint captures for this service. */
+    final AtomicBoolean shipInFlight = new AtomicBoolean(false);
+
+    /** Serializes checkpoint installs off the NIO demultiplexer thread. */
+    final ExecutorService installExecutor;
+
+    record PeerReport(VectorTimestamp vc, byte[] digest, long timeMs) {
+    }
+
+    record ShipRecord(VectorTimestamp vc, byte[] digest, long timeMs) {
+    }
+
+    LazyServiceState(String serviceName, int epoch, Set<NodeIDType> nodes) {
+        this.serviceName = serviceName;
+        this.epoch = epoch;
+        this.nodes = nodes;
+        List<String> nodeIds = new ArrayList<>();
+        for (NodeIDType node : nodes) {
+            nodeIds.add(node.toString());
+        }
+        this.vc = new VectorTimestamp(nodeIds);
+        this.installExecutor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "lazy-install-" + serviceName);
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    void shutdown() {
+        this.installExecutor.shutdownNow();
+    }
+}

--- a/src/edu/umass/cs/eventual/VectorClockCodec.java
+++ b/src/edu/umass/cs/eventual/VectorClockCodec.java
@@ -1,0 +1,111 @@
+package edu.umass.cs.eventual;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import edu.umass.cs.clientcentric.VectorTimestamp;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Wire codec and small helpers for {@link VectorTimestamp}, used by the anti-entropy packets in
+ * {@link edu.umass.cs.eventual.packets}. The wire format matches the length-delimited
+ * (nodeId, counter) pair encoding used elsewhere in this codebase (see
+ * ClientCentricWriteAfterPacket), kept local so the clientcentric package stays untouched.
+ */
+public final class VectorClockCodec {
+
+    private VectorClockCodec() {
+    }
+
+    public static int computeSize(VectorTimestamp timestamp) {
+        List<String> nodeIds = new ArrayList<>(timestamp.getNodeIds());
+        Collections.sort(nodeIds);
+        int size = 0;
+        for (String nodeId : nodeIds) {
+            size += CodedOutputStream.computeStringSize(1, nodeId);
+            size += CodedOutputStream.computeInt64Size(2, timestamp.getNodeTimestamp(nodeId));
+        }
+        return size;
+    }
+
+    public static byte[] encode(VectorTimestamp timestamp) {
+        byte[] encoded = new byte[computeSize(timestamp)];
+        CodedOutputStream output = CodedOutputStream.newInstance(encoded);
+        try {
+            List<String> nodeIds = new ArrayList<>(timestamp.getNodeIds());
+            Collections.sort(nodeIds);
+            for (String nodeId : nodeIds) {
+                output.writeString(1, nodeId);
+                output.writeInt64(2, timestamp.getNodeTimestamp(nodeId));
+            }
+            output.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to encode VectorTimestamp", e);
+        }
+        return encoded;
+    }
+
+    public static VectorTimestamp decode(byte[] encodedTimestamp) throws IOException {
+        CodedInputStream input = CodedInputStream.newInstance(encodedTimestamp);
+        List<String> nodeIds = new ArrayList<>();
+        List<Long> counters = new ArrayList<>();
+        int tag;
+        while ((tag = input.readTag()) != 0) {
+            switch (tag) {
+                case 10 -> nodeIds.add(input.readStringRequireUtf8());
+                case 16 -> counters.add(input.readInt64());
+                default -> input.skipField(tag);
+            }
+        }
+        if (nodeIds.size() != counters.size()) {
+            throw new IOException("Mismatched vector timestamp components");
+        }
+        VectorTimestamp timestamp = new VectorTimestamp(nodeIds);
+        for (int i = 0; i < nodeIds.size(); i++) {
+            timestamp.updateNodeTimestamp(nodeIds.get(i), counters.get(i));
+        }
+        return timestamp;
+    }
+
+    /** Returns a deep copy of the given vector timestamp. */
+    public static VectorTimestamp copy(VectorTimestamp timestamp) {
+        List<String> nodeIds = new ArrayList<>(timestamp.getNodeIds());
+        VectorTimestamp copied = new VectorTimestamp(nodeIds);
+        for (String nodeId : nodeIds) {
+            copied.updateNodeTimestamp(nodeId, timestamp.getNodeTimestamp(nodeId));
+        }
+        return copied;
+    }
+
+    /** Sum of all components, i.e., the size of the applied-write set the clock encodes. */
+    public static long sum(VectorTimestamp timestamp) {
+        long total = 0;
+        for (String nodeId : timestamp.getNodeIds()) {
+            total += timestamp.getNodeTimestamp(nodeId);
+        }
+        return total;
+    }
+
+    /**
+     * The frontier total order: a replica with a larger applied-write set wins; ties are broken
+     * by node ID. Returns true iff (sumA, idA) beats (sumB, idB).
+     */
+    public static boolean frontierWins(long sumA, String idA, long sumB, String idB) {
+        if (sumA != sumB) return sumA > sumB;
+        return idA.compareTo(idB) > 0;
+    }
+
+    /** Component-wise max-merge of {@code from} into {@code into} (mutates {@code into}). */
+    public static void maxMergeInto(VectorTimestamp into, VectorTimestamp from) {
+        for (String nodeId : into.getNodeIds()) {
+            if (!from.getNodeIds().contains(nodeId)) continue;
+            long theirs = from.getNodeTimestamp(nodeId);
+            if (theirs > into.getNodeTimestamp(nodeId)) {
+                into.updateNodeTimestamp(nodeId, theirs);
+            }
+        }
+    }
+}

--- a/src/edu/umass/cs/eventual/interfaces/CheckpointableApplication.java
+++ b/src/edu/umass/cs/eventual/interfaces/CheckpointableApplication.java
@@ -1,0 +1,52 @@
+package edu.umass.cs.eventual.interfaces;
+
+/**
+ * CheckpointableApplication is implemented by applications whose whole service state can be
+ * captured and restored as an opaque blob, enabling checkpoint-based anti-entropy in
+ * {@link edu.umass.cs.eventual.LazyReplicaCoordinator}. The coordinator guarantees that no
+ * request is being executed for the service while {@link #captureCheckpoint(String)} or
+ * {@link #applyCheckpoint(String, byte[])} runs, so implementations only need to provide a
+ * point-in-time snapshot of durable state (e.g., an archive of the service's state directory).
+ *
+ * <p>This is a sibling of {@code edu.umass.cs.primarybackup.interfaces.BackupableApplication},
+ * which captures incremental statediffs; this interface captures the complete state.
+ */
+public interface CheckpointableApplication {
+
+  /**
+   * Captures the complete durable state of the given service as an opaque blob.
+   *
+   * @return the encoded checkpoint, or null on failure.
+   */
+  byte[] captureCheckpoint(String serviceName);
+
+  /**
+   * Replaces the service's durable state with the given checkpoint. Implementations must only
+   * return after the service is ready to execute requests again (e.g., after a container
+   * restart), otherwise subsequent request executions can be silently lost.
+   *
+   * @return true on success; false leaves the caller free to retry later.
+   */
+  boolean applyCheckpoint(String serviceName, byte[] checkpoint);
+
+  /**
+   * Returns a stable digest (e.g., sha256) of the service's current durable state, used to
+   * detect divergence between replicas whose applied-write sets are equal. May return null if
+   * the digest cannot be computed, which disables digest-based reconciliation.
+   */
+  byte[] getStateDigest(String serviceName);
+
+  /**
+   * Captures a checkpoint too large to ship inline and returns an out-of-band handle (e.g., a
+   * {@code edu.umass.cs.gigapaxos.paxosutil.LargeCheckpointer} handle) that a peer can redeem
+   * with {@link #applyCheckpointHandle(String, String)}. Returns null if unsupported.
+   */
+  default String captureCheckpointHandle(String serviceName) {
+    return null;
+  }
+
+  /** Redeems a handle produced by {@link #captureCheckpointHandle(String)}. */
+  default boolean applyCheckpointHandle(String serviceName, String handle) {
+    return false;
+  }
+}

--- a/src/edu/umass/cs/eventual/packets/LazyCheckpointPacket.java
+++ b/src/edu/umass/cs/eventual/packets/LazyCheckpointPacket.java
@@ -1,0 +1,241 @@
+package edu.umass.cs.eventual.packets;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import edu.umass.cs.clientcentric.VectorTimestamp;
+import edu.umass.cs.eventual.VectorClockCodec;
+import edu.umass.cs.nio.interfaces.Byteable;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * LazyCheckpointPacket ships a frontier replica's complete service state to a lagging peer,
+ * stamped with the vector clock at capture time. Small checkpoints travel inline
+ * ({@link #MODE_INLINE}); large ones travel as an out-of-band handle ({@link #MODE_HANDLE},
+ * e.g., a LargeCheckpointer handle redeemed by the receiver).
+ */
+public class LazyCheckpointPacket extends LazyPacket implements Byteable {
+
+    public static final int MODE_INLINE = 1;
+    public static final int MODE_HANDLE = 2;
+
+    private final long packetId;
+    private final String senderId;
+    private final String serviceName;
+    private final VectorTimestamp vectorClock;
+    private final byte[] stateDigest; // nullable
+    private final int epoch;
+    private final int mode;
+    private final byte[] checkpointData;   // non-null iff mode == MODE_INLINE
+    private final String checkpointHandle; // non-null iff mode == MODE_HANDLE
+
+    public static LazyCheckpointPacket createInline(String senderId, String serviceName,
+                                                    VectorTimestamp vectorClock,
+                                                    byte[] stateDigest, int epoch,
+                                                    byte[] checkpointData) {
+        return new LazyCheckpointPacket(UUID.randomUUID().getLeastSignificantBits(), senderId,
+                serviceName, vectorClock, stateDigest, epoch, MODE_INLINE, checkpointData, null);
+    }
+
+    public static LazyCheckpointPacket createWithHandle(String senderId, String serviceName,
+                                                        VectorTimestamp vectorClock,
+                                                        byte[] stateDigest, int epoch,
+                                                        String checkpointHandle) {
+        return new LazyCheckpointPacket(UUID.randomUUID().getLeastSignificantBits(), senderId,
+                serviceName, vectorClock, stateDigest, epoch, MODE_HANDLE, null, checkpointHandle);
+    }
+
+    private LazyCheckpointPacket(long packetId, String senderId, String serviceName,
+                                 VectorTimestamp vectorClock, byte[] stateDigest, int epoch,
+                                 int mode, byte[] checkpointData, String checkpointHandle) {
+        assert senderId != null : "The sender cannot be null";
+        assert serviceName != null : "The service name cannot be null";
+        assert vectorClock != null : "The vector clock cannot be null";
+        assert (mode == MODE_INLINE && checkpointData != null)
+                || (mode == MODE_HANDLE && checkpointHandle != null)
+                : "Checkpoint payload must match the declared mode";
+        this.packetId = packetId;
+        this.senderId = senderId;
+        this.serviceName = serviceName;
+        this.vectorClock = vectorClock;
+        this.stateDigest = stateDigest;
+        this.epoch = epoch;
+        this.mode = mode;
+        this.checkpointData = checkpointData;
+        this.checkpointHandle = checkpointHandle;
+    }
+
+    @Override
+    public IntegerPacketType getRequestType() {
+        return LazyPacketType.LAZY_CHECKPOINT;
+    }
+
+    @Override
+    public String getServiceName() {
+        return this.serviceName;
+    }
+
+    @Override
+    public long getRequestID() {
+        return this.packetId;
+    }
+
+    @Override
+    public boolean needsCoordination() {
+        return true;
+    }
+
+    public String getSenderId() {
+        return senderId;
+    }
+
+    public VectorTimestamp getVectorClock() {
+        return vectorClock;
+    }
+
+    public byte[] getStateDigest() {
+        return stateDigest;
+    }
+
+    public int getEpoch() {
+        return epoch;
+    }
+
+    public int getMode() {
+        return mode;
+    }
+
+    public byte[] getCheckpointData() {
+        return checkpointData;
+    }
+
+    public String getCheckpointHandle() {
+        return checkpointHandle;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        byte[] encodedVc = VectorClockCodec.encode(this.vectorClock);
+
+        int payloadSize = CodedOutputStream.computeInt64Size(1, this.packetId)
+                + CodedOutputStream.computeStringSize(2, this.senderId)
+                + CodedOutputStream.computeStringSize(3, this.serviceName)
+                + CodedOutputStream.computeByteArraySize(4, encodedVc)
+                + (this.stateDigest != null
+                ? CodedOutputStream.computeByteArraySize(5, this.stateDigest) : 0)
+                + CodedOutputStream.computeInt32Size(6, this.epoch)
+                + CodedOutputStream.computeInt32Size(7, this.mode)
+                + (this.checkpointData != null
+                ? CodedOutputStream.computeByteArraySize(8, this.checkpointData) : 0)
+                + (this.checkpointHandle != null
+                ? CodedOutputStream.computeStringSize(9, this.checkpointHandle) : 0);
+
+        byte[] serialized = new byte[Integer.BYTES + payloadSize];
+        ByteBuffer.wrap(serialized, 0, Integer.BYTES).putInt(this.getRequestType().getInt());
+
+        CodedOutputStream output =
+                CodedOutputStream.newInstance(serialized, Integer.BYTES, payloadSize);
+        try {
+            output.writeInt64(1, this.packetId);
+            output.writeString(2, this.senderId);
+            output.writeString(3, this.serviceName);
+            output.writeByteArray(4, encodedVc);
+            if (this.stateDigest != null) {
+                output.writeByteArray(5, this.stateDigest);
+            }
+            output.writeInt32(6, this.epoch);
+            output.writeInt32(7, this.mode);
+            if (this.checkpointData != null) {
+                output.writeByteArray(8, this.checkpointData);
+            }
+            if (this.checkpointHandle != null) {
+                output.writeString(9, this.checkpointHandle);
+            }
+            output.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize LazyCheckpointPacket", e);
+        }
+
+        return serialized;
+    }
+
+    public static LazyCheckpointPacket createFromBytes(byte[] encodedPacket) {
+        assert encodedPacket != null && encodedPacket.length > 0 : "Encoded packet cannot be empty";
+
+        if (encodedPacket.length < Integer.BYTES) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazyCheckpointPacket: header too small");
+            return null;
+        }
+
+        int packetType = ByteBuffer.wrap(encodedPacket, 0, Integer.BYTES).getInt();
+        if (packetType != LazyPacketType.LAZY_CHECKPOINT.getInt()) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazyCheckpointPacket: unexpected type "
+                            + packetType);
+            return null;
+        }
+
+        long packetId = 0;
+        String senderId = null;
+        String serviceName = null;
+        byte[] encodedVc = null;
+        byte[] stateDigest = null;
+        int epoch = 0;
+        int mode = 0;
+        byte[] checkpointData = null;
+        String checkpointHandle = null;
+
+        CodedInputStream input = CodedInputStream.newInstance(
+                encodedPacket, Integer.BYTES, encodedPacket.length - Integer.BYTES);
+        // Raise the default 64MB CodedInputStream limit so large inline checkpoints,
+        // bounded separately by the NIO payload cap, still decode.
+        input.setSizeLimit(Integer.MAX_VALUE);
+        try {
+            int tag;
+            while ((tag = input.readTag()) != 0) {
+                switch (tag) {
+                    case 8 -> packetId = input.readInt64();
+                    case 18 -> senderId = input.readStringRequireUtf8();
+                    case 26 -> serviceName = input.readStringRequireUtf8();
+                    case 34 -> encodedVc = input.readByteArray();
+                    case 42 -> stateDigest = input.readByteArray();
+                    case 48 -> epoch = input.readInt32();
+                    case 56 -> mode = input.readInt32();
+                    case 66 -> checkpointData = input.readByteArray();
+                    case 74 -> checkpointHandle = input.readStringRequireUtf8();
+                    default -> input.skipField(tag);
+                }
+            }
+        } catch (IOException e) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazyCheckpointPacket: " + e.getMessage());
+            return null;
+        }
+
+        if (senderId == null || serviceName == null || encodedVc == null
+                || (mode == MODE_INLINE && checkpointData == null)
+                || (mode == MODE_HANDLE && checkpointHandle == null)) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazyCheckpointPacket: missing fields");
+            return null;
+        }
+
+        VectorTimestamp vectorClock;
+        try {
+            vectorClock = VectorClockCodec.decode(encodedVc);
+        } catch (IOException e) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazyCheckpointPacket: bad vector clock");
+            return null;
+        }
+
+        return new LazyCheckpointPacket(packetId, senderId, serviceName, vectorClock, stateDigest,
+                epoch, mode, checkpointData, checkpointHandle);
+    }
+}

--- a/src/edu/umass/cs/eventual/packets/LazyPacket.java
+++ b/src/edu/umass/cs/eventual/packets/LazyPacket.java
@@ -25,6 +25,14 @@ public abstract class LazyPacket implements ReplicableRequest {
             return LazyWriteAfterPacket.createFromBytes(encodedPacket, appRequestParser);
         }
 
+        if (packetType.equals(LazyPacketType.LAZY_SYNC)) {
+            return LazySyncPacket.createFromBytes(encodedPacket);
+        }
+
+        if (packetType.equals(LazyPacketType.LAZY_CHECKPOINT)) {
+            return LazyCheckpointPacket.createFromBytes(encodedPacket);
+        }
+
         throw new RuntimeException("Unimplemented deserializer handler for packet type of " +
                 packetType);
     }

--- a/src/edu/umass/cs/eventual/packets/LazyPacketType.java
+++ b/src/edu/umass/cs/eventual/packets/LazyPacketType.java
@@ -11,7 +11,13 @@ public enum LazyPacketType implements IntegerPacketType {
     // Wrapper packet for all packet types for Lazy Replication
     LAZY_PACKET(55500),
 
-    LAZY_WRITE_AFTER(55501);
+    LAZY_WRITE_AFTER(55501),
+
+    // Periodic anti-entropy heartbeat carrying the sender's vector clock and state digest.
+    LAZY_SYNC(55502),
+
+    // Frontier-to-laggard checkpoint transfer (inline bytes or out-of-band handle).
+    LAZY_CHECKPOINT(55503);
 
     private static final Map<Integer, LazyPacketType> numbers = new HashMap<>();
 

--- a/src/edu/umass/cs/eventual/packets/LazySyncPacket.java
+++ b/src/edu/umass/cs/eventual/packets/LazySyncPacket.java
@@ -1,0 +1,181 @@
+package edu.umass.cs.eventual.packets;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import edu.umass.cs.clientcentric.VectorTimestamp;
+import edu.umass.cs.eventual.VectorClockCodec;
+import edu.umass.cs.nio.interfaces.Byteable;
+import edu.umass.cs.nio.interfaces.IntegerPacketType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * LazySyncPacket is the periodic anti-entropy heartbeat: it advertises the sender's
+ * applied-write vector clock and an optional digest of its current state. A receiver uses it to
+ * decide whether it is the frontier and must ship a checkpoint back to the sender.
+ */
+public class LazySyncPacket extends LazyPacket implements Byteable {
+
+    private final long packetId;
+    private final String senderId;
+    private final String serviceName;
+    private final VectorTimestamp vectorClock;
+    private final byte[] stateDigest; // nullable
+    private final int epoch;
+
+    public LazySyncPacket(String senderId, String serviceName, VectorTimestamp vectorClock,
+                          byte[] stateDigest, int epoch) {
+        this(UUID.randomUUID().getLeastSignificantBits(), senderId, serviceName, vectorClock,
+                stateDigest, epoch);
+    }
+
+    private LazySyncPacket(long packetId, String senderId, String serviceName,
+                           VectorTimestamp vectorClock, byte[] stateDigest, int epoch) {
+        assert senderId != null : "The sender cannot be null";
+        assert serviceName != null : "The service name cannot be null";
+        assert vectorClock != null : "The vector clock cannot be null";
+        this.packetId = packetId;
+        this.senderId = senderId;
+        this.serviceName = serviceName;
+        this.vectorClock = vectorClock;
+        this.stateDigest = stateDigest;
+        this.epoch = epoch;
+    }
+
+    @Override
+    public IntegerPacketType getRequestType() {
+        return LazyPacketType.LAZY_SYNC;
+    }
+
+    @Override
+    public String getServiceName() {
+        return this.serviceName;
+    }
+
+    @Override
+    public long getRequestID() {
+        return this.packetId;
+    }
+
+    @Override
+    public boolean needsCoordination() {
+        return true;
+    }
+
+    public String getSenderId() {
+        return senderId;
+    }
+
+    public VectorTimestamp getVectorClock() {
+        return vectorClock;
+    }
+
+    public byte[] getStateDigest() {
+        return stateDigest;
+    }
+
+    public int getEpoch() {
+        return epoch;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        byte[] encodedVc = VectorClockCodec.encode(this.vectorClock);
+
+        int payloadSize = CodedOutputStream.computeInt64Size(1, this.packetId)
+                + CodedOutputStream.computeStringSize(2, this.senderId)
+                + CodedOutputStream.computeStringSize(3, this.serviceName)
+                + CodedOutputStream.computeByteArraySize(4, encodedVc)
+                + (this.stateDigest != null
+                ? CodedOutputStream.computeByteArraySize(5, this.stateDigest) : 0)
+                + CodedOutputStream.computeInt32Size(6, this.epoch);
+
+        byte[] serialized = new byte[Integer.BYTES + payloadSize];
+        ByteBuffer.wrap(serialized, 0, Integer.BYTES).putInt(this.getRequestType().getInt());
+
+        CodedOutputStream output =
+                CodedOutputStream.newInstance(serialized, Integer.BYTES, payloadSize);
+        try {
+            output.writeInt64(1, this.packetId);
+            output.writeString(2, this.senderId);
+            output.writeString(3, this.serviceName);
+            output.writeByteArray(4, encodedVc);
+            if (this.stateDigest != null) {
+                output.writeByteArray(5, this.stateDigest);
+            }
+            output.writeInt32(6, this.epoch);
+            output.flush();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize LazySyncPacket", e);
+        }
+
+        return serialized;
+    }
+
+    public static LazySyncPacket createFromBytes(byte[] encodedPacket) {
+        assert encodedPacket != null && encodedPacket.length > 0 : "Encoded packet cannot be empty";
+
+        if (encodedPacket.length < Integer.BYTES) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazySyncPacket: header too small");
+            return null;
+        }
+
+        int packetType = ByteBuffer.wrap(encodedPacket, 0, Integer.BYTES).getInt();
+        if (packetType != LazyPacketType.LAZY_SYNC.getInt()) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazySyncPacket: unexpected type " + packetType);
+            return null;
+        }
+
+        long packetId = 0;
+        String senderId = null;
+        String serviceName = null;
+        byte[] encodedVc = null;
+        byte[] stateDigest = null;
+        int epoch = 0;
+
+        CodedInputStream input = CodedInputStream.newInstance(
+                encodedPacket, Integer.BYTES, encodedPacket.length - Integer.BYTES);
+        try {
+            int tag;
+            while ((tag = input.readTag()) != 0) {
+                switch (tag) {
+                    case 8 -> packetId = input.readInt64();
+                    case 18 -> senderId = input.readStringRequireUtf8();
+                    case 26 -> serviceName = input.readStringRequireUtf8();
+                    case 34 -> encodedVc = input.readByteArray();
+                    case 42 -> stateDigest = input.readByteArray();
+                    case 48 -> epoch = input.readInt32();
+                    default -> input.skipField(tag);
+                }
+            }
+        } catch (IOException e) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazySyncPacket: " + e.getMessage());
+            return null;
+        }
+
+        if (senderId == null || serviceName == null || encodedVc == null) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazySyncPacket: missing fields");
+            return null;
+        }
+
+        VectorTimestamp vectorClock;
+        try {
+            vectorClock = VectorClockCodec.decode(encodedVc);
+        } catch (IOException e) {
+            Logger.getGlobal().log(Level.SEVERE,
+                    "Receiving an invalid encoded LazySyncPacket: bad vector clock");
+            return null;
+        }
+
+        return new LazySyncPacket(packetId, senderId, serviceName, vectorClock, stateDigest,
+                epoch);
+    }
+}

--- a/src/edu/umass/cs/eventual/packets/LazyWriteAfterPacket.java
+++ b/src/edu/umass/cs/eventual/packets/LazyWriteAfterPacket.java
@@ -8,7 +8,6 @@ import edu.umass.cs.gigapaxos.interfaces.Request;
 import edu.umass.cs.nio.interfaces.Byteable;
 import edu.umass.cs.nio.interfaces.IntegerPacketType;
 import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
-import edu.umass.cs.xdn.interfaces.behavior.BehavioralRequest;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -16,25 +15,41 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * LazyWriteAfterPacket is the best-effort fast path: after executing and acknowledging a client
+ * write, the source replica broadcasts the encoded write, stamped with its per-source sequence
+ * number, so peers can apply it eagerly. Peers apply a write-after only when it is contiguous
+ * with their vector clock; gapped or duplicate packets are dropped and the periodic anti-entropy
+ * checkpoint transfer recovers the missed writes.
+ */
 public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
 
     private final long packetId;
     private final String senderId;
-    private final ClientRequest clientWriteOnlyRequest;
+    private final long senderSeqNum;
+    private final int epoch;
+    private final ClientRequest clientRequest;   // parsed request (receive side / execution)
+    private final byte[] encodedClientRequest;   // wire encoding (send side)
+    private final String serviceName;
 
-    public LazyWriteAfterPacket(String senderId, ClientRequest clientWriteOnlyRequest) {
-        this(UUID.randomUUID().getLeastSignificantBits(), senderId, clientWriteOnlyRequest);
+    public LazyWriteAfterPacket(String senderId, long senderSeqNum, int epoch,
+                                ClientRequest clientRequest, byte[] encodedClientRequest) {
+        this(UUID.randomUUID().getLeastSignificantBits(), senderId, senderSeqNum, epoch,
+                clientRequest, encodedClientRequest);
     }
 
-    private LazyWriteAfterPacket(long packetId, String senderId, ClientRequest clientWriteOnlyRequest) {
+    private LazyWriteAfterPacket(long packetId, String senderId, long senderSeqNum, int epoch,
+                                 ClientRequest clientRequest, byte[] encodedClientRequest) {
         assert packetId != 0 : "A likely invalid packetID given";
         assert senderId != null : "The sender cannot be null";
-        assert clientWriteOnlyRequest != null : "The provided ClientRequest cannot be null";
-        assert (clientWriteOnlyRequest instanceof BehavioralRequest br && br.isWriteOnlyRequest()) :
-                "The provided ClientRequest must be a WriteOnlyRequest";
+        assert clientRequest != null : "The provided ClientRequest cannot be null";
         this.packetId = packetId;
         this.senderId = senderId;
-        this.clientWriteOnlyRequest = clientWriteOnlyRequest;
+        this.senderSeqNum = senderSeqNum;
+        this.epoch = epoch;
+        this.clientRequest = clientRequest;
+        this.encodedClientRequest = encodedClientRequest;
+        this.serviceName = clientRequest.getServiceName();
     }
 
     @Override
@@ -44,7 +59,7 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
 
     @Override
     public String getServiceName() {
-        return this.clientWriteOnlyRequest.getServiceName();
+        return this.serviceName;
     }
 
     @Override
@@ -57,19 +72,34 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
         return true;
     }
 
-    public ClientRequest getClientWriteOnlyRequest() {
-        return clientWriteOnlyRequest;
+    public String getSenderId() {
+        return senderId;
+    }
+
+    public long getSenderSeqNum() {
+        return senderSeqNum;
+    }
+
+    public int getEpoch() {
+        return epoch;
+    }
+
+    public ClientRequest getClientRequest() {
+        return clientRequest;
     }
 
     @Override
     public byte[] toBytes() {
-        byte[] encodedClientRequest = this.clientWriteOnlyRequest.toBytes();
+        byte[] encodedRequest = this.encodedClientRequest != null
+                ? this.encodedClientRequest : this.clientRequest.toBytes();
         String serviceName = this.getServiceName();
 
         int payloadSize = CodedOutputStream.computeInt64Size(1, this.packetId)
                 + CodedOutputStream.computeStringSize(2, this.senderId)
                 + CodedOutputStream.computeStringSize(3, serviceName)
-                + CodedOutputStream.computeByteArraySize(4, encodedClientRequest);
+                + CodedOutputStream.computeByteArraySize(4, encodedRequest)
+                + CodedOutputStream.computeInt64Size(5, this.senderSeqNum)
+                + CodedOutputStream.computeInt32Size(6, this.epoch);
 
         byte[] serialized = new byte[Integer.BYTES + payloadSize];
         ByteBuffer.wrap(serialized, 0, Integer.BYTES).putInt(this.getRequestType().getInt());
@@ -79,7 +109,9 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
             output.writeInt64(1, this.packetId);
             output.writeString(2, this.senderId);
             output.writeString(3, serviceName);
-            output.writeByteArray(4, encodedClientRequest);
+            output.writeByteArray(4, encodedRequest);
+            output.writeInt64(5, this.senderSeqNum);
+            output.writeInt32(6, this.epoch);
             output.flush();
         } catch (IOException e) {
             throw new RuntimeException("Failed to serialize LazyWriteAfterPacket", e);
@@ -108,6 +140,8 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
         String senderId = null;
         String serviceName = null;
         byte[] encodedClientRequest = null;
+        long senderSeqNum = 0;
+        int epoch = 0;
 
         CodedInputStream input = CodedInputStream.newInstance(
                 encodedPacket, Integer.BYTES, encodedPacket.length - Integer.BYTES);
@@ -119,6 +153,8 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
                     case 18 -> senderId = input.readStringRequireUtf8();
                     case 26 -> serviceName = input.readStringRequireUtf8();
                     case 34 -> encodedClientRequest = input.readByteArray();
+                    case 40 -> senderSeqNum = input.readInt64();
+                    case 48 -> epoch = input.readInt32();
                     default -> input.skipField(tag);
                 }
             }
@@ -142,8 +178,6 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
 
         assert (clientRequest instanceof ClientRequest) :
                 "The request inside LazyWriteAfterPacket must implement ClientRequest interface";
-        assert (clientRequest instanceof BehavioralRequest br && br.isWriteOnlyRequest()) :
-                "The client request inside LazyWriteAfterPacket must be WriteOnlyRequest";
 
         ClientRequest concreteRequest = (ClientRequest) clientRequest;
         if (serviceName != null && !serviceName.equals(concreteRequest.getServiceName())) {
@@ -151,6 +185,7 @@ public class LazyWriteAfterPacket extends LazyPacket implements Byteable {
                     "Service name mismatch when decoding LazyWriteAfterPacket");
         }
 
-        return new LazyWriteAfterPacket(packetId, senderId, concreteRequest);
+        return new LazyWriteAfterPacket(packetId, senderId, senderSeqNum, epoch, concreteRequest,
+                encodedClientRequest);
     }
 }

--- a/src/edu/umass/cs/eventual/proto/lazy_packet.proto
+++ b/src/edu/umass/cs/eventual/proto/lazy_packet.proto
@@ -1,4 +1,7 @@
 // protoc --java_out=./src src/edu/umass/cs/eventual/proto/lazy_packet.proto
+//
+// NOTE: serialization is currently hand-rolled with CodedOutputStream/CodedInputStream in the
+// packet classes (no generated LazyPacketProto class); this schema documents the wire format.
 syntax = "proto3";
 
 package lazy;
@@ -6,7 +9,7 @@ package lazy;
 option java_package = "edu.umass.cs.eventual.proto";
 option java_outer_classname = "LazyPacketProto";
 
-// Protobuf definition for packets used by the lazy replication subsystem.
+// Best-effort fast path: the source replica broadcasts each executed write to peers.
 message LazyWriteAfterPacket {
   // Unique identifier for the packet.
   int64 packet_id = 1;
@@ -19,4 +22,50 @@ message LazyWriteAfterPacket {
 
   // Serialized client request payload.
   bytes encoded_client_request = 4;
+
+  // The sender's per-source sequence number for this write (its own vector-clock
+  // component after executing the write). Receivers apply contiguously or drop.
+  int64 sender_seq_num = 5;
+
+  // Placement epoch of the sender's replica group; mismatches are dropped.
+  int32 epoch = 6;
+}
+
+// Periodic anti-entropy heartbeat advertising the sender's applied-write vector clock.
+message LazySyncPacket {
+  int64 packet_id = 1;
+  string sender_node_id = 2;
+  string service_name = 3;
+
+  // Encoded vector clock: repeated (string node_id = 1, int64 counter = 2) pairs.
+  bytes vector_clock = 4;
+
+  // Optional sha256 digest of the sender's current service state.
+  bytes state_digest = 5;
+
+  int32 epoch = 6;
+}
+
+// Frontier-to-laggard checkpoint transfer.
+message LazyCheckpointPacket {
+  int64 packet_id = 1;
+  string sender_node_id = 2;
+  string service_name = 3;
+
+  // Encoded vector clock at capture time (same encoding as LazySyncPacket).
+  bytes vector_clock = 4;
+
+  // Optional sha256 digest of the captured state.
+  bytes state_digest = 5;
+
+  int32 epoch = 6;
+
+  // 1 = inline (checkpoint_data set), 2 = handle (checkpoint_handle set).
+  int32 mode = 7;
+
+  // The complete service state archive, when shipped inline.
+  bytes checkpoint_data = 8;
+
+  // Out-of-band handle (e.g., LargeCheckpointer handle) for large checkpoints.
+  string checkpoint_handle = 9;
 }

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -594,6 +594,22 @@ public class ReconfigurationConfig {
         XDN_FUSELOG_BASE_DIR("/tmp/xdn/state/fuselog/"),
 
         /**
+         * Anti-entropy round period (ms) for the eventual-consistency
+         * LazyReplicaCoordinator: every period, replicas exchange vector clocks and
+         * state digests, and a frontier replica ships its checkpoint to lagging peers.
+         * TODO: this should be specific to XDN, and not Gigapaxos config.
+         */
+        XDN_EVENTUAL_ANTI_ENTROPY_INTERVAL_MS(5000L),
+
+        /**
+         * Maximum checkpoint size (bytes) shipped inline inside a LazyCheckpointPacket;
+         * larger checkpoints use an out-of-band LargeCheckpointer handle. Must stay
+         * below NIO_MAX_PAYLOAD_SIZE with headroom.
+         * TODO: this should be specific to XDN, and not Gigapaxos config.
+         */
+        XDN_EVENTUAL_CHECKPOINT_INLINE_MAX_BYTES(8_000_000L),
+
+        /**
          * A flag to enable/disable batching in HttpActiveReplica.
          */
         HTTP_AR_FRONTEND_BATCH_ENABLED(false),

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -2,6 +2,7 @@ package edu.umass.cs.xdn;
 
 import static org.junit.Assert.assertNotNull;
 
+import edu.umass.cs.eventual.interfaces.CheckpointableApplication;
 import edu.umass.cs.gigapaxos.PaxosConfig;
 import edu.umass.cs.gigapaxos.interfaces.Replicable;
 import edu.umass.cs.gigapaxos.interfaces.Request;
@@ -38,6 +39,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -48,10 +51,15 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.json.JSONException;
 
 public class XdnGigapaxosApp
-    implements Replicable, Reconfigurable, BackupableApplication, InitialStateValidator {
+    implements Replicable,
+        Reconfigurable,
+        BackupableApplication,
+        CheckpointableApplication,
+        InitialStateValidator {
 
   private final boolean IS_RESTART_UPON_STATE_DIFF_APPLY = false;
 
@@ -1848,6 +1856,229 @@ public class XdnGigapaxosApp
     }
 
     return true;
+  }
+
+  // ==================== CheckpointableApplication (eventual consistency) ====================
+  // Whole-state checkpoint capture/restore used by LazyReplicaCoordinator's frontier-based
+  // anti-entropy. Capture archives the recorder's state directory of the LIVE service (the
+  // coordinator excludes writes while capturing, and CSM crash-consistency covers snapshots
+  // taken at request boundaries). Restore stops the containers, replaces the state directory,
+  // restarts the containers, and waits until the service answers HTTP again, because
+  // execute() silently no-ops while the container is unreachable.
+
+  @Override
+  public byte[] captureCheckpoint(String serviceName) {
+    String tarPath = this.captureCheckpointTar(serviceName);
+    if (tarPath == null) return null;
+    try {
+      return Files.readAllBytes(Paths.get(tarPath));
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to read captured checkpoint of " + serviceName, e);
+      return null;
+    }
+  }
+
+  @Override
+  public String captureCheckpointHandle(String serviceName) {
+    String tarPath = this.captureCheckpointTar(serviceName);
+    if (tarPath == null) return null;
+    return this.largeCheckpointer.createCheckpointHandle(this.myNodeId, tarPath);
+  }
+
+  @Override
+  public boolean applyCheckpoint(String serviceName, byte[] checkpoint) {
+    if (checkpoint == null || checkpoint.length == 0) return false;
+    String tarPath =
+        String.format("/tmp/xdn/eventual/%s/%s/rcv_ckpt.tar", this.myNodeId, serviceName);
+    try {
+      Files.createDirectories(Paths.get(tarPath).getParent());
+      Files.write(
+          Paths.get(tarPath),
+          checkpoint,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.DSYNC);
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to persist received checkpoint of " + serviceName, e);
+      return false;
+    }
+    return this.restoreServiceFromCheckpointTar(serviceName, tarPath);
+  }
+
+  @Override
+  public boolean applyCheckpointHandle(String serviceName, String handle) {
+    if (handle == null || handle.isEmpty()) return false;
+    String tarPath =
+        String.format("/tmp/xdn/eventual/%s/%s/rcv_ckpt.tar", this.myNodeId, serviceName);
+    try {
+      Files.createDirectories(Paths.get(tarPath).getParent());
+    } catch (IOException e) {
+      logger.log(Level.SEVERE, "Failed to prepare checkpoint dir of " + serviceName, e);
+      return false;
+    }
+    String fetchedTarPath = LargeCheckpointer.restoreCheckpointHandle(handle, tarPath);
+    if (fetchedTarPath == null) {
+      logger.log(Level.SEVERE, "Failed to fetch checkpoint handle of " + serviceName);
+      return false;
+    }
+    return this.restoreServiceFromCheckpointTar(serviceName, tarPath);
+  }
+
+  @Override
+  public byte[] getStateDigest(String serviceName) {
+    Integer epoch = this.getEpoch(serviceName);
+    if (epoch == null) return null;
+    Path mountDir = Paths.get(stateDiffRecorder.getTargetDirectory(serviceName, epoch));
+    if (!Files.isDirectory(mountDir)) return null;
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      List<Path> paths;
+      try (var walked = Files.walk(mountDir)) {
+        paths =
+            walked
+                .sorted(Comparator.comparing(p -> mountDir.relativize(p).toString()))
+                .collect(Collectors.toList());
+      }
+      for (Path path : paths) {
+        String relative = mountDir.relativize(path).toString();
+        if (relative.isEmpty()) continue;
+        digest.update(relative.getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+        if (Files.isRegularFile(path)) {
+          digest.update(Files.readAllBytes(path));
+        }
+      }
+      return digest.digest();
+    } catch (NoSuchAlgorithmException | IOException e) {
+      logger.log(Level.WARNING, "Failed to compute state digest of " + serviceName, e);
+      return null;
+    }
+  }
+
+  /** Archives the current state directory of the service; returns the tar path or null. */
+  private String captureCheckpointTar(String serviceName) {
+    Integer epoch = this.getEpoch(serviceName);
+    ServiceInstance service = this.services.get(serviceName);
+    if (epoch == null || service == null) {
+      logger.log(Level.WARNING, "Ignoring checkpoint capture for unknown service=" + serviceName);
+      return null;
+    }
+
+    String captureDirPath =
+        String.format("/tmp/xdn/eventual/%s/%s/cap/", this.myNodeId, serviceName);
+    int code = Shell.runCommand(String.format("rm -rf %s", captureDirPath), true);
+    assert code == 0;
+    code = Shell.runCommand(String.format("mkdir -p %s", captureDirPath), true);
+    assert code == 0;
+
+    // Copy the state with rsync (see captureContainerizedServiceFinalState for why rsync
+    // and not `cp -a`), retrying since the service may be mutating background files.
+    String mountDir = stateDiffRecorder.getTargetDirectory(serviceName, epoch);
+    String copyCommand = String.format("rsync -a %s %s", mountDir, captureDirPath);
+    int attempts = 0;
+    while (true) {
+      if (++attempts >= 10) {
+        logger.log(
+            Level.WARNING,
+            "{0}:{1} rsync failed to capture checkpoint of {2} after {3} attempts",
+            new Object[] {
+              this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), serviceName, attempts
+            });
+        return null;
+      }
+      int exitCode = Shell.runCommand(copyCommand, true);
+      if (exitCode == 0) break;
+    }
+
+    String tarPath = String.format("/tmp/xdn/eventual/%s/%s/ckpt.tar", this.myNodeId, serviceName);
+    code = Shell.runCommand(String.format("rm -f %s", tarPath), true);
+    assert code == 0;
+    ZipFiles.zipDirectory(new File(captureDirPath), tarPath);
+    return tarPath;
+  }
+
+  /** Stops the service, replaces its state directory with the tar contents, restarts it. */
+  private boolean restoreServiceFromCheckpointTar(String serviceName, String tarPath) {
+    Integer epoch = this.getEpoch(serviceName);
+    ServiceInstance service = this.services.get(serviceName);
+    if (epoch == null || service == null) {
+      logger.log(Level.WARNING, "Ignoring checkpoint restore for unknown service=" + serviceName);
+      return false;
+    }
+
+    // Stop the containers; app memory caches (e.g., database page caches) make an
+    // in-place file overwrite of a running service unsafe.
+    if (service.composeFilePath != null) {
+      boolean isStopped =
+          DockerComposeManager.composeStop(service.composeFilePath, service.composeProjectName);
+      if (!isStopped) {
+        logger.log(Level.SEVERE, "Failed to stop compose project of " + serviceName);
+        return false;
+      }
+    } else {
+      for (String containerName : service.containerNames) {
+        int exitCode =
+            runShellCommand(String.format("docker container stop %s", containerName), true);
+        if (exitCode != 0 && exitCode != 1) {
+          logger.log(Level.SEVERE, "Failed to stop container " + containerName);
+          return false;
+        }
+      }
+    }
+
+    // Replace the state directory with the checkpoint contents.
+    String mountDir = stateDiffRecorder.getTargetDirectory(serviceName, epoch);
+    int code = Shell.runCommand(String.format("rm -rf %s", mountDir), true);
+    assert code == 0;
+    code = Shell.runCommand(String.format("mkdir -p %s", mountDir), true);
+    assert code == 0;
+    ZipFiles.unzip(tarPath, mountDir);
+
+    // Restart the containers; docker preserves port bindings across stop/start.
+    if (service.composeFilePath != null) {
+      boolean isStarted =
+          DockerComposeManager.composeUp(service.composeFilePath, service.composeProjectName);
+      if (!isStarted) {
+        logger.log(Level.SEVERE, "Failed to restart compose project of " + serviceName);
+        return false;
+      }
+    } else {
+      for (String containerName : service.containerNames) {
+        int exitCode = runShellCommand(String.format("docker start %s", containerName), true);
+        if (exitCode != 0) {
+          logger.log(Level.SEVERE, "Failed to restart container " + containerName);
+          return false;
+        }
+      }
+    }
+
+    // Wait until the service answers HTTP again: execute() returns true with a null
+    // response while the container is unreachable, which would silently drop the
+    // coordinator's own-write re-application after this restore.
+    Integer httpPort = this.activeServicePorts.get(serviceName);
+    if (httpPort == null) httpPort = service.allocatedHttpPort;
+    long deadline = System.currentTimeMillis() + 30_000;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        HttpURLConnection connection =
+            (HttpURLConnection) new URL("http://127.0.0.1:" + httpPort + "/").openConnection();
+        connection.setConnectTimeout(500);
+        connection.setReadTimeout(500);
+        connection.getResponseCode(); // any HTTP status means the service is up
+        connection.disconnect();
+        return true;
+      } catch (IOException e) {
+        try {
+          TimeUnit.MILLISECONDS.sleep(200);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          return false;
+        }
+      }
+    }
+    logger.log(
+        Level.SEVERE, "Service " + serviceName + " did not become ready after checkpoint restore");
+    return false;
   }
 
   @Deprecated

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -768,8 +768,18 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
 
   private AbstractReplicaCoordinator<NodeIDType> inferCoordinatorByProperties(
       ServiceProperty serviceProperties) {
-    // For non-deterministic service we always use primary-backup, the only coordinator
-    // we have implemented that can handle non-determinism.
+    // An explicitly declared EVENTUAL consistency always uses the anti-entropy
+    // LazyReplicaCoordinator, regardless of determinism or declared behaviors:
+    // frontier-based checkpoint transfer converges replicas to identical state even
+    // for non-deterministic, non-commutative services (see edu.umass.cs.eventual).
+    // Primary-backup remains the default only for strong consistency on
+    // non-deterministic services.
+    if (serviceProperties.getConsistencyModel().equals(ConsistencyModel.EVENTUAL)) {
+      return this.lazyReplicaCoordinator;
+    }
+
+    // For non-deterministic service we otherwise use primary-backup, the only coordinator
+    // we have implemented that can handle non-determinism under strong consistency.
     if (!serviceProperties.isDeterministic()) {
       return this.primaryBackupCoordinator;
     }
@@ -835,19 +845,6 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
       if (declaredConsModel.equals(ConsistencyModel.PRAM)
           && !nonRmwBehaviors.containsAll(allDeclaredBehaviors)) {
         return this.awReplicaCoordinator;
-      }
-
-      // Lazy replications generally works for service whose operations are monotonic.
-      Set<RequestBehaviorType> protocolConstraints =
-          new HashSet<>(
-              Arrays.asList(
-                  RequestBehaviorType.MONOTONIC,
-                  RequestBehaviorType.READ_ONLY,
-                  RequestBehaviorType.WRITE_ONLY));
-      allDeclaredBehaviors.remove(RequestBehaviorType.NIL_EXTERNAL); // optional
-      if (declaredConsModel.equals(ConsistencyModel.EVENTUAL)
-          && allDeclaredBehaviors.equals(protocolConstraints)) {
-        return this.lazyReplicaCoordinator;
       }
 
       // It is always safe to fall back with sequential consistency, if the service

--- a/test/edu/umass/cs/xdn/XdnEventualConvergenceTest.java
+++ b/test/edu/umass/cs/xdn/XdnEventualConvergenceTest.java
@@ -1,0 +1,177 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.utils.Config;
+import edu.umass.cs.xdn.util.XdnTestCluster;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Arrays;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for the frontier-based anti-entropy eventual-consistency coordinator
+ * (LazyReplicaCoordinator). Uses fadhilkurnia/xdn-randstate: a NON-deterministic service (each
+ * write appends a random row, and each replica also boots with different random state) exposing GET
+ * /hash, a sha256 digest of its whole on-disk state. Re-executing writes therefore never makes
+ * replicas byte-identical; only checkpoint-based anti-entropy can, which is exactly what this test
+ * asserts: after writes to all three replicas stop, all replicas eventually report the same state
+ * hash.
+ */
+public class XdnEventualConvergenceTest {
+
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+  private static final String SERVICE_IMAGE = "fadhilkurnia/xdn-randstate";
+  private static final int NUM_REPLICAS = 3;
+
+  @Test
+  public void testConvergenceWithWritesToAllReplicas() throws Exception {
+    assertTrue(
+        XdnTestCluster.isDockerAvailable(), "Docker is required for this XDN integration test");
+
+    // Speed up anti-entropy so convergence happens well within the test deadline.
+    Config.register(new String[] {"XDN_EVENTUAL_ANTI_ENTROPY_INTERVAL_MS=1000"});
+
+    String serviceName = "randstate_eventual_convergence_test";
+
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+
+      // Launch WITHOUT request matchers and with deterministic=false: default matchers
+      // classify POST as read-modify-write, which the relaxed EVENTUAL dispatch must
+      // still route to the LazyReplicaCoordinator (previously this would have fallen
+      // back to primary-backup).
+      cluster.launchService(serviceName, SERVICE_IMAGE, "/app/data/", "EVENTUAL", false, null);
+
+      cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      for (int replicaIdx = 0; replicaIdx < NUM_REPLICAS; replicaIdx++) {
+        cluster.awaitReplicaReady(serviceName, replicaIdx, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      }
+
+      // Diverge: write directly to EVERY replica. Each write appends a random row at the
+      // receiving replica (and random re-execution at peers via the write-after fast path
+      // still yields different bytes), so replica states are guaranteed to differ.
+      int numWritesPerReplica = 3;
+      for (int replicaIdx = 0; replicaIdx < NUM_REPLICAS; replicaIdx++) {
+        for (int i = 0; i < numWritesPerReplica; i++) {
+          HttpResponse<String> writeResponse =
+              sendPostRequest(cluster, serviceName, replicaIdx, "/write");
+          assertTrue(
+              writeResponse.statusCode() >= 200 && writeResponse.statusCode() < 300,
+              String.format(
+                  "write %d to replica %d failed with status %d: %s",
+                  i, replicaIdx, writeResponse.statusCode(), writeResponse.body()));
+        }
+      }
+
+      // Converge: poll every replica's state hash until all three are identical. A replica
+      // may briefly refuse connections while it restarts to install a checkpoint; treat
+      // that as not-converged-yet rather than a failure.
+      String[] lastHashes = new String[NUM_REPLICAS];
+      long deadline = System.currentTimeMillis() + 120_000;
+      boolean converged = false;
+      while (System.currentTimeMillis() < deadline && !converged) {
+        boolean allReadable = true;
+        for (int replicaIdx = 0; replicaIdx < NUM_REPLICAS; replicaIdx++) {
+          try {
+            HttpResponse<String> hashResponse =
+                cluster.sendGetRequest(serviceName, replicaIdx, "/hash", Duration.ofSeconds(5));
+            if (hashResponse.statusCode() != 200 || hashResponse.body().isEmpty()) {
+              allReadable = false;
+              break;
+            }
+            lastHashes[replicaIdx] = hashResponse.body().trim();
+          } catch (IOException e) {
+            allReadable = false;
+            break;
+          }
+        }
+        converged =
+            allReadable
+                && lastHashes[0] != null
+                && lastHashes[0].equals(lastHashes[1])
+                && lastHashes[1].equals(lastHashes[2]);
+        if (!converged) {
+          Thread.sleep(500);
+        }
+      }
+      assertTrue(
+          converged,
+          "replicas did not converge to the same state hash under anti-entropy: "
+              + Arrays.toString(lastHashes));
+      System.out.println("Replicas converged with state hash: " + lastHashes[0]);
+
+      // Stability: the hashes must still be identical after three more anti-entropy
+      // rounds, guarding against having sampled a transient coincidence.
+      Thread.sleep(3_000);
+      String stableHash = null;
+      for (int replicaIdx = 0; replicaIdx < NUM_REPLICAS; replicaIdx++) {
+        HttpResponse<String> hashResponse =
+            cluster.sendGetRequest(serviceName, replicaIdx, "/hash", Duration.ofSeconds(5));
+        assertEquals(200, hashResponse.statusCode(), "hash read failed after convergence");
+        if (stableHash == null) {
+          stableHash = hashResponse.body().trim();
+        } else {
+          assertEquals(
+              stableHash,
+              hashResponse.body().trim(),
+              "replica " + replicaIdx + " diverged again after convergence");
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testEventualServiceUsesLazyCoordinator() throws Exception {
+    assertTrue(
+        XdnTestCluster.isDockerAvailable(), "Docker is required for this XDN integration test");
+
+    String serviceName = "randstate_eventual_protocol_test";
+
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+
+      // Non-deterministic service with default matchers: under the relaxed dispatch, an
+      // explicit EVENTUAL declaration must route to the LazyReplicaCoordinator instead of
+      // primary-backup.
+      cluster.launchService(serviceName, SERVICE_IMAGE, "/app/data/", "EVENTUAL", false, null);
+      cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
+
+      HttpResponse<String> infoResponse =
+          cluster.sendGetRequest(
+              serviceName, 0, "/api/v2/services/" + serviceName + "/replica/info");
+      assertEquals(200, infoResponse.statusCode(), "replica/info failed: " + infoResponse.body());
+
+      JSONObject info = new JSONObject(infoResponse.body());
+      assertEquals(
+          "LazyReplicaCoordinator",
+          info.getString("protocol"),
+          "EVENTUAL service must use the LazyReplicaCoordinator: " + infoResponse.body());
+      assertEquals(
+          "EVENTUAL",
+          info.getString("consistency").toUpperCase(),
+          "unexpected consistency: " + infoResponse.body());
+    }
+  }
+
+  private HttpResponse<String> sendPostRequest(
+      XdnTestCluster cluster, String serviceName, int replicaIdx, String endpoint)
+      throws IOException, InterruptedException {
+    int httpPort = cluster.getActiveHttpPort("AR" + replicaIdx);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + httpPort + endpoint))
+            .timeout(XdnTestCluster.REQUEST_TIMEOUT)
+            .header("XDN", serviceName)
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
Implements the eventual-consistency protocol as described in the ReFlex paper (§2.4.2, "Eventual: anti-entropy"): convergence to byte-identical state for **any** service, non-deterministic and non-monotonic included.

## Protocol
- Each replica maintains a per-service **vector clock** of applied writes and **retains its own executed writes** until every peer's clock covers them (classic vector-clock GC).
- The existing write-after broadcast stays as a best-effort **fast path**: peers apply a forwarded write only when contiguous with their clock, otherwise drop it.
- **Periodic anti-entropy** (`XDN_EVENTUAL_ANTI_ENTROPY_INTERVAL_MS`, default 5s): replicas exchange `(vector clock, state digest)` in `LazySyncPacket`s. A replica that detects itself as the **frontier** relative to a peer (larger clock sum, ties by node id) captures a whole-state checkpoint and ships it (`LazyCheckpointPacket`, inline up to `XDN_EVENTUAL_CHECKPOINT_INLINE_MAX_BYTES`, LargeCheckpointer handle beyond).
- The receiver installs the checkpoint (container stop → state-dir replace → start → readiness wait), adopts the checkpoint clock, and **re-applies its own writes the checkpoint lacks**. At equal clocks, a digest mismatch forces one final verbatim transfer from the tie-break winner, which is what makes non-deterministic replicas byte-identical.
- Strict install rule rejects stale/dominated checkpoints (never regresses a foreign clock component; never installs below the pruned own-write log).

## Wiring
- `consistency=eventual` now **always** routes to `LazyReplicaCoordinator`: the old exact `{MONOTONIC, READ_ONLY, WRITE_ONLY}` behavior gate is gone, and the non-deterministic short-circuit to primary-backup no longer overrides an explicit EVENTUAL declaration (primary-backup remains the default only for strong consistency on non-deterministic services).
- Checkpoint capture/restore/digest is exposed via a new `CheckpointableApplication` interface (implemented by `XdnGigapaxosApp` with the existing rsync/zip machinery), keeping `eventual/` decoupled from `xdn/`.

## CI
- New `XdnEventualConvergenceTest` (added to the integration matrix): diverges three replicas of the non-deterministic `fadhilkurnia/xdn-randstate` service with direct per-replica writes, then asserts all replicas eventually report the same state `/hash`, plus stability after three more rounds; a second method asserts `replica/info` reports `protocol=LazyReplicaCoordinator`.
- Locally: convergence test 2/2 passed, `XdnEventualConsistencyBatchingTest` and `XdnGetReplicaInfoTest` regressions pass, google-java-format clean.

## Known limitations (by design, documented in the class javadoc)
- Protocol state is in-memory: a replica process restart rejoins with a zeroed clock and re-adopts its own component from the first installed checkpoint.
- Epoch/membership changes reset protocol state; packets carry the epoch and mismatches are dropped (reconfiguration continues to use the existing final-state path).
- Convergence liveness assumes replicas eventually communicate.
- State digests of database-backed services may differ transiently (e.g., WAL files) causing extra reconciliation rounds; bounded by per-(clock,digest) ship dedup with a 3-interval backoff.