### PR TITLE
Feat/xdnd modif

### DIFF
--- a/bin/gpServer.sh
+++ b/bin/gpServer.sh
@@ -324,10 +324,10 @@ trim_file_list "$conf_transferrables"
 
 # prepare ssh args if `SSH_KEY_PATH` envvar is set
 SSH_KEY_PATH_ARG=""
-RSYNC_SSH_KEY_PATH_ARG=""
+RSYNC_SSH_KEY_PATH_ARG=()
 if [[ ! -z $SSH_KEY_PATH ]]; then
   SSH_KEY_PATH_ARG="-i $SSH_KEY_PATH"
-  RSYNC_SSH_KEY_PATH_ARG="-e 'ssh -x -i $SSH_KEY_PATH -o StrictHostKeyChecking=no'"
+  RSYNC_SSH_KEY_PATH_ARG=(-e "ssh -x -i $SSH_KEY_PATH -o StrictHostKeyChecking=no")
 fi
 
 # disabling warnings to prevent manual override; can supply ssh keys
@@ -336,7 +336,7 @@ fi
 SSH="ssh $SSH_KEY_PATH_ARG -x -o StrictHostKeyChecking=no"
 
 RSYNC_PATH="mkdir -p $INSTALL_PATH $INSTALL_PATH/$CONF"
-RSYNC="rsync --force -aL $RSYNC_SSH_KEY_PATH_ARG "
+RSYNC=(rsync --force -aL "${RSYNC_SSH_KEY_PATH_ARG[@]}")
 
 # get username from (1) environment variable GP_USERNAME, (2) from
 # gigapaxos properties file, or (3) from whoami
@@ -393,9 +393,9 @@ function rsync_symlink {
   address=$1
   print 1 "Transferring conf files to $address:$INSTALL_PATH"
 
-  print 2 "$RSYNC --rsync-path=\"$RSYNC_PATH $LINK_CMD && rsync\" \
+  print 2 "${RSYNC[*]} --rsync-path=\"$RSYNC_PATH $LINK_CMD && rsync\" \
     $conf_transferrables $username@$address:$INSTALL_PATH/$CONF/"
-  $RSYNC --rsync-path="$RSYNC_PATH $LINK_CMD && rsync" \
+  "${RSYNC[@]}" --rsync-path="$RSYNC_PATH $LINK_CMD && rsync" \
     $conf_transferrables $username@$address:$INSTALL_PATH/$CONF/
 }
 
