### PR TITLE
bookcatalog-nd add requestId logging using X-XDN-ReqId header

### DIFF
--- a/services/bookcatalog-nd/main.go
+++ b/services/bookcatalog-nd/main.go
@@ -21,7 +21,11 @@ func loggingMiddleware(next http.Handler) http.Handler {
 
 		// Calculate duration and log
 		duration := time.Since(start)
-		log.Printf("%s %s [lat=%v]", r.Method, r.URL.Path, duration)
+		reqId := r.Header.Get("X-XDN-ReqId")
+		if reqId == "" {
+			reqId = "-"
+		}
+		log.Printf("%s %s [reqId=%s] [lat=%v]", r.Method, r.URL.Path, reqId, duration)
 	})
 }
 


### PR DESCRIPTION
Very small change. Modified bookcatalog-nd application to always log requestId.
This is used for the end-to-end latency breakdown because there is a 1ms (p50) to 9ms (p95) overhead when forwarding HTTP requests from XDN to the docker container