### PR TITLE
Primary-backup latency-mode optimizations (2/3)

### DIFF
--- a/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
+++ b/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
@@ -120,6 +120,16 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
     private static final long CAPTURE_ACCUMULATION_MAX_US =
         Long.getLong("PB_CAPTURE_ACCUMULATION_MAX_US", 5_000); // 5ms default
 
+    // When true, the capture thread skips the timed accumulation window whenever
+    // no backlog is queued (low load): it drains what is already there and, only
+    // if that reveals more than the first completion, waits the window for
+    // stragglers. At low load this removes the ~CAPTURE_ACCUMULATION_MIN_US of
+    // dead wait from captureWait (the window has nothing to amortize when a
+    // single request is in flight). Under real backlog the window still runs, so
+    // batching/throughput under load is unchanged. Off by default.
+    private static final boolean SKIP_IDLE_ACCUM =
+        Boolean.getBoolean("PB_CAPTURE_SKIP_IDLE_ACCUM");
+
     // Debug flag: skip captureStateDiff + Paxos propose in the capture thread.
     // When enabled, callbacks fire immediately after workers finish execution,
     // isolating the PBM worker pipeline from the Paxos consensus overhead.
@@ -643,22 +653,42 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
                 drained = new ArrayList<>();
                 drained.add(first);
 
-                // Adaptive accumulation window: wait up to currentAccumulationUs
-                // for more completions to batch into a single captureStateDiff + propose.
-                if (currentAccumulationUs > 0) {
-                    long deadlineNs = System.nanoTime()
-                            + currentAccumulationUs * 1_000L;
-                    CompletedBatch next;
-                    while ((next = doneQueue.poll(
-                            Math.max(0, deadlineNs - System.nanoTime()),
-                            TimeUnit.NANOSECONDS)) != null) {
-                        drained.add(next);
+                if (SKIP_IDLE_ACCUM) {
+                    // Grab anything already queued without blocking. At low load
+                    // this is empty and we proceed straight to capture; only when
+                    // it reveals a backlog do we spend the timed window waiting
+                    // for stragglers (nothing to amortize otherwise).
+                    doneQueue.drainTo(drained);
+                    if (currentAccumulationUs > 0 && drained.size() > 1) {
+                        long deadlineNs = System.nanoTime()
+                                + currentAccumulationUs * 1_000L;
+                        CompletedBatch next;
+                        while ((next = doneQueue.poll(
+                                Math.max(0, deadlineNs - System.nanoTime()),
+                                TimeUnit.NANOSECONDS)) != null) {
+                            drained.add(next);
+                        }
+                        // Catch any that landed during the wait.
+                        doneQueue.drainTo(drained);
                     }
-                }
+                } else {
+                    // Adaptive accumulation window: wait up to currentAccumulationUs
+                    // for more completions to batch into a single captureStateDiff + propose.
+                    if (currentAccumulationUs > 0) {
+                        long deadlineNs = System.nanoTime()
+                                + currentAccumulationUs * 1_000L;
+                        CompletedBatch next;
+                        while ((next = doneQueue.poll(
+                                Math.max(0, deadlineNs - System.nanoTime()),
+                                TimeUnit.NANOSECONDS)) != null) {
+                            drained.add(next);
+                        }
+                    }
 
-                // Non-blocking drain of any additional completions that
-                // arrived while we were processing the previous cycle.
-                doneQueue.drainTo(drained);
+                    // Non-blocking drain of any additional completions that
+                    // arrived while we were processing the previous cycle.
+                    doneQueue.drainTo(drained);
+                }
 
                 // Adapt accumulation window based on load pressure.
                 // If the queue still has items after draining, we're under

--- a/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
+++ b/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
@@ -126,9 +126,11 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
     // stragglers. At low load this removes the ~CAPTURE_ACCUMULATION_MIN_US of
     // dead wait from captureWait (the window has nothing to amortize when a
     // single request is in flight). Under real backlog the window still runs, so
-    // batching/throughput under load is unchanged. Off by default.
+    // batching/throughput under load is unchanged — this is strictly dominant, so
+    // it is ON by default (a latency win with no throughput cost). Set
+    // -DPB_CAPTURE_SKIP_IDLE_ACCUM=false to restore the always-wait behavior.
     private static final boolean SKIP_IDLE_ACCUM =
-        Boolean.getBoolean("PB_CAPTURE_SKIP_IDLE_ACCUM");
+        Boolean.parseBoolean(System.getProperty("PB_CAPTURE_SKIP_IDLE_ACCUM", "true"));
 
     // Debug flag: skip captureStateDiff + Paxos propose in the capture thread.
     // When enabled, callbacks fire immediately after workers finish execution,

--- a/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
+++ b/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
@@ -1792,11 +1792,55 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
         return true;
     }
 