@@ -483,10 +483,10 @@ function start_server {
     non_local="$server=$addressport $non_local"
     echo "Starting remote server $server"
     print 1 "Transferring jar files $jar_files to $address:$INSTALL_PATH"
-    print 2 "$RSYNC --rsync-path=\"$RSYNC_PATH && rsync\" \
+    print 2 "${RSYNC[*]} --rsync-path=\"$RSYNC_PATH && rsync\" \
       $jar_files $username@$address:$INSTALL_PATH/jars/ "
-    $RSYNC --rsync-path="$RSYNC_PATH && rsync" \
-      $jar_files $username@$address:$INSTALL_PATH/jars/ 
+    "${RSYNC[@]}" --rsync-path="$RSYNC_PATH && rsync" \
+      $jar_files $username@$address:$INSTALL_PATH/jars/
     rsync_symlink $address
 
     # then start remote server
@@ -494,13 +494,13 @@ function start_server {
       $JAVA $DEBUG_ARGS $REMOTE_JVMARGS \
       -cp \`ls jars/*|awk '{printf \$0\":\"}'\` \
       edu.umass.cs.reconfiguration.ReconfigurableNode \
-      $APP_ARGS $server \""
+      $APP_ARGS SSH_KEY_PATH=/users/$username/.ssh/xdn_ssh_key $server \""
     
     $SSH $username@$address "cd $INSTALL_PATH; sudo \
       $JAVA $DEBUG_ARGS $REMOTE_JVMARGS \
       -cp \`ls jars/*|awk '{printf \$0\":\"}'\` \
       edu.umass.cs.reconfiguration.ReconfigurableNode \
-      $APP_ARGS $server "&
+      $APP_ARGS SSH_KEY_PATH=/users/$username/.ssh/xdn_ssh_key $server "&
   fi
 }
 

--- a/bin/gpServer.sh
+++ b/bin/gpServer.sh
@@ -154,7 +154,9 @@ for arg in "$@"; do
     value=`echo $arg|grep "\-D.*="|sed s/-D//g|sed s/.*=//g`
     if [[ $key == "gigapaxosConfig" ]]; then
       GP_PROPERTIES=$value
-    elif [[ ! -z `echo $arg|grep "\-D$APP_RESOURCES_KEY="` ]]; 
+    elif [[ $key == "xdnConfig" ]]; then
+      XDN_CONFIG_SET=true
+    elif [[ ! -z `echo $arg|grep "\-D$APP_RESOURCES_KEY="` ]];
     then
       # app args
       APP_RESOURCES="`echo $arg|grep "\-D$APP_RESOURCES_KEY="|\
@@ -489,18 +491,24 @@ function start_server {
       $jar_files $username@$address:$INSTALL_PATH/jars/
     rsync_symlink $address
 
+    # after
+    REMOTE_APP_ARGS="$APP_ARGS"
+    if [[ $XDN_CONFIG_SET == true ]]; then
+      REMOTE_APP_ARGS="$REMOTE_APP_ARGS SSH_KEY_PATH=/users/$username/.ssh/xdn_ssh_key"
+    fi
+
     # then start remote server
     print 2 "$SSH $username@$address \"cd $INSTALL_PATH; nohup \
       $JAVA $DEBUG_ARGS $REMOTE_JVMARGS \
       -cp \`ls jars/*|awk '{printf \$0\":\"}'\` \
       edu.umass.cs.reconfiguration.ReconfigurableNode \
-      $APP_ARGS SSH_KEY_PATH=/users/$username/.ssh/xdn_ssh_key $server \""
+      $REMOTE_APP_ARGS $server \""
     
     $SSH $username@$address "cd $INSTALL_PATH; sudo \
       $JAVA $DEBUG_ARGS $REMOTE_JVMARGS \
       -cp \`ls jars/*|awk '{printf \$0\":\"}'\` \
       edu.umass.cs.reconfiguration.ReconfigurableNode \
-      $APP_ARGS SSH_KEY_PATH=/users/$username/.ssh/xdn_ssh_key $server "&
+      $REMOTE_APP_ARGS $server "&
   fi
 }
 

--- a/bin/xdnd
+++ b/bin/xdnd
@@ -375,9 +375,12 @@ function do_clear_all() {
   CONFIG_DIR=$(cd "$(dirname "$CONFIG")" && pwd)
   local CONFIG_ABS="$CONFIG_DIR/$(basename "$CONFIG")"
 
-  local XDN_CONFIG_DIR
-  XDN_CONFIG_DIR=$(cd "$(dirname "$XDN_CONFIG")" && pwd)
-  local XDN_CONFIG_ABS="$XDN_CONFIG_DIR/$(basename "$XDN_CONFIG")"
+  local XDN_CONFIG_ABS=""
+  if [ -n "$XDN_CONFIG" ]; then
+    local XDN_CONFIG_DIR
+    XDN_CONFIG_DIR=$(cd "$(dirname "$XDN_CONFIG")" && pwd)
+    XDN_CONFIG_ABS="$XDN_CONFIG_DIR/$(basename "$XDN_CONFIG")"
+  fi
 
   local GPSERVER="$XDN_SRC_PATH/bin/gpServer.sh"
   if [ ! -x "$GPSERVER" ]; then
@@ -386,14 +389,19 @@ function do_clear_all() {
   fi
 
   echo " - config file     : ${CONFIG_ABS}"
-  echo " - xdn config file : ${XDN_CONFIG_ABS}"
+  echo " - xdn config file : ${XDN_CONFIG_ABS:-<none>}"
   echo " - ssh key         : ${SSH_KEY}"
   echo " - username        : ${USERNAME}"
   echo ""
   echo "Invoking gpServer to force-clear all nodes ..."
 
+  local GP_ARGS=("-DgigapaxosConfig=$CONFIG_ABS")
+  if [ -n "$XDN_CONFIG_ABS" ]; then
+    GP_ARGS+=("-DxdnConfig=$XDN_CONFIG_ABS")
+  fi
+
   SSH_KEY_PATH="$SSH_KEY" GP_USERNAME="$USERNAME" "$GPSERVER" \
-    "-DgigapaxosConfig=$CONFIG_ABS" "-DxdnConfig=$XDN_CONFIG_ABS" forceclear all
+    "${GP_ARGS[@]}" forceclear all
   local gp_exit=$?
 
   # wipe leftover fuselog/state directories on every node after forceclear,
@@ -407,7 +415,7 @@ function do_clear_all() {
   for ip in "${unique_ips[@]}"; do
     if ! ssh -i "$ssh_key_expanded" -o StrictHostKeyChecking=no "$USERNAME@$ip" '
         mount | awk "\$5 == \"fuse.fuselog\" {print \$3}" | xargs -r -n1 sudo fusermount3 -u
-        sudo rm -rf /tmp/xdn /tmp/xdn2 ~/XdnApp
+        sudo rm -rf /tmp/xdn /tmp/xdn2 ~/XdnApp ~/XdnGigapaxosApp
       '; then
       echo " - $ip: failed to clean up (mount/state/XdnApp)" >&2
     fi

--- a/bin/xdnd
+++ b/bin/xdnd
@@ -245,6 +245,7 @@ function do_start_all() {
   local DEFAULT_XDN_CONFIG="./conf/xdn.properties"
   local CONFIG=$DEFAULT_CONFIG
   local XDN_CONFIG=$DEFAULT_XDN_CONFIG
+  local XDN_CONFIG_SET=0
   local SSH_KEY=""
   local USERNAME=""
 
@@ -255,6 +256,7 @@ function do_start_all() {
       ;;
     -xdn-config=*)
       XDN_CONFIG="${ARG#*=}"
+      XDN_CONFIG_SET=1
       ;;
     -ssh-key=*)
       SSH_KEY="${ARG#*=}"
@@ -270,9 +272,12 @@ function do_start_all() {
     exit 1
   fi
 
-  if [ ! -f "$XDN_CONFIG" ]; then
+  if [ "$XDN_CONFIG_SET" -eq 1 ] && [ ! -f "$XDN_CONFIG" ]; then
     echo "XDN config file '$XDN_CONFIG' can not be found!"
     exit 1
+  fi
+  if [ "$XDN_CONFIG_SET" -eq 0 ] && [ ! -f "$XDN_CONFIG" ]; then
+    XDN_CONFIG=""
   fi
 
   if [ -z "$SSH_KEY" ]; then
@@ -289,9 +294,12 @@ function do_start_all() {
   CONFIG_DIR=$(cd "$(dirname "$CONFIG")" && pwd)
   local CONFIG_ABS="$CONFIG_DIR/$(basename "$CONFIG")"
 
-  local XDN_CONFIG_DIR
-  XDN_CONFIG_DIR=$(cd "$(dirname "$XDN_CONFIG")" && pwd)
-  local XDN_CONFIG_ABS="$XDN_CONFIG_DIR/$(basename "$XDN_CONFIG")"
+  local XDN_CONFIG_ABS=""
+  if [ -n "$XDN_CONFIG" ]; then
+    local XDN_CONFIG_DIR
+    XDN_CONFIG_DIR=$(cd "$(dirname "$XDN_CONFIG")" && pwd)
+    XDN_CONFIG_ABS="$XDN_CONFIG_DIR/$(basename "$XDN_CONFIG")"
+  fi
 
   local GPSERVER="$XDN_SRC_PATH/bin/gpServer.sh"
   if [ ! -x "$GPSERVER" ]; then
@@ -300,14 +308,19 @@ function do_start_all() {
   fi
 
   echo " - config file     : ${CONFIG_ABS}"
-  echo " - xdn config file : ${XDN_CONFIG_ABS}"
+  echo " - xdn config file : ${XDN_CONFIG_ABS:-<none>}"
   echo " - ssh key         : ${SSH_KEY}"
   echo " - username        : ${USERNAME}"
   echo ""
   echo "Invoking gpServer to start all nodes ..."
 
+  local GP_ARGS=("-DgigapaxosConfig=$CONFIG_ABS")
+  if [ -n "$XDN_CONFIG_ABS" ]; then
+    GP_ARGS+=("-DxdnConfig=$XDN_CONFIG_ABS")
+  fi
+
   SSH_KEY_PATH="$SSH_KEY" GP_USERNAME="$USERNAME" "$GPSERVER" \
-    "-DgigapaxosConfig=$CONFIG_ABS" "-DxdnConfig=$XDN_CONFIG_ABS" start all
+    "${GP_ARGS[@]}" start all
   exit $?
 }
 

--- a/bin/xdnd
+++ b/bin/xdnd
@@ -331,6 +331,7 @@ function do_clear_all() {
   local DEFAULT_XDN_CONFIG="./conf/xdn.properties"
   local CONFIG=$DEFAULT_CONFIG
   local XDN_CONFIG=$DEFAULT_XDN_CONFIG
+  local XDN_CONFIG_SET=0
   local SSH_KEY=""
   local USERNAME=""
 
@@ -341,6 +342,7 @@ function do_clear_all() {
       ;;
     -xdn-config=*)
       XDN_CONFIG="${ARG#*=}"
+      XDN_CONFIG_SET=1
       ;;
     -ssh-key=*)
       SSH_KEY="${ARG#*=}"
@@ -356,9 +358,12 @@ function do_clear_all() {
     exit 1
   fi
 
-  if [ ! -f "$XDN_CONFIG" ]; then
+  if [ "$XDN_CONFIG_SET" -eq 1 ] && [ ! -f "$XDN_CONFIG" ]; then
     echo "XDN config file '$XDN_CONFIG' can not be found!"
     exit 1
+  fi
+  if [ "$XDN_CONFIG_SET" -eq 0 ] && [ ! -f "$XDN_CONFIG" ]; then
+    XDN_CONFIG=""
   fi
 
   if [ -z "$SSH_KEY" ]; then

--- a/bin/xdnd
+++ b/bin/xdnd
@@ -186,6 +186,10 @@ function do_distributed_initialization() {
       prepare_remote_ssh_config "$machine" "$CONFIG" "$SSH_KEY" "$USERNAME"
       progress_line "$machine" "[ssh] ok"
 
+      progress_line "$machine" "[root-ssh] start"
+      prepare_remote_root_ssh_config "$machine" "$CONFIG" "$SSH_KEY" "$USERNAME"
+      progress_line "$machine" "[root-ssh] ok"
+
       progress_line "$machine" "[install] start"
       install_dependencies "$machine" "$SSH_KEY" "$USERNAME"
       progress_line "$machine" "[install] ok"
@@ -238,7 +242,9 @@ function do_start_all() {
   echo "Starting all gigapaxos servers defined in the config ..."
 
   local DEFAULT_CONFIG="./conf/gigapaxos.properties"
+  local DEFAULT_XDN_CONFIG="./conf/xdn.properties"
   local CONFIG=$DEFAULT_CONFIG
+  local XDN_CONFIG=$DEFAULT_XDN_CONFIG
   local SSH_KEY=""
   local USERNAME=""
 
@@ -246,6 +252,9 @@ function do_start_all() {
     case $ARG in
     -config=*)
       CONFIG="${ARG#*=}"
+      ;;
+    -xdn-config=*)
+      XDN_CONFIG="${ARG#*=}"
       ;;
     -ssh-key=*)
       SSH_KEY="${ARG#*=}"
@@ -258,6 +267,11 @@ function do_start_all() {
 
   if [ ! -f "$CONFIG" ]; then
     echo "Config file '$CONFIG' can not be found!"
+    exit 1
+  fi
+
+  if [ ! -f "$XDN_CONFIG" ]; then
+    echo "XDN config file '$XDN_CONFIG' can not be found!"
     exit 1
   fi
 
@@ -275,20 +289,118 @@ function do_start_all() {
   CONFIG_DIR=$(cd "$(dirname "$CONFIG")" && pwd)
   local CONFIG_ABS="$CONFIG_DIR/$(basename "$CONFIG")"
 
+  local XDN_CONFIG_DIR
+  XDN_CONFIG_DIR=$(cd "$(dirname "$XDN_CONFIG")" && pwd)
+  local XDN_CONFIG_ABS="$XDN_CONFIG_DIR/$(basename "$XDN_CONFIG")"
+
   local GPSERVER="$XDN_SRC_PATH/bin/gpServer.sh"
   if [ ! -x "$GPSERVER" ]; then
     echo "Unable to find executable gpServer at '$GPSERVER'"
     exit 1
   fi
 
-  echo " - config file : ${CONFIG_ABS}"
-  echo " - ssh key     : ${SSH_KEY}"
-  echo " - username    : ${USERNAME}"
+  echo " - config file     : ${CONFIG_ABS}"
+  echo " - xdn config file : ${XDN_CONFIG_ABS}"
+  echo " - ssh key         : ${SSH_KEY}"
+  echo " - username        : ${USERNAME}"
   echo ""
   echo "Invoking gpServer to start all nodes ..."
 
-  SSH_KEY_PATH="$SSH_KEY" GP_USERNAME="$USERNAME" "$GPSERVER" "-DgigapaxosConfig=$CONFIG_ABS" start all
+  SSH_KEY_PATH="$SSH_KEY" GP_USERNAME="$USERNAME" "$GPSERVER" \
+    "-DgigapaxosConfig=$CONFIG_ABS" "-DxdnConfig=$XDN_CONFIG_ABS" start all
   exit $?
+}
+
+function do_clear_all() {
+  echo "Force-clearing all gigapaxos servers defined in the config ..."
+
+  local DEFAULT_CONFIG="./conf/gigapaxos.properties"
+  local DEFAULT_XDN_CONFIG="./conf/xdn.properties"
+  local CONFIG=$DEFAULT_CONFIG
+  local XDN_CONFIG=$DEFAULT_XDN_CONFIG
+  local SSH_KEY=""
+  local USERNAME=""
+
+  for ARG in "$@"; do
+    case $ARG in
+    -config=*)
+      CONFIG="${ARG#*=}"
+      ;;
+    -xdn-config=*)
+      XDN_CONFIG="${ARG#*=}"
+      ;;
+    -ssh-key=*)
+      SSH_KEY="${ARG#*=}"
+      ;;
+    -username=*)
+      USERNAME="${ARG#*=}"
+      ;;
+    esac
+  done
+
+  if [ ! -f "$CONFIG" ]; then
+    echo "Config file '$CONFIG' can not be found!"
+    exit 1
+  fi
+
+  if [ ! -f "$XDN_CONFIG" ]; then
+    echo "XDN config file '$XDN_CONFIG' can not be found!"
+    exit 1
+  fi
+
+  if [ -z "$SSH_KEY" ]; then
+    echo "Please specify the ssh key with '-ssh-key=<location>' argument."
+    exit 1
+  fi
+
+  if [ -z "$USERNAME" ]; then
+    echo "Please specify the username with '-username=<name>' argument."
+    exit 1
+  fi
+
+  local CONFIG_DIR
+  CONFIG_DIR=$(cd "$(dirname "$CONFIG")" && pwd)
+  local CONFIG_ABS="$CONFIG_DIR/$(basename "$CONFIG")"
+
+  local XDN_CONFIG_DIR
+  XDN_CONFIG_DIR=$(cd "$(dirname "$XDN_CONFIG")" && pwd)
+  local XDN_CONFIG_ABS="$XDN_CONFIG_DIR/$(basename "$XDN_CONFIG")"
+
+  local GPSERVER="$XDN_SRC_PATH/bin/gpServer.sh"
+  if [ ! -x "$GPSERVER" ]; then
+    echo "Unable to find executable gpServer at '$GPSERVER'"
+    exit 1
+  fi
+
+  echo " - config file     : ${CONFIG_ABS}"
+  echo " - xdn config file : ${XDN_CONFIG_ABS}"
+  echo " - ssh key         : ${SSH_KEY}"
+  echo " - username        : ${USERNAME}"
+  echo ""
+  echo "Invoking gpServer to force-clear all nodes ..."
+
+  SSH_KEY_PATH="$SSH_KEY" GP_USERNAME="$USERNAME" "$GPSERVER" \
+    "-DgigapaxosConfig=$CONFIG_ABS" "-DxdnConfig=$XDN_CONFIG_ABS" forceclear all
+  local gp_exit=$?
+
+  # wipe leftover fuselog/state directories on every node after forceclear,
+  # so a fresh start-all doesn't inherit stale data from a prior run.
+  local ssh_key_expanded="${SSH_KEY/#\~/$HOME}"
+  local unique_ips=()
+  mapfile -t unique_ips < <(get_unique_ips_from_config "$CONFIG")
+
+  echo ""
+  echo "Unmounting any active fuselog mounts, then clearing state on all nodes ..."
+  for ip in "${unique_ips[@]}"; do
+    if ! ssh -i "$ssh_key_expanded" -o StrictHostKeyChecking=no "$USERNAME@$ip" '
+        mount | awk "\$5 == \"fuse.fuselog\" {print \$3}" | xargs -r -n1 sudo fusermount3 -u
+        sudo rm -rf /tmp/xdn /tmp/xdn2 ~/XdnApp
+      '; then
+      echo " - $ip: failed to clean up (mount/state/XdnApp)" >&2
+    fi
+  done
+
+  exit $gp_exit
 }
 
 function do_start_ar_instance() {
@@ -430,6 +542,57 @@ EOF
   rm -f "$tmp_config"
 
   return $err
+}
+
+function prepare_remote_root_ssh_config() {
+  if [ "$#" -lt 4 ]; then
+    echo "prepare_remote_root_ssh_config expects 4 args (node, config, ssh_key, username)" >&2
+    return 1
+  fi
+
+  local node=$1;
+  local config_file=$2;
+  local ssh_key=$3;
+  local username=$4;
+  local err=0
+
+  echo "Preparing root ssh access for machine $node ..."
+
+  ssh_key="${ssh_key/#\~/$HOME}"
+
+  local pub_key
+  pub_key=$(ssh-keygen -y -f "$ssh_key")
+
+  # stage the key under /tmp (user-writable), then use sudo remotely to
+  # move it into /root/.ssh, which the regular user can't write directly.
+  scp -i "$ssh_key" -o StrictHostKeyChecking=no "$ssh_key" "$username@$node:/tmp/xdn_ssh_key" || err=1
+  ssh -i "$ssh_key" -o StrictHostKeyChecking=no "$username@$node" "
+    echo '$pub_key' > /tmp/xdn_ssh_key.pub &&
+    sudo mkdir -p /root/.ssh &&
+    sudo chmod 700 /root/.ssh &&
+    sudo cp /tmp/xdn_ssh_key /root/.ssh/xdn_ssh_key &&
+    sudo chmod 600 /root/.ssh/xdn_ssh_key &&
+    cat /tmp/xdn_ssh_key.pub | sudo tee -a /root/.ssh/authorized_keys > /dev/null &&
+    sudo chmod 600 /root/.ssh/authorized_keys &&
+    sudo chown root:root /root/.ssh/xdn_ssh_key /root/.ssh/authorized_keys &&
+    rm -f /tmp/xdn_ssh_key /tmp/xdn_ssh_key.pub
+  " || err=1
+
+  return $err
+}
+
+function check_passwordless_sudo() {
+  if [ "$#" -lt 3 ]; then
+    echo "check_passwordless_sudo expects 3 args (node, ssh_key, username)" >&2
+    return 1
+  fi
+
+  local node=$1;
+  local ssh_key=$2;
+  local username=$3;
+
+  ssh_key="${ssh_key/#\~/$HOME}"
+  ssh -i "$ssh_key" -o StrictHostKeyChecking=no -o BatchMode=yes "$username@$node" "sudo -n true" 2>/dev/null
 }
 
 function prepare_local_ssh_config() {
@@ -636,7 +799,10 @@ function print_usage() {
   echo "   xdnd dist-init -config=gigapaxos.properties -ssh-key=/ssh/key -username=user"
   echo ""
   echo " To start all gigapaxos servers using gpServer:"
-  echo "   xdnd start-all -config=gigapaxos.properties -ssh-key=/ssh/key -username=user"
+  echo "   xdnd start-all -config=gigapaxos.properties -xdn-config=xdn.properties -ssh-key=/ssh/key -username=user"
+  echo ""
+  echo " To force-clear all gigapaxos servers using gpServer:"
+  echo "   xdnd clear-all -config=gigapaxos.properties -xdn-config=xdn.properties -ssh-key=/ssh/key -username=user"
   echo ""
   echo " To initialize distributed observability:"
   echo "   xdnd dist-init-observability -config=gigapaxos.properties -ssh-key=/ssh/key -username=user"
@@ -1065,7 +1231,7 @@ function main() {
 
   # parse the second param, i.e., the action.
   local SECOND_PARAM=$1
-  local VALID_ACTIONS=("dist-init" "dist-init-observability" "start-all" "init-driver" "start" "help" "check")
+  local VALID_ACTIONS=("dist-init" "dist-init-observability" "start-all" "clear-all" "init-driver" "start" "help" "check")
   if ! is_in_list "$SECOND_PARAM" "${VALID_ACTIONS[@]}"; then
     echo "Action '$SECOND_PARAM' is not a valid actions."
     echo "Valid actions are: start, check, dist-init, help."
@@ -1084,6 +1250,9 @@ function main() {
     ;;
   "start-all")
     do_start_all "$@"
+    ;;
+  "clear-all")
+    do_clear_all "$@"
     ;;
   "init-driver")
     do_init_driver "$@"

--- a/bin/xdnd
+++ b/bin/xdnd
@@ -429,6 +429,112 @@ function do_clear_all() {
   exit $gp_exit
 }
 
+# do_set_latency injects a uniform, static netem delay on every node's
+# experiment-subnet interface (auto-detected per node), before start-all.
+function do_set_latency() {
+  echo "Injecting uniform network latency on all nodes defined in the config ..."
+
+  local parsed_args
+  if ! parsed_args=$(parse_common_dist_args "$@"); then
+    exit 1
+  fi
+  read -r CONFIG SSH_KEY USERNAME <<<"$parsed_args"
+
+  local DELAY_MS=""
+  for ARG in "$@"; do
+    case $ARG in
+    -delay-ms=*)
+      DELAY_MS="${ARG#*=}"
+      ;;
+    esac
+  done
+  if [ -z "$DELAY_MS" ]; then
+    echo "Please specify the delay with '-delay-ms=<value>' argument." >&2
+    exit 1
+  fi
+
+  local ssh_key_expanded="${SSH_KEY/#\~/$HOME}"
+  local unique_ips=()
+  mapfile -t unique_ips < <(get_unique_ips_from_config "$CONFIG")
+  if [ ${#unique_ips[@]} -eq 0 ]; then
+    echo "No machines found in config '$CONFIG'." >&2
+    exit 1
+  fi
+
+  echo " - config file : ${CONFIG}"
+  echo " - ssh key     : ${SSH_KEY}"
+  echo " - username    : ${USERNAME}"
+  echo " - delay       : ${DELAY_MS}ms"
+  echo " - machines    :"
+  for ip in "${unique_ips[@]}"; do
+    echo "   - $ip"
+  done
+  echo ""
+
+  local failed=0
+  for ip in "${unique_ips[@]}"; do
+    local iface
+    iface=$(ssh -i "$ssh_key_expanded" -o StrictHostKeyChecking=no "$USERNAME@$ip" \
+      "ip -4 -o addr show | grep -F '$ip/' | awk '{print \$2}'")
+    if [ -z "$iface" ]; then
+      echo "[latency] $ip: could not detect interface for $ip" >&2
+      failed=1
+      continue
+    fi
+    echo "[latency] $ip: iface=$iface, setting delay=${DELAY_MS}ms"
+    if ! ssh -i "$ssh_key_expanded" -o StrictHostKeyChecking=no "$USERNAME@$ip" \
+      "sudo tc qdisc replace dev $iface root netem delay ${DELAY_MS}ms"; then
+      echo "[latency] $ip: failed to set qdisc" >&2
+      failed=1
+    fi
+  done
+
+  if [ $failed -ne 0 ]; then
+    echo ""
+    echo "[set-latency] completed with failures." >&2
+    exit 1
+  fi
+
+  echo ""
+  echo "[set-latency] ${DELAY_MS}ms delay set on all nodes."
+  exit 0
+}
+
+function do_clear_latency() {
+  echo "Clearing injected network latency on all nodes defined in the config ..."
+
+  local parsed_args
+  if ! parsed_args=$(parse_common_dist_args "$@"); then
+    exit 1
+  fi
+  read -r CONFIG SSH_KEY USERNAME <<<"$parsed_args"
+
+  local ssh_key_expanded="${SSH_KEY/#\~/$HOME}"
+  local unique_ips=()
+  mapfile -t unique_ips < <(get_unique_ips_from_config "$CONFIG")
+  if [ ${#unique_ips[@]} -eq 0 ]; then
+    echo "No machines found in config '$CONFIG'." >&2
+    exit 1
+  fi
+
+  for ip in "${unique_ips[@]}"; do
+    local iface
+    iface=$(ssh -i "$ssh_key_expanded" -o StrictHostKeyChecking=no "$USERNAME@$ip" \
+      "ip -4 -o addr show | grep -F '$ip/' | awk '{print \$2}'")
+    if [ -z "$iface" ]; then
+      echo "[latency] $ip: could not detect interface, skipping" >&2
+      continue
+    fi
+    echo "[latency] $ip: clearing qdisc on $iface"
+    ssh -i "$ssh_key_expanded" -o StrictHostKeyChecking=no "$USERNAME@$ip" \
+      "sudo tc qdisc del dev $iface root" 2>/dev/null
+  done
+
+  echo ""
+  echo "[clear-latency] done."
+  exit 0
+}
+
 function do_start_ar_instance() {
   echo "unimplemented"
 }
@@ -829,6 +935,12 @@ function print_usage() {
   echo ""
   echo " To force-clear all gigapaxos servers using gpServer:"
   echo "   xdnd clear-all -config=gigapaxos.properties -xdn-config=xdn.properties -ssh-key=/ssh/key -username=user"
+  echo ""
+  echo " To inject uniform network latency on all nodes:"
+  echo "   xdnd set-latency -config=gigapaxos.properties -ssh-key=/ssh/key -username=user -delay-ms=50"
+  echo ""
+  echo " To clear injected network latency on all nodes:"
+  echo "   xdnd clear-latency -config=gigapaxos.properties -ssh-key=/ssh/key -username=user"
   echo ""
   echo " To initialize distributed observability:"
   echo "   xdnd dist-init-observability -config=gigapaxos.properties -ssh-key=/ssh/key -username=user"
@@ -1257,7 +1369,7 @@ function main() {
 
   # parse the second param, i.e., the action.
   local SECOND_PARAM=$1
-  local VALID_ACTIONS=("dist-init" "dist-init-observability" "start-all" "clear-all" "init-driver" "start" "help" "check")
+  local VALID_ACTIONS=("dist-init" "dist-init-observability" "start-all" "clear-all" "set-latency" "clear-latency" "init-driver" "start" "help" "check")
   if ! is_in_list "$SECOND_PARAM" "${VALID_ACTIONS[@]}"; then
     echo "Action '$SECOND_PARAM' is not a valid actions."
     echo "Valid actions are: start, check, dist-init, help."
@@ -1279,6 +1391,12 @@ function main() {
     ;;
   "clear-all")
     do_clear_all "$@"
+    ;;
+  "set-latency")
+    do_set_latency "$@"
+    ;;
+  "clear-latency")
+    do_clear_latency "$@"
     ;;
   "init-driver")
     do_init_driver "$@"


### PR DESCRIPTION
- Added ssh key support for xdnd. Made for root user. The ssh key only needed to be copied over to the driver machine. Then `xdnd` will handle sending the ssh-key to all the nodes automatically, including root user support for the ssh-key
- Fixed rsync ssh key issue in gpServer.sh
- Added `clear-all` to remove deployment state on all machine
Note 1: `start-all` and `clear-all` only works on remote machine. Use `gpServer.sh` for local deployment of XDN
Note 2: because `xdnd` deploys XDN using root user, when inspecting the docker containers in the active replicas, sudo is required to run docker
```
./bin/xdnd dist-init -config=conf/gigapaxos.properties -ssh-key=path/to/ssh-key -username=user

./bin/xdnd start-all -config=conf/gigapaxos.properties -ssh-key=path/to/ssh-key -username=user

./bin/xdnd clear-all -config=conf/gigapaxos.properties -ssh-key=path/to/ssh-key -username=user
```