### PR TITLE
Protocol-switch eval harnesses (3/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ docs/xdn/site/
 services/todo/
 # superseded root-level aws terraform (moved to deployment/aws/ in #56)
 /aws/
+
+# protocol-switch measurement datasets (results, not source)
+eval/datasets/protocol-switch/

--- a/conf/gigapaxos.xdn.clemson.properties
+++ b/conf/gigapaxos.xdn.clemson.properties
@@ -1,0 +1,43 @@
+APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp
+
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+
+ENABLE_ACTIVE_REPLICA_HTTP=true
+ENABLE_RECONFIGURATOR_HTTP=true
+BATCHING_ENABLED=true
+REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator
+ENABLE_STARTUP_LEADER_ELECTION=false
+HIBERNATE_OPTION=true
+SYNC=true
+
+# 768MB
+# Needed for large non-deterministic state transfer packets 
+# (observed ~663MB in logs).
+NIO_MAX_PAYLOAD_SIZE=805306368
+
+INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator
+INITIAL_STATE_NUM_REPLICAS_EXTRACTOR_CLASS=edu.umass.cs.xdn.XdnServiceNumReplicasExtractor
+XDN_PB_STATEDIFF_RECORDER_TYPE=FUSELOG
+XDN_FUSELOG_BASE_DIR=/dev/shm/xdn/state/fuselog/
+XDN_PB_ENABLE_NON_DETERMINISTIC_INIT=true
+
+REPLICATE_ALL=false
+EMULATE_UNREPLICATED=false
+HTTP_AR_FRONTEND_BATCH_ENABLED=true
+HTTP_AR_FRONTEND_REQUEST_TIMEOUT_MS=60000
+XDN_HTTP_MAX_POOL_SIZE=128
+
+DEMAND_PROFILE_TYPE=edu.umass.cs.xdn.XdnGeoDemandProfiler
+
+# format: active.<active_server_name>=host:port
+
+# format: active.<active_server_name>.geolocation="latitude,longitude"
+# AR0, AR1 in us-east-1 (Northern Virginia); AR2, AR3 in us-west-1 (Northern California).
+
+# format: reconfigurator.<active_server_name>=host:port
+
+RECONFIGURE_IN_PLACE=true
+reconfigurator.0=10.10.1.4:3000
+active.1=10.10.1.1:2000
+active.2=10.10.1.2:2000
+active.3=10.10.1.3:2000

--- a/eval/plot_protocol_switch.py
+++ b/eval/plot_protocol_switch.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Plot median latency over time from protocol_switch_demo.py output, with the
+Paxos->primary-backup switch annotated.
+
+  python3 eval/plot_protocol_switch.py -o psw.png /tmp/psw-demo.json
+"""
+
+import argparse
+import json
+import statistics
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+INK = "#333333"
+INK_MUTED = "#767676"
+GRID = "#e5e5e2"
+C_PAXOS = "#2a78d6"
+C_PB = "#eb6834"
+
+
+def sliding_median(samples, window_s):
+    """Median latency of OK requests in a trailing window, sampled per second."""
+    ok = [(s["t"], s["latency_ms"]) for s in samples if s["ok"]]
+    if not ok:
+        return [], []
+    tmax = ok[-1][0]
+    xs, ys = [], []
+    t = window_s
+    while t <= tmax:
+        win = [lat for (ti, lat) in ok if t - window_s <= ti <= t]
+        if win:
+            xs.append(t)
+            ys.append(statistics.median(win))
+        t += 1.0
+    return xs, ys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("datasets", nargs="+")
+    ap.add_argument("-o", "--out", required=True)
+    ap.add_argument("--window", type=float, default=3.0, help="median window (s)")
+    ap.add_argument("--pdf", action="store_true")
+    args = ap.parse_args()
+
+    fig, ax = plt.subplots(figsize=(7.2, 3.4))
+    for path in args.datasets:
+        d = json.load(open(path))
+        samples = d["samples"]
+        switch_t = d["switch_at_rel"]
+        xs, ys = sliding_median(samples, args.window)
+        # split the line at the switch so each regime carries its own color
+        pre_x = [x for x in xs if x <= switch_t]
+        pre_y = [ys[i] for i, x in enumerate(xs) if x <= switch_t]
+        post_x = [x for x in xs if x > switch_t]
+        post_y = [ys[i] for i, x in enumerate(xs) if x > switch_t]
+        ax.plot(pre_x, pre_y, color=C_PAXOS, linewidth=2, label="active replication (Paxos)")
+        ax.plot(post_x, post_y, color=C_PB, linewidth=2, label="primary-backup")
+        ax.axvline(switch_t, color=INK_MUTED, linestyle="--", linewidth=1)
+        ax.annotate("switch", (switch_t, ax.get_ylim()[1]), xytext=(4, -4),
+                    textcoords="offset points", fontsize=8, color=INK_MUTED,
+                    va="top")
+
+        pre = [s["latency_ms"] for s in samples if s["ok"] and s["phase"] == "paxos"]
+        post = [s["latency_ms"] for s in samples
+                if s["ok"] and s["phase"] == "primary-backup" and s["t"] > switch_t + 5]
+        parts = []
+        if pre:
+            parts.append(f"Paxos median {statistics.median(pre):.0f}ms")
+        if post:
+            parts.append(f"PB median {statistics.median(post):.0f}ms")
+        if parts:
+            ax.set_title(
+                f"{d['service']}: {' -> '.join(parts)}"
+                f"  (request {d['pad_bytes']//1000}KB, statediff tiny)",
+                fontsize=9, color=INK)
+
+    ax.set_ylim(bottom=0)
+    ax.set_xlabel("time (s)", fontsize=9, color=INK)
+    ax.set_ylabel(f"median latency (ms, {args.window:.0f}s window)", fontsize=9, color=INK)
+    ax.tick_params(labelsize=8, colors=INK_MUTED)
+    for s in ("top", "right"):
+        ax.spines[s].set_visible(False)
+    for s in ("left", "bottom"):
+        ax.spines[s].set_color(GRID)
+    ax.grid(axis="y", color=GRID, linewidth=0.6)
+    ax.set_axisbelow(True)
+    # dedupe legend labels
+    handles, labels = ax.get_legend_handles_labels()
+    seen = {}
+    for h, l in zip(handles, labels):
+        seen.setdefault(l, h)
+    ax.legend(seen.values(), seen.keys(), frameon=False, fontsize=8, loc="upper right")
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=180 if not args.pdf else None,
+                format="pdf" if args.pdf else None, facecolor="#fcfcfb")
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/plot_switch_sweep.py
+++ b/eval/plot_switch_sweep.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Latency vs request size crossover plot from protocol_switch_sweep.py output.
+
+  python3 eval/plot_switch_sweep.py -o crossover.png sweep-paxos.json sweep-pb.json
+"""
+import argparse
+import json
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+INK = "#333333"
+INK_MUTED = "#767676"
+GRID = "#e5e5e2"
+COLORS = {"paxos": "#2a78d6", "primary-backup": "#eb6834", "pb": "#eb6834"}
+NAMES = {"paxos": "active replication (Paxos)", "primary-backup": "primary-backup",
+         "pb": "primary-backup"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("datasets", nargs="+")
+    ap.add_argument("-o", "--out", required=True)
+    ap.add_argument("--pdf", action="store_true")
+    args = ap.parse_args()
+
+    fig, ax = plt.subplots(figsize=(7.0, 4.0))
+    curves = {}
+    for path in args.datasets:
+        d = json.load(open(path))
+        lab = d["label"]
+        xs = [r["size"] / 1024 for r in d["results"] if r["median_ms"] is not None]
+        ys = [r["median_ms"] for r in d["results"] if r["median_ms"] is not None]
+        curves[lab] = (xs, ys)
+        c = COLORS.get(lab, "#4a3aa7")
+        ax.plot(xs, ys, marker="o", markersize=6, linewidth=2, color=c, label=NAMES.get(lab, lab))
+        for x, y in zip(xs, ys):
+            ax.annotate(f"{y:.0f}", (x, y), textcoords="offset points", xytext=(0, 7),
+                        fontsize=6.5, color=INK_MUTED, ha="center")
+
+    # crossover: first size where PB <= Paxos
+    if "paxos" in curves and any(k in curves for k in ("primary-backup", "pb")):
+        pk = "primary-backup" if "primary-backup" in curves else "pb"
+        px, py = curves["paxos"]
+        bx, by = curves[pk]
+        # Meaningful crossover: first size where Paxos is >20% slower than PB
+        # (beyond ~1ms measurement noise), not the first noise-level tie.
+        common = sorted(set(px) & set(bx))
+        cross = None
+        for x in common:
+            p, b = py[px.index(x)], by[bx.index(x)]
+            if p > 1.2 * b and p - b > 1.5:
+                cross = x
+                break
+        if cross is not None:
+            ax.axvline(cross, color=INK_MUTED, linestyle=":", linewidth=1)
+            ax.annotate(f"PB wins from ~{cross:.0f}KB", (cross, ax.get_ylim()[1]),
+                        xytext=(4, -4), textcoords="offset points", fontsize=8,
+                        color=INK_MUTED, va="top")
+
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel("request size (KB, log)", fontsize=9, color=INK)
+    ax.set_ylabel("median latency (ms, log)", fontsize=9, color=INK)
+    ax.set_title("bookcatalog: latency vs request size, Paxos vs primary-backup",
+                 fontsize=10, color=INK)
+    ax.tick_params(labelsize=8, colors=INK_MUTED)
+    for s in ("top", "right"):
+        ax.spines[s].set_visible(False)
+    for s in ("left", "bottom"):
+        ax.spines[s].set_color(GRID)
+    ax.grid(which="both", color=GRID, linewidth=0.6)
+    ax.set_axisbelow(True)
+    ax.legend(frameon=False, fontsize=8, loc="upper left")
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=180 if not args.pdf else None,
+                format="pdf" if args.pdf else None, facecolor="#fcfcfb")
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/protocol_switch_README.md
+++ b/eval/protocol_switch_README.md
@@ -1,0 +1,128 @@
+# Dynamic protocol switch demo (Paxos -> primary-backup)
+
+Prototype on branch `protocol-switch`. Switches a running deterministic
+service from active replication (Paxos) to primary-backup at runtime via an
+in-place placement update, to show lower latency under a large-request /
+small-statediff workload (e.g. bookcatalog padded POSTs whose extra JSON
+fields the app parses and drops).
+
+## Mechanism (implemented)
+
+- `ServiceProperty` carries an optional `replication` field
+  (`active` | `primary-backup`); `XdnReplicaCoordinator.inferCoordinatorByProperties`
+  honors it before the determinism/consistency inference.
+- The RC placement endpoint accepts `"REPLICATION": "primary-backup"` in the
+  `PUT /api/v2/services/{name}/placement` body; it rides the placement
+  metadata (`REPLICATION_MODE` key) into the next epoch, where the AR stamps
+  it on the property so it is sticky (round-trips through every future epoch
+  final state, like the cluster ordinal map).
+- The epoch's container state tar is protocol-agnostic, so a Paxos-epoch
+  checkpoint restores cleanly into a primary-backup epoch. `XdnGigapaxosApp`
+  now treats the PB nondeter-create/revive prefixes (not the determinism
+  flag) as the signal to initialize the statediff recorder, so a switched
+  deterministic service gets recorder setup and does not wipe its restored
+  state.
+
+## Trigger the switch
+
+    curl -X PUT http://<rc>:3300/api/v2/services/bookcatalog/placement \
+      -H 'Content-Type: application/json' \
+      -d '{"NODES":["AR1","AR2","AR3"],"COORDINATOR":"AR1","REPLICATION":"primary-backup"}'
+
+The COORDINATOR becomes the PB primary. Primary election converges in a few
+seconds; requests during that window may fail (part of the story).
+
+## Requirements for a fair latency measurement
+
+- **Linux + FUSELOG/FUSERUST recorder** (`XDN_PB_STATEDIFF_RECORDER_TYPE=FUSELOG`).
+  RSYNC spawns a subprocess per capture (~250ms floor on macOS loopback) that
+  swamps the request-vs-diff saving; the switch mechanism is correct there but
+  the latency win is invisible. Verified: a 200KB padded POST yields a
+  106-byte rsync statediff (~2000:1), so the size asymmetry is real; only the
+  capture cost is the blocker.
+- **`RECONFIGURE_IN_PLACE=true`** (already set in `conf/gigapaxos.cloudlab.properties`).
+  Without it a same-active-set placement update no-ops. Locally the switch
+  fired only because the COORDINATOR change forced reconfiguration.
+- Tune the primary's capture accumulation low: `-DPB_CAPTURE_ACCUMULATION_US=500`.
+
+## Run
+
+    # cluster up under Paxos, bookcatalog launched deterministic=true, then:
+    python3 eval/protocol_switch_demo.py \
+        --frontends 10.10.1.1:2300,10.10.1.2:2300,10.10.1.3:2300 \
+        --rc 10.10.1.1:3300 --service bookcatalog \
+        --nodes AR1,AR2,AR3 --primary AR1 \
+        --pad-bytes 200000 --duration 90 --switch-at 45 \
+        --rate 40 --workers 16 --out /tmp/psw-demo.json
+    python3 eval/plot_protocol_switch.py -o psw.png /tmp/psw-demo.json
+
+The harness is open-loop (worker pool) so the election window does not freeze
+the timeline. The plot shows median latency over time with the switch marked.
+Route all traffic to the primary's frontend with `--entry` (under PB only the
+primary serves; hitting a backup frontend hangs).
+
+## Result (Clemson r6525, fuselog, 2026-08-04)
+
+`eval/datasets/protocol-switch/bookcatalog-1mb-bw100mbit.json`: median latency
+**234ms (Paxos) -> 30ms (primary-backup)**, ~8x, after an in-place switch at
+t=60s, 1MB incompressible requests, 3 replicas, inter-replica egress shaped to
+100mbit. The Paxos-only baseline
+(`bookcatalog-1mb-paxos-baseline.json`, 180s, no switch) is flat at ~230ms,
+confirming this is a genuine steady-state protocol difference, not a warmup
+artifact. The switch is timestamped at INITIATION; a ~15s primary-election
+gap follows (no successful requests) before PB serves at ~30ms.
+
+TWO METHODOLOGY BUGS were found and fixed to get an honest result (both
+initially FAKED a win):
+- **Compressible padding.** A `"x"*N` blob compresses to ~nothing, so the
+  "1MB request" was ~1KB on the wire and never exercised the bandwidth
+  mechanism (Paxos measured ~28ms == PB, the bandwidth shaping did nothing).
+  The pad is now base64(os.urandom) -- incompressible -- so 1MB is really 1MB
+  on the wire and Paxos pays ~230ms to replicate it. THIS is what makes the
+  win real.
+- **Warmup ramp masqueraded as the switch.** With the compressible pad,
+  Paxos latency declined 52->28ms over ~90s (JIT/TCP), and a 30s warmup ended
+  mid-ramp so the switch at t=60 coincided with the tail of the decline and
+  looked causal. A Paxos-only baseline exposed this: Paxos alone reaches PB's
+  latency with no switch at all. Fixed by incompressible padding (removes the
+  ramp -- the real 230ms bandwidth cost dwarfs JIT/TCP noise) plus verifying
+  against the flat baseline.
+
+Three findings that shape the honest framing:
+
+- **The latency win requires inter-replica BANDWIDTH to be the bottleneck.**
+  On the bare Clemson LAN both protocols sit at ~10ms because replicating even
+  1MB is nearly free. The result above shapes the ARs' egress with `tc tbf
+  rate 100mbit` (pure token bucket, NO injected delay) so replicating the 1MB
+  request to each backup costs real time while PB's tiny statediff does not.
+  Only the inter-replica REPLICATION leg is shaped; client ingress (via the
+  driver, unshaped) is fast and equal for both protocols. A latency-bound
+  config (adding netem delay) makes Paxos ~= PB because both pay similar RTT
+  rounds -- the request-vs-diff SIZE difference only shows when bandwidth is
+  the constraint. tbf `latency 5000ms` (queue depth) is required so large
+  flows queue rather than tail-drop (a small value collapses throughput via
+  TCP retransmits -- an early 1MB run got 0 ok).
+- **The bandwidth number is a stand-in for the ratio.** The win magnitude is
+  (request - statediff) x (replicas-1) / bandwidth; 1MB/100mbit gives Paxos
+  ~230ms of replication cost that PB avoids. 100mbit is a realistic per-vNIC /
+  edge-uplink cap and 1MB a realistic document/media request; the same win
+  follows from any combination with the same ratio. The request must be
+  INCOMPRESSIBLE or the ratio is meaningless (see methodology bugs above).
+- **Switch under LOW load only.** Hammering the service during the epoch
+  transition wedges the primary election (in-flight requests never drain, no
+  primary elected, no container); low load (a few req/s) transitions cleanly.
+  Fine for latency measurement (low concurrency = cleaner per-request latency
+  anyway) but switch-under-load robustness is a real follow-up (the
+  under-tested PB epoch path).
+
+## Workload realism
+
+The 200KB padded POST (a `blob` field the app parses and drops) is a
+stand-in that dials the request:statediff ratio; the mechanism is identical
+to real large-request/small-diff patterns: a large document persisted as a
+server-side projection (WordPress editPost: full HTML body >> DB delta;
+image upload -> stored thumbnail), periodic full-catalog sync at low change
+rate (ONIX feed ingestion: large batch of real records, few actually
+changed), and idempotent re-writes / duplicate submissions (zero diff). A
+paper-grade bookcatalog workload would batch-upsert records carrying real
+`description` fields at a low change rate (archetype 2) so nothing is padded.

--- a/eval/protocol_switch_demo.py
+++ b/eval/protocol_switch_demo.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Protocol-switch latency demo for XDN.
+
+Drives bookcatalog with the large-request / small-statediff workload (padded
+POSTs whose extra fields the app parses and drops, so the on-disk row is
+tiny) while measuring per-request latency over time. Partway through, it
+flips the service from active replication (Paxos) to primary-backup via an
+in-place placement update. Under this workload primary-backup replicates the
+small statediff instead of the large request, so median latency drops after
+the switch.
+
+Output: a JSON time series (t, latency_ms, phase) and, if matplotlib is
+present, a median-latency-over-time plot with the switch annotated.
+
+Open-loop by design: a fixed pool of workers issues requests concurrently at
+a target rate, so the seconds-long primary-election window after the switch
+does not freeze the timeline (a closed-loop driver would serialize behind the
+first timeout and lose all post-switch samples). Requires a fast statediff
+recorder to show the latency win: on Linux use FUSELOG/FUSERUST, not RSYNC
+(rsync spawns a subprocess per capture, adding a ~250ms floor that swamps the
+request-vs-diff saving). Tune the primary's capture accumulation low, e.g.
+-DPB_CAPTURE_ACCUMULATION_US=500.
+
+Usage (from a running cluster with bookcatalog launched under Paxos):
+  python3 eval/protocol_switch_demo.py \
+      --frontends 10.10.1.1:2300,10.10.1.2:2300,10.10.1.3:2300 \
+      --rc 10.10.1.1:3300 --service bookcatalog \
+      --nodes AR1,AR2,AR3 --primary AR1 \
+      --pad-bytes 200000 --duration 90 --switch-at 45 \
+      --rate 40 --workers 16 --out /tmp/psw-demo.json
+"""
+
+import argparse
+import base64
+import json
+import os
+import queue
+import statistics
+import sys
+import threading
+import time
+import urllib.request
+
+
+def make_body(book_id, pad_bytes):
+    """Request body with an INCOMPRESSIBLE pad. The 'blob' field is not in the
+    app schema, so the server parses and discards it: large request, tiny
+    statediff. base64(os.urandom) is incompressible -- a naive 'x'*N pad
+    gzips to nothing, so any compression in the HTTP/replication path would
+    make the 'large' request tiny on the wire and the bandwidth experiment
+    would measure nothing."""
+    blob = base64.b64encode(os.urandom((pad_bytes * 3) // 4)).decode()
+    return json.dumps({"id": book_id, "title": "T", "author": "A", "blob": blob}).encode()
+
+
+def post_book(frontend, service, book_id, pad_bytes, update_id=None):
+    """One write. Default: POST a new row (unique id). With update_id set:
+    PUT the SAME row, so the table size stays constant (an idempotent
+    re-write -- the persisted columns don't change, only the dropped blob),
+    which keeps the statediff small and constant and avoids growing the
+    epoch-transition state tar."""
+    if update_id is not None:
+        url = f"http://{frontend}/api/books/{update_id}"
+        method = "PUT"
+        data = make_body(update_id, pad_bytes)
+    else:
+        url = f"http://{frontend}/api/books"
+        method = "POST"
+        data = make_body(book_id, pad_bytes)
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={"XDN": service, "Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            resp.read()
+        ok = True
+    except Exception:
+        ok = False
+    return (time.time() - t0) * 1000.0, ok
+
+
+def seed_book(frontend, service, book_id):
+    """POST a book so a later PUT to it succeeds (UpdateBook 404s otherwise)."""
+    data = json.dumps({"id": book_id, "title": "T", "author": "A"}).encode()
+    req = urllib.request.Request(
+        f"http://{frontend}/api/books", data=data, method="POST",
+        headers={"XDN": service, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            resp.read()
+    except Exception:
+        pass
+
+
+def switch_to_pb(rc, service, nodes, primary):
+    body = {"NODES": nodes, "COORDINATOR": primary, "REPLICATION": "primary-backup"}
+    req = urllib.request.Request(
+        f"http://{rc}/api/v2/services/{service}/placement",
+        data=json.dumps(body).encode(), method="PUT",
+        headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        resp.read()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--frontends", required=True, help="comma-separated host:port")
+    ap.add_argument("--rc", required=True, help="reconfigurator host:port")
+    ap.add_argument("--service", default="bookcatalog")
+    ap.add_argument("--nodes", required=True, help="comma-separated AR ids for the switch")
+    ap.add_argument("--primary", required=True, help="AR id to become PB primary")
+    ap.add_argument("--entry", help="single frontend host:port for ALL requests "
+                    "(default: rotate). Set to the primary's frontend so the switch does "
+                    "not send traffic to non-serving backups.")
+    ap.add_argument("--pad-bytes", type=int, default=200000)
+    ap.add_argument("--update-id", type=int,
+                    help="PUT this fixed book id every request (constant table size, "
+                    "idempotent re-write) instead of POSTing unique rows")
+    ap.add_argument("--duration", type=float, default=60.0)
+    ap.add_argument("--switch-at", type=float, default=30.0)
+    ap.add_argument("--rate", type=float, default=40.0, help="target requests/sec")
+    ap.add_argument("--workers", type=int, default=16, help="concurrent request workers")
+    ap.add_argument("--warmup", type=float, default=20.0,
+                    help="seconds of unrecorded warmup before measurement (JVM JIT + "
+                    "connection-pool ramp), so the pre-switch baseline is flat")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    frontends = args.frontends.split(",")
+    nodes = args.nodes.split(",")
+    samples = []
+    samples_lock = threading.Lock()
+    switch_done = {"t": None}
+    stop = threading.Event()
+    recording = threading.Event()  # set once warmup ends; workers only record then
+    start_holder = {"t": time.time()}  # measurement t=0, reset after warmup
+
+    def do_switch():
+        # Mark the switch at INITIATION, not completion: the placement PUT takes
+        # a few seconds to coordinate at the RC, during which PB already takes
+        # over and latency drops. Timestamping at return would plot those fast
+        # samples just before the switch line (a spurious pre-switch dip).
+        switch_done["t"] = time.time()
+        switch_to_pb(args.rc, args.service, nodes, args.primary)
+
+    # Open-loop generator: enqueue one job per tick at the target rate; a
+    # bounded pool of workers services them concurrently, so slow requests
+    # (e.g. during the election window) never stall the timeline.
+    jobs = queue.Queue(maxsize=args.workers * 4)
+    counter = {"n": 0}
+    counter_lock = threading.Lock()
+
+    def worker():
+        while not stop.is_set():
+            try:
+                book_id = jobs.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            fe = args.entry if args.entry else frontends[book_id % len(frontends)]
+            lat, ok = post_book(fe, args.service, book_id, args.pad_bytes, args.update_id)
+            if recording.is_set():
+                phase = "paxos" if switch_done["t"] is None else "primary-backup"
+                with samples_lock:
+                    samples.append({"t": round(time.time() - start_holder["t"], 4),
+                                    "latency_ms": round(lat, 3), "ok": ok,
+                                    "phase": phase, "frontend": fe})
+            jobs.task_done()
+
+    # For PUT mode, seed the target row so UpdateBook doesn't 404.
+    if args.update_id is not None:
+        seed_fe = args.entry if args.entry else frontends[0]
+        seed_book(seed_fe, args.service, args.update_id)
+        time.sleep(1)
+
+    pool = [threading.Thread(target=worker, daemon=True) for _ in range(args.workers)]
+    for w in pool:
+        w.start()
+
+    def generate(until, tag):
+        """Enqueue at the target rate until `until` seconds elapse from now."""
+        t0 = time.time()
+        interval = 1.0 / args.rate if args.rate > 0 else 0
+        switched = [False]
+        while True:
+            now = time.time()
+            elapsed = now - t0
+            if elapsed >= until:
+                break
+            if tag == "measure" and not switched[0] and elapsed >= args.switch_at:
+                threading.Thread(target=do_switch, daemon=True).start()
+                switched[0] = True
+            with counter_lock:
+                book_id = 1000 + counter["n"]
+                counter["n"] += 1
+            try:
+                jobs.put(book_id, timeout=1.0)
+            except queue.Full:
+                pass
+            if interval:
+                sleep = interval - (time.time() - now)
+                if sleep > 0:
+                    time.sleep(sleep)
+
+    # Warmup: drive load, record nothing (lets the JVM JIT-compile and the
+    # HTTP connection pools fill, so the pre-switch baseline is already flat).
+    if args.warmup > 0:
+        print(f"[warmup] {args.warmup:.0f}s (unrecorded)", flush=True)
+        generate(args.warmup, "warmup")
+
+    # Measurement window: reset t=0 and start recording.
+    start_holder["t"] = time.time()
+    recording.set()
+    generate(args.duration, "measure")
+
+    stop.set()
+    for w in pool:
+        w.join(timeout=20)
+
+    switch_rel = (switch_done["t"] - start_holder["t"]) if switch_done["t"] else args.switch_at
+    samples.sort(key=lambda s: s["t"])
+    out = {
+        "service": args.service,
+        "pad_bytes": args.pad_bytes,
+        "duration": args.duration,
+        "switch_at_rel": round(switch_rel, 3),
+        "samples": samples,
+    }
+    with open(args.out, "w") as f:
+        json.dump(out, f)
+
+    # Per-sample CSV alongside the JSON (same basename), for external analysis.
+    csv_path = args.out.rsplit(".", 1)[0] + ".csv"
+    with open(csv_path, "w") as f:
+        f.write("t_s,latency_ms,ok,phase,frontend,switch_at_s,pad_bytes\n")
+        for s in samples:
+            f.write("%s,%s,%d,%s,%s,%s,%d\n" % (
+                s["t"], s["latency_ms"], 1 if s["ok"] else 0,
+                s["phase"], s["frontend"], switch_rel, args.pad_bytes))
+
+    ok_lat = [s["latency_ms"] for s in samples if s["ok"]]
+    pre = [s["latency_ms"] for s in samples if s["ok"] and s["phase"] == "paxos"]
+    post = [s["latency_ms"] for s in samples if s["ok"] and s["phase"] == "primary-backup"]
+    print(f"[done] {len(samples)} reqs ({len(ok_lat)} ok) -> {args.out}")
+    if pre:
+        print(f"  paxos          median={statistics.median(pre):.1f}ms  n={len(pre)}")
+    if post:
+        print(f"  primary-backup median={statistics.median(post):.1f}ms  n={len(post)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/protocol_switch_sweep.py
+++ b/eval/protocol_switch_sweep.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Steady-state latency vs request size, for one running service (Paxos or PB).
+
+Warms up ONCE (past the ~90s gigapaxos ramp), then measures median latency at
+each request size against a fixed frontend. Run it against a Paxos service and
+again against the same service after switching to primary-backup, then plot
+both curves with eval/plot_switch_sweep.py to find the crossover request size
+(the decision threshold for a dynamic protocol selector).
+
+  python3 eval/protocol_switch_sweep.py --frontend 10.10.1.1:2300 \
+      --service bookcatalog --update-id 1 --label paxos \
+      --sizes 1024,4096,16384,65536,262144,1048576 \
+      --warmup 100 --per-size 40 --rate 4 --workers 3 --out /tmp/sweep-paxos.json
+"""
+import argparse
+import base64
+import json
+import os
+import queue
+import statistics
+import threading
+import time
+import urllib.request
+
+
+def body(book_id, n):
+    blob = base64.b64encode(os.urandom((n * 3) // 4)).decode()
+    return json.dumps({"id": book_id, "title": "T", "author": "A", "blob": blob}).encode()
+
+
+def seed(frontend, service, book_id):
+    d = json.dumps({"id": book_id, "title": "T", "author": "A"}).encode()
+    r = urllib.request.Request(f"http://{frontend}/api/books", data=d, method="POST",
+                               headers={"XDN": service, "Content-Type": "application/json"})
+    try:
+        urllib.request.urlopen(r, timeout=15).read()
+    except Exception:
+        pass
+
+
+def put(frontend, service, book_id, n):
+    r = urllib.request.Request(f"http://{frontend}/api/books/{book_id}", data=body(book_id, n),
+                               method="PUT", headers={"XDN": service, "Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        urllib.request.urlopen(r, timeout=30).read()
+        ok = True
+    except Exception:
+        ok = False
+    return (time.time() - t0) * 1000.0, ok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--frontend", required=True)
+    ap.add_argument("--service", default="bookcatalog")
+    ap.add_argument("--update-id", type=int, default=1)
+    ap.add_argument("--label", required=True, help="paxos | primary-backup")
+    ap.add_argument("--sizes", required=True, help="comma-separated request sizes in bytes")
+    ap.add_argument("--warmup", type=float, default=100.0)
+    ap.add_argument("--per-size", type=float, default=40.0)
+    ap.add_argument("--rate", type=float, default=4.0)
+    ap.add_argument("--workers", type=int, default=3)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    sizes = [int(x) for x in args.sizes.split(",")]
+    cur = {"n": sizes[0]}                 # current request size for workers
+    lat = []                              # (size, latency_ms, ok) collected in the active window
+    lat_lock = threading.Lock()
+    recording = threading.Event()
+    stop = threading.Event()
+    jobs = queue.Queue(maxsize=args.workers * 4)
+
+    def worker():
+        while not stop.is_set():
+            try:
+                jobs.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            n = cur["n"]
+            ms, ok = put(args.frontend, args.service, args.update_id, n)
+            if recording.is_set():
+                with lat_lock:
+                    lat.append((n, ms, ok))
+            jobs.task_done()
+
+    seed(args.frontend, args.service, args.update_id)
+    time.sleep(1)
+    pool = [threading.Thread(target=worker, daemon=True) for _ in range(args.workers)]
+    for w in pool:
+        w.start()
+
+    interval = 1.0 / args.rate if args.rate > 0 else 0
+
+    def drive(seconds):
+        t0 = time.time()
+        while time.time() - t0 < seconds:
+            now = time.time()
+            try:
+                jobs.put(1, timeout=1.0)
+            except queue.Full:
+                pass
+            if interval:
+                s = interval - (time.time() - now)
+                if s > 0:
+                    time.sleep(s)
+
+    # Warm up at the largest size (heaviest path) so every measured point is post-ramp.
+    print(f"[{args.label}] warmup {args.warmup:.0f}s", flush=True)
+    cur["n"] = sizes[-1]
+    drive(args.warmup)
+
+    results = []
+    recording.set()
+    for n in sizes:
+        cur["n"] = n
+        with lat_lock:
+            lat.clear()
+        drive(args.per_size)
+        with lat_lock:
+            oks = [ms for (sz, ms, ok) in lat if ok and sz == n]
+        med = statistics.median(oks) if oks else None
+        p90 = statistics.quantiles(oks, n=10)[8] if len(oks) >= 10 else None
+        results.append({"size": n, "median_ms": med, "p90_ms": p90, "n": len(oks)})
+        print(f"  size={n:8d}B  median={med}  n={len(oks)}", flush=True)
+
+    stop.set()
+    out = {"label": args.label, "frontend": args.frontend, "service": args.service,
+           "results": results}
+    with open(args.out, "w") as f:
+        json.dump(out, f)
+    # CSV too
+    with open(args.out.rsplit(".", 1)[0] + ".csv", "w") as f:
+        f.write("label,size_bytes,median_ms,p90_ms,n\n")
+        for r in results:
+            f.write(f"{args.label},{r['size']},{r['median_ms']},{r['p90_ms']},{r['n']}\n")
+    print(f"[done] -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/psw_json_to_csv.py
+++ b/eval/psw_json_to_csv.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Convert protocol_switch_demo.py JSON output to per-sample CSV.
+
+  python3 eval/psw_json_to_csv.py results.json [more.json ...]
+Writes <name>.csv next to each input.
+"""
+import json
+import sys
+
+
+def convert(path):
+    d = json.load(open(path))
+    sw = d.get("switch_at_rel", "")
+    pad = d.get("pad_bytes", "")
+    out = path.rsplit(".", 1)[0] + ".csv"
+    with open(out, "w") as f:
+        f.write("t_s,latency_ms,ok,phase,frontend,switch_at_s,pad_bytes\n")
+        for s in sorted(d["samples"], key=lambda x: x["t"]):
+            f.write("%s,%s,%d,%s,%s,%s,%s\n" % (
+                s["t"], s["latency_ms"], 1 if s["ok"] else 0,
+                s["phase"], s.get("frontend", ""), sw, pad))
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    for p in sys.argv[1:]:
+        convert(p)


### PR DESCRIPTION
Third of a 3-PR stack (on top of the optimizations). Adds the measurement
harnesses and runbook; the datasets they produce under
`eval/datasets/protocol-switch/` are **gitignored** (results, not source —
regenerate with the harnesses).

- `eval/protocol_switch_demo.py` — open-loop switch-over-time latency demo.
- `eval/protocol_switch_sweep.py` — steady-state latency vs request size (the crossover).
- `eval/plot_protocol_switch.py`, `eval/plot_switch_sweep.py` — plotters.
- `eval/protocol_switch_README.md` — methodology + runbook.
- `conf/gigapaxos.xdn.clemson.properties` — FUSELOG recorder, in-place reconfig.

The crossover (where primary-backup starts winning) tracks bandwidth:
~16–32 KB at 100 Mbit, ~2.6 KB at 20 Mbit.

Stack: mechanism → optimizations → **eval**.
