### PR TITLE
Runtime active-replication → primary-backup protocol switch (1/3: mechanism)

### DIFF
--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -1258,14 +1258,21 @@ public class Reconfigurator<NodeIDType> implements
             newActives.add(nodeIdDeserialized.valueOf(nodeId));
         }
 
-        // parse the preferred coordinator as metadata within initial state
-        // checkout XdnGeoDemandProfiler for the similar placement metadata
+        // parse the preferred coordinator and/or replication mode as metadata within
+        // initial state; checkout XdnGeoDemandProfiler for the similar placement metadata
         String placementMetadata = null;
-        if (preferredCoordinatorId != null) {
+        String replicationMode = request.getReplicationMode();
+        if (preferredCoordinatorId != null || replicationMode != null) {
             JSONObject metadataJson = new JSONObject();
             try {
-                metadataJson.put(AbstractDemandProfile.Keys.PREFERRED_COORDINATOR.toString(),
-                        preferredCoordinatorId);
+                if (preferredCoordinatorId != null) {
+                    metadataJson.put(AbstractDemandProfile.Keys.PREFERRED_COORDINATOR.toString(),
+                            preferredCoordinatorId);
+                }
+                if (replicationMode != null) {
+                    metadataJson.put(AbstractDemandProfile.Keys.REPLICATION_MODE.toString(),
+                            replicationMode);
+                }
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }

--- a/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpReconfigurator.java
@@ -865,9 +865,11 @@ public class HttpReconfigurator {
             // Parse active names from the body
             // example: `{"NODES" : ["AR0", "AR2", "AR3"]}`
             // example: `{"NODES" : ["AR0", "AR2", "AR3"], "COORDINATOR": "AR0"}`
+            // example: `{"NODES" : ["AR0", "AR2", "AR3"], "REPLICATION": "primary-backup"}`
             String contentBody = content.content().toString(StandardCharsets.ISO_8859_1);
             Set<String> nodeIds = new HashSet<>();
             String coordinatorId = null;
+            String replicationMode = null;
             try {
                 JSONObject contentJson = new JSONObject(contentBody);
                 JSONArray nodeIdArray = contentJson.getJSONArray("NODES");
@@ -877,12 +879,14 @@ public class HttpReconfigurator {
                 }
                 coordinatorId = contentJson.has("COORDINATOR") ?
                         contentJson.getString("COORDINATOR") : null;
+                replicationMode = contentJson.has("REPLICATION") ?
+                        contentJson.getString("REPLICATION") : null;
             } catch (JSONException e) {
                 return null;
             }
 
             return new SetReplicaPlacementRequest(
-                    sender, serviceName, nodeIds, coordinatorId);
+                    sender, serviceName, nodeIds, coordinatorId, replicationMode);
         }
 
         private GetReplicaPlacementRequest parseGetReplicaPlacementRequest(InetSocketAddress sender,

--- a/src/edu/umass/cs/reconfiguration/reconfigurationpackets/SetReplicaPlacementRequest.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationpackets/SetReplicaPlacementRequest.java
@@ -11,21 +11,34 @@ public class SetReplicaPlacementRequest extends ClientReconfigurationPacket {
     private final Set<String> newReplicaPlacement;
     private final String coordinatorNodeId;
 
+    /**
+     * Optional replication-mode override for the new epoch: "active" or "primary-backup".
+     * Rides the placement metadata so a protocol switch is just an in-place placement update.
+     */
+    private final String replicationMode;
+
     public SetReplicaPlacementRequest(InetSocketAddress initiator,
                                       String name,
                                       Set<String> placement) {
-        super(initiator, PacketType.SET_REPLICA_PLACEMENT_REQUEST, name, 0);
-        this.newReplicaPlacement = placement;
-        this.coordinatorNodeId = null;
+        this(initiator, name, placement, null, null);
     }
 
     public SetReplicaPlacementRequest(InetSocketAddress initiator,
                                       String name,
                                       Set<String> placement,
                                       String coordinatorNodeId) {
+        this(initiator, name, placement, coordinatorNodeId, null);
+    }
+
+    public SetReplicaPlacementRequest(InetSocketAddress initiator,
+                                      String name,
+                                      Set<String> placement,
+                                      String coordinatorNodeId,
+                                      String replicationMode) {
         super(initiator, PacketType.SET_REPLICA_PLACEMENT_REQUEST, name, 0);
         this.newReplicaPlacement = placement;
         this.coordinatorNodeId = coordinatorNodeId;
+        this.replicationMode = replicationMode;
     }
 
     public Set<String> getNewReplicaPlacement() {
@@ -36,11 +49,16 @@ public class SetReplicaPlacementRequest extends ClientReconfigurationPacket {
         return coordinatorNodeId;
     }
 
+    public String getReplicationMode() {
+        return replicationMode;
+    }
+
     @Override
     public JSONObject toJSONObjectImpl() throws JSONException {
         JSONObject jsonObject = super.toJSONObjectImpl();
         jsonObject.put("PLACEMENT", newReplicaPlacement);
         jsonObject.put("COORDINATOR", coordinatorNodeId);
+        jsonObject.put("REPLICATION", replicationMode);
         return jsonObject;
     }
 }

--- a/src/edu/umass/cs/reconfiguration/reconfigurationutils/AbstractDemandProfile.java
+++ b/src/edu/umass/cs/reconfiguration/reconfigurationutils/AbstractDemandProfile.java
@@ -66,7 +66,8 @@ public abstract class AbstractDemandProfile {
 
 	public static enum Keys {
 		SERVICE_NAME,
-		PREFERRED_COORDINATOR
+		PREFERRED_COORDINATOR,
+		REPLICATION_MODE
 	};
 
 	protected final String name;

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -577,8 +577,11 @@ public class XdnGigapaxosApp
     }
 
     // Case-6: handle create service for non-deterministic initialization in primary-backup.
+    // Keep the prefix intact: createServiceInstance() strips it itself and uses it as the
+    // signal that this instance is primary-backup-managed (recorder setup + sticky
+    // replication mode). Stripping here made a switched deterministic service look like a
+    // plain active-replication create, whose raw mount wipe destroyed the restored state.
     if (state.startsWith(ServiceProperty.NON_DETERMINISTIC_CREATE_PREFIX)) {
-      state = state.substring(ServiceProperty.NON_DETERMINISTIC_CREATE_PREFIX.length());
       boolean isServiceCreated = createServiceInstance(name, state);
       if (!isServiceCreated) {
         throw new RuntimeException(
@@ -590,7 +593,10 @@ public class XdnGigapaxosApp
     // Case-7: handle start Fuselog in backup (non-deterministic init)
     if (state.startsWith(ServiceProperty.NON_DETERMINISTIC_START_BACKUP_PREFIX)) {
       System.out.println("Running postInitialization() in backup");
-      int placementEpoch = 0;
+      // Use the instance's actual placement epoch: after a reconfiguration (or a
+      // protocol switch) the backup's recorder lives at e<epoch>, not e0.
+      Integer currentEpoch = this.getEpoch(name);
+      int placementEpoch = currentEpoch != null ? currentEpoch : 0;
 
       return this.stateDiffRecorder.postInitialization(name, placementEpoch);
     }
@@ -721,14 +727,22 @@ public class XdnGigapaxosApp
    *     prefix.
    */
   private boolean createServiceInstance(String serviceName, String initialState) {
+    // The PBM prefixes its create/restore calls, so the prefix (not the service's
+    // determinism flag) is the authoritative signal that this instance is
+    // primary-backup-managed and needs the statediff recorder. A deterministic service
+    // switched onto primary-backup via a replication-mode override arrives here with
+    // deterministic=true but still requires recorder initialization.
+    boolean isPrimaryBackupManaged = false;
     if (initialState.startsWith(ServiceProperty.NON_DETERMINISTIC_CREATE_PREFIX)) {
       initialState =
           initialState.substring(ServiceProperty.NON_DETERMINISTIC_CREATE_PREFIX.length());
+      isPrimaryBackupManaged = true;
     }
 
     if (initialState.startsWith(ServiceProperty.NON_DETERMINISTIC_START_BACKUP_PREFIX)) {
       initialState =
           initialState.substring(ServiceProperty.NON_DETERMINISTIC_START_BACKUP_PREFIX.length());
+      isPrimaryBackupManaged = true;
     }
 
     // validate the initial state
@@ -765,6 +779,11 @@ public class XdnGigapaxosApp
       } catch (JSONException e) {
         throw new RuntimeException(e);
       }
+      if (isPrimaryBackupManaged) {
+        // Record the mode on the property so every downstream recorder guard sees it and
+        // so getFinalState() embeds it, making a protocol switch sticky across epochs.
+        property.setReplicationMode("primary-backup");
+      }
 
       // Cluster reconfiguration is deferred (Component 6): the xdn:final: branch needs to
       // recompute the persistent ordinal map, signal XDN_CLUSTER_PHASE=join for fresh
@@ -779,17 +798,19 @@ public class XdnGigapaxosApp
                 + " — pin placement at launch (Component 6 follow-up)");
       }
 
-      // prepare statediff directory, if required
+      // prepare statediff directory, if required (a PB-managed instance needs the
+      // recorder regardless of determinism -- see isPrimaryBackupManaged above)
+      boolean needsRecorder = needsStateDiffRecorder(property);
       String stateDirMountSource =
           stateDiffRecorder.getTargetDirectory(serviceName, newPlacementEpoch);
       String stateDirMountTarget = property.getStatefulComponentDirectory();
-      if (!property.isDeterministic()) {
+      if (needsRecorder) {
         stateDiffRecorder.preInitialization(serviceName, newPlacementEpoch);
       }
 
       // Validates the previous epoch final state, then put it into the to-be-mounted dir.
       // First, prepare the mounted dir.
-      if (!property.isDeterministic()) {
+      if (needsRecorder) {
         stateDiffRecorder.removeServiceRecorder(serviceName, newPlacementEpoch);
       }
       String mountDir = stateDiffRecorder.getTargetDirectory(serviceName, newPlacementEpoch);
@@ -848,6 +869,9 @@ public class XdnGigapaxosApp
         property = ServiceProperty.createFromJsonString(initialState);
       } catch (JSONException e) {
         throw new RuntimeException("Invalid initial state as JSON: " + e);
+      }
+      if (isPrimaryBackupManaged) {
+        property.setReplicationMode("primary-backup");
       }
 
       // Cluster services share a swarm overlay so peers see each other at replica-N;
@@ -974,7 +998,10 @@ public class XdnGigapaxosApp
 
     // TODO: Fix ordering. Must be:
     // preInitialization -> startContainer -> postInitialization
-    if (!service.property.isDeterministic()) {
+    // A PB-managed instance (non-deterministic, or deterministic after a protocol switch)
+    // must use the recorder's preserve-aware initialization: the raw wipe below would
+    // destroy state that a reconfiguration just restored into the mount dir.
+    if (needsStateDiffRecorder(service.property)) {
       stateDiffRecorder.preInitialization(serviceName, initialPlacementEpoch);
       stateDiffRecorder.postInitialization(serviceName, initialPlacementEpoch);
     } else {
@@ -1338,6 +1365,16 @@ public class XdnGigapaxosApp
    * @param placementEpoch
    * @return
    */
+  /**
+   * True when this instance requires the statediff recorder: either the service is
+   * non-deterministic (primary-backup is the only strong-consistency option) or its replication
+   * mode was explicitly set to primary-backup (e.g., a deterministic service switched off active
+   * replication).
+   */
+  private static boolean needsStateDiffRecorder(ServiceProperty property) {
+    return !property.isDeterministic() || "primary-backup".equals(property.getReplicationMode());
+  }
+
   private boolean reviveContainerizedService(
       String serviceName,
       String encodedServiceProperty,
@@ -1363,18 +1400,24 @@ public class XdnGigapaxosApp
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }
+    // This revive path is only ever entered from the PrimaryBackupManager (the
+    // nondeter-prefixed restore), so the instance is primary-backup-managed regardless of
+    // the service's determinism flag -- a deterministic service arrives here after a
+    // replication-mode switch. Recording the mode on the property makes every recorder
+    // guard below correct and makes getFinalState() embed it (sticky across epochs).
+    property.setReplicationMode("primary-backup");
 
     // prepare statediff directory, if required
     String stateDirMountSource = stateDiffRecorder.getTargetDirectory(serviceName, placementEpoch);
     String stateDirMountTarget = property.getStatefulComponentDirectory();
-    if (!property.isDeterministic()) {
+    if (needsStateDiffRecorder(property)) {
       stateDiffRecorder.preInitialization(serviceName, placementEpoch);
     }
 
     // Validates the previous epoch final state, then put it into the to-be-mounted dir.
     // First, prepare the mounted dir.
     // TODO: test with fuse
-    if (!property.isDeterministic()) {
+    if (needsStateDiffRecorder(property)) {
       stateDiffRecorder.removeServiceRecorder(serviceName, placementEpoch);
     }
     String mountDir = stateDiffRecorder.getTargetDirectory(serviceName, placementEpoch);
@@ -1504,7 +1547,7 @@ public class XdnGigapaxosApp
       System.err.println(
           "WARNING: non-deterministic service can generate different " + "initial state");
     }
-    if (!property.isDeterministic()) {
+    if (needsStateDiffRecorder(property)) {
       stateDiffRecorder.postInitialization(serviceName, placementEpoch);
     }
 

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -23,6 +23,7 @@ import edu.umass.cs.reconfiguration.PaxosReplicaCoordinator;
 import edu.umass.cs.reconfiguration.reconfigurationpackets.ClientReconfigurationPacket;
 import edu.umass.cs.reconfiguration.reconfigurationpackets.ReplicableClientRequest;
 import edu.umass.cs.reconfiguration.reconfigurationpackets.SetCoordinatorNodeRequest;
+import edu.umass.cs.reconfiguration.reconfigurationutils.AbstractDemandProfile;
 import edu.umass.cs.reconfiguration.reconfigurationutils.RequestParseException;
 import edu.umass.cs.sequential.AwReplicaCoordinator;
 import edu.umass.cs.xdn.cluster.StatefulClusterReplicaCoordinator;
@@ -716,6 +717,28 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
       throw new RuntimeException(e);
     }
 
+    // A replication-mode override riding the placement metadata switches the service's
+    // protocol for this and subsequent epochs: the updated property is stored below and
+    // round-trips through every future epoch's final state (like the cluster ordinal map),
+    // so the switch is sticky until overridden again.
+    if (placementMetadata != null && !placementMetadata.isEmpty()) {
+      try {
+        JSONObject metadataJson = new JSONObject(placementMetadata);
+        String modeKey = AbstractDemandProfile.Keys.REPLICATION_MODE.toString();
+        if (metadataJson.has(modeKey) && !metadataJson.isNull(modeKey)) {
+          serviceProperty.setReplicationMode(metadataJson.getString(modeKey));
+          logger.log(
+              Level.INFO,
+              "{0}:XdnReplicaCoordinator - replication mode override for {1}: {2} (epoch={3})",
+              new Object[] {
+                myNodeID, serviceName, serviceProperty.getReplicationMode(), placementEpoch
+              });
+        }
+      } catch (JSONException e) {
+        logger.log(Level.WARNING, "Ignoring unparseable placement metadata: " + placementMetadata);
+      }
+    }
+
     // Infer the replica coordinator based on the declared properties
     AbstractReplicaCoordinator<NodeIDType> coordinator =
         inferCoordinatorByProperties(serviceProperty);
@@ -797,6 +820,22 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
     // meaningless for a self-clustering service.
     if (serviceProperties.isClusterManaged()) {
       return this.statefulClusterCoordinator;
+    }
+
+    // An explicit replication-mode override (set at launch or via a placement update with
+    // REPLICATION) takes precedence over the determinism/consistency inference below. Active
+    // replication replays every request at every replica and therefore requires determinism;
+    // primary-backup executes once and ships statediffs, so it is always legal.
+    String replicationOverride = serviceProperties.getReplicationMode();
+    if (replicationOverride != null) {
+      if (replicationOverride.equals("primary-backup")) {
+        return this.primaryBackupCoordinator;
+      }
+      if (replicationOverride.equals("active")) {
+        assert serviceProperties.isDeterministic()
+            : "active replication requires a deterministic service";
+        return this.paxosCoordinator;
+      }
     }
 
     // An explicitly declared EVENTUAL consistency always uses the anti-entropy

--- a/src/edu/umass/cs/xdn/recorder/RsyncStateDiffRecorder.java
+++ b/src/edu/umass/cs/xdn/recorder/RsyncStateDiffRecorder.java
@@ -183,6 +183,15 @@ public class RsyncStateDiffRecorder extends AbstractStateDiffRecorder {
     String targetDiffFile =
         String.format("%s%s/e%d.diff", this.baseDiffDirPath, serviceName, placementEpoch);
 
+    // Self-sufficient directory setup: capture must not depend on which initialization
+    // path ran before it (fresh create, reconfiguration revive, or a protocol switch onto
+    // primary-backup). rsync only creates the final path component, so missing parents
+    // (snp/<svc>/, diff/<svc>/) otherwise fail the batch with exit 12. Against a fresh
+    // empty snapshot the first diff simply carries the full current state, which applies
+    // cleanly on backups restored from the same epoch final state.
+    Shell.runCommand("mkdir -p " + targetDestDir);
+    Shell.runCommand("mkdir -p " + String.format("%s%s/", this.baseDiffDirPath, serviceName));
+
     String command =
         String.format(
             "%s -ar --write-batch=%s %s %s",
@@ -220,6 +229,11 @@ public class RsyncStateDiffRecorder extends AbstractStateDiffRecorder {
         String.format("%s%s/e%d/", this.baseMountDirPath, serviceName, placementEpoch);
     String targetDiffFile =
         String.format("%s%s/e%d.diff", this.baseDiffDirPath, serviceName, placementEpoch);
+
+    // Same self-sufficiency as captureStateDiff: a backup applying its first diff after a
+    // reconfiguration or protocol switch may not have the diff/mnt trees yet.
+    Shell.runCommand("mkdir -p " + String.format("%s%s/", this.baseDiffDirPath, serviceName));
+    Shell.runCommand("mkdir -p " + targetDir);
 
     int retCode = Shell.runCommand("rm -rf " + targetDiffFile);
     assert retCode == 0;

--- a/src/edu/umass/cs/xdn/service/ServiceProperty.java
+++ b/src/edu/umass/cs/xdn/service/ServiceProperty.java
@@ -47,6 +47,15 @@ public class ServiceProperty {
    */
   private Map<String, Integer> ordinalMap;
 
+  /**
+   * Optional replication-mode override: "active" (replicate the request, every replica executes) or
+   * "primary-backup" (execute once, replicate the statediff). Null means infer from determinism and
+   * consistency as before. Mutable so a dynamic protocol switch can flip it between placement
+   * epochs (it rides the placement metadata into the next epoch and then round-trips through the
+   * epoch final state like the ordinal map).
+   */
+  private String replicationMode;
+
   private ServiceProperty(
       String serviceName,
       boolean isDeterministic,
@@ -276,6 +285,12 @@ public class ServiceProperty {
             deploymentMode,
             peerPort,
             ordinalMap);
+
+    // parsing the optional replication-mode override ("active" | "primary-backup"),
+    // carried across epochs like the ordinal map
+    if (json.has("replication") && !json.isNull("replication")) {
+      prop.setReplicationMode(json.getString("replication"));
+    }
 
     // automatically infer is-stateful of component via the state directory
     if (stateDirectory != null && stateDirectory.split(":").length == 2) {
@@ -730,6 +745,23 @@ public class ServiceProperty {
     if (this.maxReplicas != null) {
       target.put("max_replicas", this.maxReplicas.intValue());
     }
+    if (this.replicationMode != null) {
+      target.put("replication", this.replicationMode);
+    }
+  }
+
+  public String getReplicationMode() {
+    return this.replicationMode;
+  }
+
+  public void setReplicationMode(String replicationMode) {
+    if (replicationMode != null
+        && !replicationMode.equals("active")
+        && !replicationMode.equals("primary-backup")) {
+      throw new IllegalStateException(
+          "replication must be 'active' or 'primary-backup' (got " + replicationMode + ")");
+    }
+    this.replicationMode = replicationMode;
   }
 
   /**


### PR DESCRIPTION
First of a 3-PR stack. Adds the in-place **protocol switch**: a running,
unmodified deterministic XDN service can be moved from active replication
(Paxos) to primary-backup via a placement update.

- `ServiceProperty` gains an optional `replication` field (`active` |
  `primary-backup`) that rides epochs (serialized like `ordinalMap`).
- RC placement endpoint accepts `"REPLICATION":"primary-backup"` →
  `SetReplicaPlacementRequest` → `Reconfigurator` placement metadata →
  `XdnReplicaCoordinator.initializeReplicaGroup` (sticky across epochs).
- `inferCoordinatorByProperties` honors the mode before the
  determinism/consistency inference.
- The epoch container-state tar is protocol-agnostic, so a Paxos checkpoint
  restores into the primary-backup epoch; `needsStateDiffRecorder()` treats a
  switched deterministic service as PB-managed.

Stack: **mechanism** → optimizations → eval.