+    // Poll/retry cadence for becoming the paxos coordinator during a primary
+    // election. The old code slept a fixed 3s between attempts, so even though
+    // winning the ballot takes ~1 RTT the election window was padded to ~15s
+    // (several 3s naps). We instead poll frequently -- so we proceed the instant
+    // we win -- while re-issuing the ballot preemption only occasionally, so we
+    // do not cause a ballot storm.
+    private static final long COORD_POLL_MS =
+        Long.getLong("PB_COORD_POLL_MS", 150);
+    private static final long COORD_RETRY_MS =
+        Long.getLong("PB_COORD_RETRY_MS", 2000);
+    private static final long COORD_WAIT_BUDGET_MS =
+        Long.getLong("PB_COORD_WAIT_BUDGET_MS", 30_000);
+
+    /**
+     * Block until this node is the paxos coordinator for {@code groupName}. Polls
+     * every COORD_POLL_MS and re-issues tryToBePaxosCoordinator every
+     * COORD_RETRY_MS, up to COORD_WAIT_BUDGET_MS. Null coordinator (instance not
+     * ready yet) is treated as "not us" and keeps polling.
+     */
+    private void waitToBecomeCoordinator(String groupName, String context) {
+        long start = System.currentTimeMillis();
+        long lastTry = -COORD_RETRY_MS; // force a try on the first iteration
+        while (!this.myNodeID.equals(this.paxosManager.getPaxosCoordinator(groupName))) {
+            long now = System.currentTimeMillis();
+            if (now - start > COORD_WAIT_BUDGET_MS) {
+                throw new RuntimeException(String.format(
+                        "%s:%s - unable to become paxos coordinator for %s (%s) after %dms",
+                        myNodeID, PrimaryBackupManager.class.getSimpleName(),
+                        groupName, context, now - start));
+            }
+            if (now - lastTry >= COORD_RETRY_MS) {
+                this.paxosManager.tryToBePaxosCoordinator(groupName);
+                lastTry = now;
+            }
+            try {
+                Thread.sleep(COORD_POLL_MS);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     private boolean initializePrimaryEpoch(String groupName, Set<NodeIDType> nodes,
                                            String placementMetadata, int placementEpoch) {
         assert groupName != null && !groupName.isEmpty();
         assert placementMetadata != null && !placementMetadata.isEmpty();
 
+        final long epochInitStartMs = System.currentTimeMillis();
+        edu.umass.cs.xdn.XdnGigapaxosApp.swTiming("pb-epoch-init " + groupName);
         logger.log(Level.INFO,
                 String.format("%s:%s:initializePrimaryEpoch - name=%s placement=%s epoch=%d",
                         this.myNodeID, PrimaryBackupManager.class.getSimpleName(),
@@ -1824,27 +1868,10 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
 
             // try to be Paxos' coordinator since we try to co-locate
             // the Primary and Paxos' coordinator.
-            int maxAttempt = 10;
-            int currAttempt = 0;
-            int attemptWaitTimeMs = 3000;
-            while (!this.paxosManager.getPaxosCoordinator(groupName).equals(this.myNodeID)) {
-                if (++currAttempt > maxAttempt) {
-                    String errorMsg = String.format("%s:%s:initializePrimaryEpoch - " +
-                                    "unable to become paxos' coordinator for " +
-                                    "name=%s:%d after %d trials",
-                            this.myNodeID, PrimaryBackupManager.class.getSimpleName(),
-                            groupName, placementEpoch, currAttempt);
-                    logger.log(Level.WARNING, errorMsg);
-                    throw new RuntimeException(errorMsg);
-                }
-
-                this.paxosManager.tryToBePaxosCoordinator(groupName);
-                try {
-                    Thread.sleep(attemptWaitTimeMs);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
+            long coordStartMs = System.currentTimeMillis();
+            waitToBecomeCoordinator(groupName, "initializePrimaryEpoch:" + placementEpoch);
+            System.out.printf(">> %s became paxos coordinator for %s in %dms%n",
+                    myNodeID, groupName, System.currentTimeMillis() - coordStartMs);
 
             // FIXME: we might need to wait for other replicas (majority) to active first,
             //  before we can propose something.
@@ -1877,8 +1904,11 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
                     groupName,
                     startPacket,
                     (proposedPacket, isHandled) -> {
-                        System.out.printf("\n\n>> %s I'M THE PRIMARY NOW FOR %s!!\n\n",
-                                myNodeID, groupName);
+                        edu.umass.cs.xdn.XdnGigapaxosApp.swTiming("pb-primary " + groupName);
+                        System.out.printf(
+                                "\n\n>> %s I'M THE PRIMARY NOW FOR %s (epoch-init->primary %dms)!!\n\n",
+                                myNodeID, groupName,
+                                System.currentTimeMillis() - epochInitStartMs);
                         currentRole.put(groupName, Role.PRIMARY);
                         currentPrimary.put(groupName, this.myNodeID);
                         currentPrimaryEpoch.put(groupName, zero);
@@ -1908,18 +1938,8 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
                         if (ENABLE_NON_DETERMINISTIC_INIT) {
                             xdnApp.nonDeterministicInitialization(groupName, ipAddresses, sshKey);
 
-                            while (!this.paxosManager.getPaxosCoordinator(groupName).equals(this.myNodeID)) {
-                                logger.log(Level.INFO, String.format(
-                                        "%s:%s - PRIMARY re-electing itself due to coordinator issues %s:%d",
-                                        myNodeID, PrimaryBackupManager.class.getSimpleName(),
-                                        groupName, placementEpoch));
-                                this.paxosManager.tryToBePaxosCoordinator(groupName);
-                                try {
-                                    Thread.sleep(3000);
-                                } catch (InterruptedException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
+                            waitToBecomeCoordinator(
+                                    groupName, "post-primary-reelect:" + placementEpoch);
                         }
 
                         // TODO: Move fuselog-apply startup to executeStartEpochPacket

--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -1217,6 +1217,11 @@ public class Reconfigurator<NodeIDType> implements
             Callback<Request, ReconfiguratorRequest> callback) {
         // get service metadata based on the provided name
         String serviceName = request.getServiceName();
+        if (Boolean.getBoolean("XDN_SWITCH_TIMING")) {
+            System.out.printf(
+                    "SWTIMING %d rc-placement-request %s%n",
+                    System.currentTimeMillis(), serviceName);
+        }
         ReconfigurationRecord<NodeIDType> record = this.DB.getReconfigurationRecord(serviceName);
         if (record == null) {
             request.setFailed(ClientReconfigurationPacket.ResponseCodes.NONEXISTENT_NAME_ERROR);

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -146,6 +146,17 @@ public class XdnGigapaxosApp
   private static final java.util.List<String> HEADERS_TO_STRIP =
       java.util.List.of(XdnHttpRequest.X_CLIENT_LOCATION_HEADER);
 
+  // Wall-clock timing of the AR->PB switch phases. Enable via -DXDN_SWITCH_TIMING=true.
+  // Each call prints "SWTIMING <epoch-ms> <event>" to stdout; grep across all node
+  // logs and sort by timestamp (NTP-synced clocks) to break down the switch gap.
+  public static final boolean SW_TIMING = Boolean.getBoolean("XDN_SWITCH_TIMING");
+
+  public static void swTiming(String event) {
+    if (SW_TIMING) {
+      System.out.printf("SWTIMING %d %s%n", System.currentTimeMillis(), event);
+    }
+  }
+
   // Maximum number of requests forwarded to the container in parallel within a single
   // batch execution. Limits tail-latency amplification when the backend serializes writes
   // (e.g., SQLite WAL). Requests beyond this limit are processed in sequential chunks.
@@ -734,6 +745,7 @@ public class XdnGigapaxosApp
    *     prefix.
    */
   private boolean createServiceInstance(String serviceName, String initialState) {
+    swTiming("ar-create-instance " + serviceName);
     // The PBM prefixes its create/restore calls, so the prefix (not the service's
     // determinism flag) is the authoritative signal that this instance is
     // primary-backup-managed and needs the statediff recorder. A deterministic service
@@ -1009,8 +1021,10 @@ public class XdnGigapaxosApp
     // must use the recorder's preserve-aware initialization: the raw wipe below would
     // destroy state that a reconfiguration just restored into the mount dir.
     if (needsStateDiffRecorder(service.property)) {
+      swTiming("ar-create-preinit-start " + serviceName);
       stateDiffRecorder.preInitialization(serviceName, initialPlacementEpoch);
       stateDiffRecorder.postInitialization(serviceName, initialPlacementEpoch);
+      swTiming("ar-create-preinit-done " + serviceName);
     } else {
       Shell.runCommand("rm -rf " + stateDirMountSource);
       Shell.runCommand("mkdir -p " + stateDirMountSource);
@@ -1418,7 +1432,9 @@ public class XdnGigapaxosApp
     String stateDirMountSource = stateDiffRecorder.getTargetDirectory(serviceName, placementEpoch);
     String stateDirMountTarget = property.getStatefulComponentDirectory();
     if (needsStateDiffRecorder(property)) {
+      swTiming("ar-revive-preinit-start " + serviceName);
       stateDiffRecorder.preInitialization(serviceName, placementEpoch);
+      swTiming("ar-revive-preinit-done " + serviceName);
     }
 
     // Validates the previous epoch final state, then put it into the to-be-mounted dir.
@@ -1645,6 +1661,7 @@ public class XdnGigapaxosApp
   private boolean stopContainerizedServiceInstance(String serviceName, int placementEpoch) {
     assert serviceName != null && !serviceName.isEmpty();
     assert placementEpoch >= 0;
+    swTiming("ar-stop-instance " + serviceName + " e" + placementEpoch);
 
     System.out.printf(
         ">> %s:XdnGigapaxosApp stopServiceInstance name=%s epoch=%d\n",
@@ -2663,6 +2680,7 @@ public class XdnGigapaxosApp
 
   @Override
   public String getFinalState(String name, int epoch) {
+    swTiming("ar-finalstate-start " + name + " e" + epoch);
     // TODO: validate whether this works with PrimaryBackup or not
     System.out.println(
         ">>> "
@@ -2793,6 +2811,7 @@ public class XdnGigapaxosApp
       String mountDirSource,
       String mountDirTarget,
       Map<String, String> env) {
+    swTiming("ar-container-start " + containerName);
 
     String publishPortSubCmd = "";
     if (publishedPort != null && allocatedHttpPort != null) {

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -139,6 +139,13 @@ public class XdnGigapaxosApp
   // with per-request latency breakdown. Enable via -DXDN_TIMING_HEADERS=true.
   public static final boolean TIMING_HEADERS_ENABLED = Boolean.getBoolean("XDN_TIMING_HEADERS");
 
+  // XDN-layer request headers stripped from the outbound request so the
+  // containerized service never sees them (parity with copyHttpRequest, which
+  // the Netty path uses). The blocking forward path skips these during
+  // serialization instead of copying-then-removing.
+  private static final java.util.List<String> HEADERS_TO_STRIP =
+      java.util.List.of(XdnHttpRequest.X_CLIENT_LOCATION_HEADER);
+
   // Maximum number of requests forwarded to the container in parallel within a single
   // batch execution. Limits tail-latency amplification when the backend serializes writes
   // (e.g., SQLite WAL). Requests beyond this limit are processed in sequential chunks.
@@ -3069,16 +3076,31 @@ public class XdnGigapaxosApp
           });
     }
 
-    FullHttpRequest forwardedHttpRequest = copyHttpRequest(xdnRequest);
-    long endRequestCreationTime = System.nanoTime();
+    long endRequestCreationTime = startTime;
 
     long endRequestResponseTime;
     long endConversionTime;
     long endResponseStoreTime;
     try {
-      // forward request to the underlying containerized service
-      FullHttpResponse httpResponse =
-          httpForwarderClient.execute("127.0.0.1", targetPort, forwardedHttpRequest);
+      // Forward to the containerized service. In latency mode (default) the
+      // blocking fast path serializes directly from the parsed request + body,
+      // avoiding the copyHttpRequest deep-copy; the Netty pool path (throughput
+      // mode) needs the assembled FullHttpRequest.
+      FullHttpResponse httpResponse;
+      if (XdnHttpForwarderClient.isBlocking()) {
+        endRequestCreationTime = System.nanoTime();
+        httpResponse =
+            httpForwarderClient.executeBlocking(
+                "127.0.0.1",
+                targetPort,
+                xdnRequest.getHttpRequest(),
+                xdnRequest.getHttpRequestContent().content(),
+                HEADERS_TO_STRIP);
+      } else {
+        FullHttpRequest forwardedHttpRequest = copyHttpRequest(xdnRequest);
+        endRequestCreationTime = System.nanoTime();
+        httpResponse = httpForwarderClient.execute("127.0.0.1", targetPort, forwardedHttpRequest);
+      }
       endRequestResponseTime = System.nanoTime();
 
       // store the response

--- a/src/edu/umass/cs/xdn/XdnHttpForwarderClient.java
+++ b/src/edu/umass/cs/xdn/XdnHttpForwarderClient.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +88,17 @@ public final class XdnHttpForwarderClient implements Closeable {
   private static final boolean FORCE_KEEPALIVE =
       Boolean.parseBoolean(System.getProperty("HTTP_FORCE_KEEPALIVE", "false"));
 
+  // ── Latency vs throughput mode ─────────────────────────────────────────────
+  //
+  // XDN defaults to LATENCY-optimal behavior; features that trade per-request
+  // latency for higher throughput are opt-in behind -DXDN_THROUGHPUT_MODE=true.
+  // For the forwarder this selects the Netty connection pool (pipelining, many
+  // in-flight per connection) over the blocking pinned-socket path. Other
+  // throughput features gated by the same switch live in their own classes
+  // (e.g. the PB capture-accumulation window, the HTTP request batcher).
+  // Individual -D flags always override the mode-derived default.
+  private static final boolean THROUGHPUT_MODE = Boolean.getBoolean("XDN_THROUGHPUT_MODE");
+
   // ── Blocking keep-alive fast path (kills the worker<->event-loop handoff) ──
   //
   // The default Netty path makes the calling (PB worker) thread submit to the
@@ -97,13 +109,24 @@ public final class XdnHttpForwarderClient implements Closeable {
   // container forward: measured ~2ms of the ~2.8ms exec stage is this plumbing,
   // not the container (which answers a 4KB PUT in <1ms directly).
   //
-  // With -DPB_FORWARD_BLOCKING=true the single-request forward does the whole
-  // HTTP/1.1 exchange on the CALLING thread over a per-thread pinned keep-alive
-  // socket: no pool acquire, no event-loop dispatch, no cross-thread wakeup.
-  // Any I/O or parse error refreshes the pinned socket and rethrows so execute()
-  // transparently falls back to the robust Netty path. Only single requests take
-  // this path; batches keep the pipelined Netty path.
-  private static final boolean FORWARD_BLOCKING = Boolean.getBoolean("PB_FORWARD_BLOCKING");
+  // The single-request forward does the whole HTTP/1.1 exchange on the CALLING
+  // thread over a per-thread pinned keep-alive socket: no pool acquire, no
+  // event-loop dispatch, no cross-thread wakeup. Any I/O or parse error refreshes
+  // the pinned socket and falls back to the robust Netty path. Only single
+  // requests take this path; batches keep the pipelined Netty path.
+  //
+  // This is a LATENCY optimization and the DEFAULT. The Netty connection pool is
+  // a THROUGHPUT feature (pipelining, many in-flight per connection) that costs
+  // per-request latency, so it is opt-in via XDN_THROUGHPUT_MODE. -DPB_FORWARD_BLOCKING
+  // explicitly overrides either way. See XDN_THROUGHPUT_MODE below.
+  private static final boolean FORWARD_BLOCKING =
+      Boolean.parseBoolean(
+          System.getProperty("PB_FORWARD_BLOCKING", String.valueOf(!THROUGHPUT_MODE)));
+
+  /** True when single-request forwards use the blocking pinned-socket fast path. */
+  public static boolean isBlocking() {
+    return FORWARD_BLOCKING;
+  }
 
   // Per-request forward-timing samples (Netty vs blocking) appended here when
   // -DXDN_TIMING_HEADERS=true, so the two paths can be compared directly.
@@ -123,11 +146,33 @@ public final class XdnHttpForwarderClient implements Closeable {
   }
 
   /**
-   * Blocking single-request forward on the calling thread over a per-thread pinned keep-alive
-   * socket. Throws on any I/O or parse failure (after discarding the pinned socket), letting the
-   * caller fall back to the Netty path.
+   * Blocking single-request forward on the calling (worker) thread over a per-thread pinned
+   * keep-alive socket, serialized directly from the parsed request metadata and body — no
+   * pre-copied FullHttpRequest, no pool acquire, no event-loop hop. {@code stripHeaders} names
+   * request headers the container must not see (XDN-layer signals like X-Client-Location). On any
+   * I/O or parse failure it discards the pinned socket and falls back to the robust Netty pool
+   * path (assembling a FullHttpRequest — the only place the body is copied — only then).
    */
-  private FullHttpResponse executeBlocking(String host, int port, FullHttpRequest request)
+  public FullHttpResponse executeBlocking(
+      String host, int port, HttpRequest meta, ByteBuf body, Collection<String> stripHeaders)
+      throws Exception {
+    try {
+      return blockingOverPinned(
+          host, port, meta.method(), meta.uri(), meta.headers(), body, stripHeaders);
+    } catch (Exception e) {
+      LOG.log(Level.FINE, "blocking forward fell back to netty: {0}", e.getMessage());
+      return execute(host, port, buildFullRequest(meta, body, stripHeaders));
+    }
+  }
+
+  private FullHttpResponse blockingOverPinned(
+      String host,
+      int port,
+      HttpMethod method,
+      String uri,
+      HttpHeaders headers,
+      ByteBuf body,
+      Collection<String> stripHeaders)
       throws Exception {
     long t0 = System.nanoTime();
     Origin origin = new Origin(host, port);
@@ -138,7 +183,8 @@ public final class XdnHttpForwarderClient implements Closeable {
         conn = new PinnedConn(openPinned(host, port));
         map.put(origin, conn);
       }
-      FullHttpResponse resp = blockingExchange(conn, host, port, request);
+      FullHttpResponse resp =
+          serializeAndRead(conn, host, port, method, uri, headers, body, stripHeaders);
       if (FWD_TRACE) {
         fwdTrace(String.format("FWD_BLOCK total=%.3f%n", (System.nanoTime() - t0) / 1e6));
       }
@@ -169,25 +215,34 @@ public final class XdnHttpForwarderClient implements Closeable {
     }
   }
 
-  /** Serialize {@code request} to HTTP/1.1, write it, and parse one response. */
-  private FullHttpResponse blockingExchange(
-      PinnedConn conn, String host, int port, FullHttpRequest request) throws Exception {
+  /**
+   * Serialize the request to HTTP/1.1 (skipping {@code stripHeaders} plus the hop-by-hop headers we
+   * set ourselves), write it over the pinned socket, and parse one response. The body is written
+   * straight from the ByteBuf's backing array when it is heap-backed, avoiding an intermediate copy.
+   */
+  private FullHttpResponse serializeAndRead(
+      PinnedConn conn,
+      String host,
+      int port,
+      HttpMethod method,
+      String uri,
+      HttpHeaders headers,
+      ByteBuf body,
+      Collection<String> stripHeaders)
+      throws Exception {
     trySetQuickAck(conn.ch);
-    ByteBuf content = request.content();
-    int bodyLen = content != null ? content.readableBytes() : 0;
+    int bodyLen = body != null ? body.readableBytes() : 0;
 
     StringBuilder head = new StringBuilder(256);
-    head.append(request.method().name())
-        .append(' ')
-        .append(request.uri())
-        .append(" HTTP/1.1\r\n");
+    head.append(method.name()).append(' ').append(uri).append(" HTTP/1.1\r\n");
     boolean hasHost = false;
-    for (Map.Entry<String, String> h : request.headers()) {
+    for (Map.Entry<String, String> h : headers) {
       String name = h.getKey();
       // Connection/Content-Length/Transfer-Encoding are set by us below.
       if (name.equalsIgnoreCase(HttpHeaderNames.CONNECTION.toString())
           || name.equalsIgnoreCase(HttpHeaderNames.CONTENT_LENGTH.toString())
-          || name.equalsIgnoreCase(HttpHeaderNames.TRANSFER_ENCODING.toString())) {
+          || name.equalsIgnoreCase(HttpHeaderNames.TRANSFER_ENCODING.toString())
+          || containsIgnoreCase(stripHeaders, name)) {
         continue;
       }
       if (name.equalsIgnoreCase(HttpHeaderNames.HOST.toString())) {
@@ -201,16 +256,52 @@ public final class XdnHttpForwarderClient implements Closeable {
     head.append("Connection: keep-alive\r\n");
     head.append("Content-Length: ").append(bodyLen).append("\r\n\r\n");
 
-    byte[] headBytes = head.toString().getBytes(StandardCharsets.ISO_8859_1);
-    conn.out.write(headBytes);
+    conn.out.write(head.toString().getBytes(StandardCharsets.ISO_8859_1));
     if (bodyLen > 0) {
-      byte[] body = new byte[bodyLen];
-      content.getBytes(content.readerIndex(), body); // absolute read: readerIndex unchanged
-      conn.out.write(body);
+      if (body.hasArray()) {
+        // Zero-copy: write straight from the ByteBuf's backing array.
+        conn.out.write(body.array(), body.arrayOffset() + body.readerIndex(), bodyLen);
+      } else {
+        byte[] tmp = new byte[bodyLen];
+        body.getBytes(body.readerIndex(), tmp); // absolute read: readerIndex unchanged
+        conn.out.write(tmp);
+      }
     }
     conn.out.flush();
 
     return readResponse(conn.in);
+  }
+
+  private static boolean containsIgnoreCase(Collection<String> names, String name) {
+    if (names == null || names.isEmpty()) {
+      return false;
+    }
+    for (String n : names) {
+      if (n.equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Assemble a FullHttpRequest (the one place the body is deep-copied) for the Netty fallback. */
+  private static FullHttpRequest buildFullRequest(
+      HttpRequest meta, ByteBuf body, Collection<String> stripHeaders) {
+    ByteBuf copied = (body != null && body.isReadable()) ? body.copy() : Unpooled.EMPTY_BUFFER;
+    DefaultFullHttpRequest full =
+        new DefaultFullHttpRequest(meta.protocolVersion(), meta.method(), meta.uri(), copied);
+    full.headers().set(meta.headers());
+    if (stripHeaders != null) {
+      for (String s : stripHeaders) {
+        full.headers().remove(s);
+      }
+    }
+    if (copied != Unpooled.EMPTY_BUFFER) {
+      HttpUtil.setContentLength(full, copied.readableBytes());
+    } else {
+      full.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+    }
+    return full;
   }
 
   private static FullHttpResponse readResponse(InputStream in) throws IOException {
@@ -344,16 +435,6 @@ public final class XdnHttpForwarderClient implements Closeable {
   public FullHttpResponse execute(String host, int port, FullHttpRequest request) throws Exception {
     Objects.requireNonNull(host, "host");
     Objects.requireNonNull(request, "request");
-    if (FORWARD_BLOCKING) {
-      try {
-        return executeBlocking(host, port, request);
-      } catch (Exception e) {
-        // Blocking fast path failed (stale socket, parse issue): fall through to
-        // the robust Netty path, which reconnects via the pool. The request
-        // ByteBuf is untouched (absolute reads), so it is safe to reuse here.
-        LOG.log(Level.FINE, "blocking forward fell back to netty: {0}", e.getMessage());
-      }
-    }
     if (MAX_RETRIES <= 0) {
       return executeOnce(host, port, request);
     }

--- a/src/edu/umass/cs/xdn/XdnHttpForwarderClient.java
+++ b/src/edu/umass/cs/xdn/XdnHttpForwarderClient.java
@@ -230,6 +230,7 @@ public final class XdnHttpForwarderClient implements Closeable {
       ByteBuf body,
       Collection<String> stripHeaders)
       throws Exception {
+    long t0 = System.nanoTime();
     trySetQuickAck(conn.ch);
     int bodyLen = body != null ? body.readableBytes() : 0;
 
@@ -268,8 +269,22 @@ public final class XdnHttpForwarderClient implements Closeable {
       }
     }
     conn.out.flush();
+    long tFlush = System.nanoTime();
 
-    return readResponse(conn.in);
+    long[] tFirstByte = new long[1];
+    FullHttpResponse resp = readResponse(conn.in, tFirstByte);
+    if (FWD_TRACE) {
+      long tDone = System.nanoTime();
+      // ser = serialize + write; wait = flush -> first response byte (container
+      // processing); parse = read + parse the response (XDN-side).
+      fwdTrace(
+          String.format(
+              "FWD_SPLIT ser=%.3f wait=%.3f parse=%.3f%n",
+              (tFlush - t0) / 1e6,
+              (tFirstByte[0] - tFlush) / 1e6,
+              (tDone - tFirstByte[0]) / 1e6));
+    }
+    return resp;
   }
 
   private static boolean containsIgnoreCase(Collection<String> names, String name) {
@@ -304,8 +319,12 @@ public final class XdnHttpForwarderClient implements Closeable {
     return full;
   }
 
-  private static FullHttpResponse readResponse(InputStream in) throws IOException {
+  private static FullHttpResponse readResponse(InputStream in, long[] tFirstByte)
+      throws IOException {
     String statusLine = readLine(in);
+    if (tFirstByte != null) {
+      tFirstByte[0] = System.nanoTime();
+    }
     if (statusLine == null || statusLine.isEmpty()) {
       throw new IOException("empty response (stale keep-alive socket)");
     }

--- a/src/edu/umass/cs/xdn/XdnHttpForwarderClient.java
+++ b/src/edu/umass/cs/xdn/XdnHttpForwarderClient.java
@@ -11,10 +11,24 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.*;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -50,9 +64,13 @@ public final class XdnHttpForwarderClient implements Closeable {
   private final boolean manageEventLoopGroup;
   private final ConcurrentMap<Origin, FixedChannelPool> pools = new ConcurrentHashMap<>();
 
-  /** Creates a client backed by its own event loop group. */
+  /**
+   * Creates a client backed by its own event loop group. The thread count defaults to Netty's 2 x
+   * cores; on many-core boxes that is a lot of mostly-idle selector threads, so -DXDN_HTTP_EVENT_LOOP_THREADS
+   * caps it (fewer, warmer loops can lower single-request wakeup latency).
+   */
   public XdnHttpForwarderClient() {
-    this(new NioEventLoopGroup(0), true);
+    this(new NioEventLoopGroup(Integer.getInteger("XDN_HTTP_EVENT_LOOP_THREADS", 0)), true);
   }
 
   private XdnHttpForwarderClient(EventLoopGroup group, boolean manageGroup) {
@@ -69,6 +87,252 @@ public final class XdnHttpForwarderClient implements Closeable {
   private static final boolean FORCE_KEEPALIVE =
       Boolean.parseBoolean(System.getProperty("HTTP_FORCE_KEEPALIVE", "false"));
 
+  // ── Blocking keep-alive fast path (kills the worker<->event-loop handoff) ──
+  //
+  // The default Netty path makes the calling (PB worker) thread submit to the
+  // event loop via pool.acquire(), dispatch writeAndFlush on the loop, and then
+  // block on a CompletableFuture that the loop completes on response — a
+  // worker->loop->worker round trip plus pool bookkeeping per request. At low
+  // load (one request in flight) that scheduling overhead dominates a local
+  // container forward: measured ~2ms of the ~2.8ms exec stage is this plumbing,
+  // not the container (which answers a 4KB PUT in <1ms directly).
+  //
+  // With -DPB_FORWARD_BLOCKING=true the single-request forward does the whole
+  // HTTP/1.1 exchange on the CALLING thread over a per-thread pinned keep-alive
+  // socket: no pool acquire, no event-loop dispatch, no cross-thread wakeup.
+  // Any I/O or parse error refreshes the pinned socket and rethrows so execute()
+  // transparently falls back to the robust Netty path. Only single requests take
+  // this path; batches keep the pipelined Netty path.
+  private static final boolean FORWARD_BLOCKING = Boolean.getBoolean("PB_FORWARD_BLOCKING");
+
+  // Per-request forward-timing samples (Netty vs blocking) appended here when
+  // -DXDN_TIMING_HEADERS=true, so the two paths can be compared directly.
+  private static final boolean FWD_TRACE = XdnGigapaxosApp.TIMING_HEADERS_ENABLED;
+  private static final Path FWD_TRACE_FILE = Path.of("/tmp/xdn_fwd.log");
+
+  // One pinned keep-alive connection per (thread, origin) for the blocking path.
+  private static final ThreadLocal<Map<Origin, PinnedConn>> PINNED =
+      ThreadLocal.withInitial(HashMap::new);
+
+  private static void fwdTrace(String line) {
+    try {
+      Files.writeString(
+          FWD_TRACE_FILE, line, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    } catch (Exception ignored) {
+    }
+  }
+
+  /**
+   * Blocking single-request forward on the calling thread over a per-thread pinned keep-alive
+   * socket. Throws on any I/O or parse failure (after discarding the pinned socket), letting the
+   * caller fall back to the Netty path.
+   */
+  private FullHttpResponse executeBlocking(String host, int port, FullHttpRequest request)
+      throws Exception {
+    long t0 = System.nanoTime();
+    Origin origin = new Origin(host, port);
+    Map<Origin, PinnedConn> map = PINNED.get();
+    PinnedConn conn = map.get(origin);
+    try {
+      if (conn == null || !conn.ch.isOpen() || !conn.ch.isConnected()) {
+        conn = new PinnedConn(openPinned(host, port));
+        map.put(origin, conn);
+      }
+      FullHttpResponse resp = blockingExchange(conn, host, port, request);
+      if (FWD_TRACE) {
+        fwdTrace(String.format("FWD_BLOCK total=%.3f%n", (System.nanoTime() - t0) / 1e6));
+      }
+      return resp;
+    } catch (Exception e) {
+      if (conn != null) {
+        conn.closeQuietly();
+        map.remove(origin);
+      }
+      throw e;
+    }
+  }
+
+  private static SocketChannel openPinned(String host, int port) throws IOException {
+    SocketChannel ch = SocketChannel.open();
+    ch.setOption(StandardSocketOptions.TCP_NODELAY, true);
+    ch.setOption(StandardSocketOptions.SO_KEEPALIVE, true);
+    trySetQuickAck(ch);
+    ch.connect(new InetSocketAddress(host, port));
+    return ch;
+  }
+
+  private static void trySetQuickAck(SocketChannel ch) {
+    try {
+      ch.setOption(jdk.net.ExtendedSocketOptions.TCP_QUICKACK, true);
+    } catch (Exception ignored) {
+      // Not supported off Linux; harmless.
+    }
+  }
+
+  /** Serialize {@code request} to HTTP/1.1, write it, and parse one response. */
+  private FullHttpResponse blockingExchange(
+      PinnedConn conn, String host, int port, FullHttpRequest request) throws Exception {
+    trySetQuickAck(conn.ch);
+    ByteBuf content = request.content();
+    int bodyLen = content != null ? content.readableBytes() : 0;
+
+    StringBuilder head = new StringBuilder(256);
+    head.append(request.method().name())
+        .append(' ')
+        .append(request.uri())
+        .append(" HTTP/1.1\r\n");
+    boolean hasHost = false;
+    for (Map.Entry<String, String> h : request.headers()) {
+      String name = h.getKey();
+      // Connection/Content-Length/Transfer-Encoding are set by us below.
+      if (name.equalsIgnoreCase(HttpHeaderNames.CONNECTION.toString())
+          || name.equalsIgnoreCase(HttpHeaderNames.CONTENT_LENGTH.toString())
+          || name.equalsIgnoreCase(HttpHeaderNames.TRANSFER_ENCODING.toString())) {
+        continue;
+      }
+      if (name.equalsIgnoreCase(HttpHeaderNames.HOST.toString())) {
+        hasHost = true;
+      }
+      head.append(name).append(": ").append(h.getValue()).append("\r\n");
+    }
+    if (!hasHost) {
+      head.append("Host: ").append(host).append(':').append(port).append("\r\n");
+    }
+    head.append("Connection: keep-alive\r\n");
+    head.append("Content-Length: ").append(bodyLen).append("\r\n\r\n");
+
+    byte[] headBytes = head.toString().getBytes(StandardCharsets.ISO_8859_1);
+    conn.out.write(headBytes);
+    if (bodyLen > 0) {
+      byte[] body = new byte[bodyLen];
+      content.getBytes(content.readerIndex(), body); // absolute read: readerIndex unchanged
+      conn.out.write(body);
+    }
+    conn.out.flush();
+
+    return readResponse(conn.in);
+  }
+
+  private static FullHttpResponse readResponse(InputStream in) throws IOException {
+    String statusLine = readLine(in);
+    if (statusLine == null || statusLine.isEmpty()) {
+      throw new IOException("empty response (stale keep-alive socket)");
+    }
+    int sp1 = statusLine.indexOf(' ');
+    int sp2 = statusLine.indexOf(' ', sp1 + 1);
+    HttpVersion version = HttpVersion.valueOf(statusLine.substring(0, sp1));
+    int code = Integer.parseInt(statusLine.substring(sp1 + 1, sp2 < 0 ? statusLine.length() : sp2));
+    String reason = sp2 < 0 ? "" : statusLine.substring(sp2 + 1);
+    HttpResponseStatus status = new HttpResponseStatus(code, reason);
+
+    HttpHeaders headers = new DefaultHttpHeaders(false);
+    while (true) {
+      String line = readLine(in);
+      if (line == null) {
+        throw new IOException("EOF in response headers");
+      }
+      if (line.isEmpty()) {
+        break;
+      }
+      int colon = line.indexOf(':');
+      if (colon > 0) {
+        headers.add(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
+      }
+    }
+
+    byte[] body;
+    String te = headers.get(HttpHeaderNames.TRANSFER_ENCODING);
+    if (te != null && te.toLowerCase().contains("chunked")) {
+      body = readChunked(in);
+      headers.remove(HttpHeaderNames.TRANSFER_ENCODING);
+    } else {
+      String cl = headers.get(HttpHeaderNames.CONTENT_LENGTH);
+      body = readN(in, cl != null ? Integer.parseInt(cl.trim()) : 0);
+    }
+
+    ByteBuf buf = body.length == 0 ? Unpooled.EMPTY_BUFFER : Unpooled.wrappedBuffer(body);
+    DefaultFullHttpResponse resp = new DefaultFullHttpResponse(version, status, buf);
+    resp.headers().set(headers);
+    HttpUtil.setContentLength(resp, body.length);
+    return resp;
+  }
+
+  /** Read one CRLF-terminated line (CR/LF stripped) as ISO-8859-1; null on immediate EOF. */
+  private static String readLine(InputStream in) throws IOException {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream(64);
+    int c;
+    boolean any = false;
+    while ((c = in.read()) != -1) {
+      any = true;
+      if (c == '\n') {
+        break;
+      }
+      if (c != '\r') {
+        buf.write(c);
+      }
+    }
+    if (!any) {
+      return null;
+    }
+    return buf.toString(StandardCharsets.ISO_8859_1);
+  }
+
+  private static byte[] readN(InputStream in, int n) throws IOException {
+    byte[] out = new byte[n];
+    int off = 0;
+    while (off < n) {
+      int r = in.read(out, off, n - off);
+      if (r < 0) {
+        throw new IOException("EOF at " + off + "/" + n + " body bytes");
+      }
+      off += r;
+    }
+    return out;
+  }
+
+  private static byte[] readChunked(InputStream in) throws IOException {
+    ByteArrayOutputStream body = new ByteArrayOutputStream();
+    while (true) {
+      String sizeLine = readLine(in);
+      if (sizeLine == null) {
+        throw new IOException("EOF in chunk size");
+      }
+      int semi = sizeLine.indexOf(';');
+      int size = Integer.parseInt((semi < 0 ? sizeLine : sizeLine.substring(0, semi)).trim(), 16);
+      if (size == 0) {
+        // Consume trailer headers up to the blank line.
+        String trailer;
+        while ((trailer = readLine(in)) != null && !trailer.isEmpty()) {
+          // discard
+        }
+        break;
+      }
+      body.write(readN(in, size));
+      readLine(in); // trailing CRLF after chunk data
+    }
+    return body.toByteArray();
+  }
+
+  /** A pinned blocking keep-alive connection: channel plus buffered I/O streams. */
+  private static final class PinnedConn {
+    final SocketChannel ch;
+    final InputStream in;
+    final OutputStream out;
+
+    PinnedConn(SocketChannel ch) {
+      this.ch = ch;
+      this.in = new BufferedInputStream(Channels.newInputStream(ch), 32 * 1024);
+      this.out = Channels.newOutputStream(ch);
+    }
+
+    void closeQuietly() {
+      try {
+        ch.close();
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
   /**
    * Sends the given HTTP request and returns a detached response. The caller is responsible for
    * releasing the returned {@link FullHttpResponse} to avoid leaking pooled buffers.
@@ -80,6 +344,16 @@ public final class XdnHttpForwarderClient implements Closeable {
   public FullHttpResponse execute(String host, int port, FullHttpRequest request) throws Exception {
     Objects.requireNonNull(host, "host");
     Objects.requireNonNull(request, "request");
+    if (FORWARD_BLOCKING) {
+      try {
+        return executeBlocking(host, port, request);
+      } catch (Exception e) {
+        // Blocking fast path failed (stale socket, parse issue): fall through to
+        // the robust Netty path, which reconnects via the pool. The request
+        // ByteBuf is untouched (absolute reads), so it is safe to reuse here.
+        LOG.log(Level.FINE, "blocking forward fell back to netty: {0}", e.getMessage());
+      }
+    }
     if (MAX_RETRIES <= 0) {
       return executeOnce(host, port, request);
     }
@@ -334,16 +608,23 @@ public final class XdnHttpForwarderClient implements Closeable {
 
     try {
       FullHttpResponse response = responseFuture.get();
-      if (reqNum % LOG_SAMPLE_INTERVAL == 0) {
+      if (FWD_TRACE || reqNum % LOG_SAMPLE_INTERVAL == 0) {
         long tEnd = System.nanoTime();
         double totalMs = (tEnd - t0) / 1_000_000.0;
         double acqMs = (ts[0] - t0) / 1_000_000.0;
         double writeMs = (ts[1] - ts[0]) / 1_000_000.0;
         double respMs = (tEnd - ts[1]) / 1_000_000.0;
-        LOG.info(
-            String.format(
-                "HTTP fwd: total=%.2fms acq=%.2fms write=%.2fms resp=%.2fms",
-                totalMs, acqMs, writeMs, respMs));
+        if (FWD_TRACE) {
+          fwdTrace(
+              String.format(
+                  "FWD_NETTY total=%.3f acq=%.3f write=%.3f resp=%.3f%n",
+                  totalMs, acqMs, writeMs, respMs));
+        } else {
+          LOG.info(
+              String.format(
+                  "HTTP fwd: total=%.2fms acq=%.2fms write=%.2fms resp=%.2fms",
+                  totalMs, acqMs, writeMs, respMs));
+        }
       }
       return response;
     } catch (ExecutionException e) {


### PR DESCRIPTION
Second of a 3-PR stack (on top of the switch mechanism). Introduces
`XDN_THROUGHPUT_MODE` (default off) as the single switch for features that
trade per-request latency for throughput; latency is the default.

- **Blocking keep-alive forward** (default): the single-request HTTP forward
  runs on the calling worker thread over a per-thread pinned socket, skipping
  the Netty pool-acquire + event-loop handoff (~1 ms/req at low load). Falls
  back to the Netty pool on any error; the pool is the opt-in throughput path.
- **Skip idle capture-accumulation** (default): the capture thread no longer
  waits the accumulation window with no backlog (~0.7 ms/req); batching under
  real load is unchanged.
- **Copy-free forward**: the blocking path serializes straight from the parsed
  request + body, skipping the `copyHttpRequest` deep-copy.
- Faster primary-election coordinator (poll 150 ms / re-issue the ballot every
  2 s instead of a fixed 3 s nap; fixes a latent NPE), plus gated
  `XDN_SWITCH_TIMING` phase timing and a forwarder serialize/wait/parse trace
  (both off by default).

Measured: the switch cuts latency e.g. 60.9→9.4 ms (256 KB / 100 Mbit) and
14.3→5.7 ms (16 KB / 20 Mbit); the workload's statediff is 17 bytes.

Stack: mechanism → **optimizations** → eval.
