### PR TITLE
xdn-cli: handle bracketed IPv6 addresses in service info

### DIFF
--- a/xdn-cli/cmd/service.go
+++ b/xdn-cli/cmd/service.go
@@ -212,7 +212,8 @@ var ServiceInfoCmd = &cobra.Command{
 				if httpAddrStr, ok := httpAddrIf.(string); ok && httpAddrStr != "" {
 					_, httpIP, parsedPort, ok := parseNodeSocketAddress(httpAddrStr)
 					if ok {
-						httpBaseURL = fmt.Sprintf("http://%s:%d", httpIP, parsedPort)
+						// JoinHostPort brackets IPv6 literals so the URL stays valid.
+						httpBaseURL = "http://" + net.JoinHostPort(httpIP, strconv.Itoa(parsedPort))
 						httpPort = parsedPort
 					}
 				}
@@ -870,22 +871,33 @@ type replicaInfo struct {
 }
 
 // parseNodeSocketAddress parses Java InetSocketAddress.toString() output
-// like "c240g5.wisc.cloudlab.us/128.105.144.59:2000" or "/127.0.0.1:2001".
-// Returns host (may be empty), ip, port; ok=false on malformed input.
+// like "c240g5.wisc.cloudlab.us/128.105.144.59:2000", "/127.0.0.1:2001", or,
+// for IPv6 nodes, "/[2600:1f18:1376:5a02:0:0:0:a]:2000".
+// Returns host (may be empty), ip (without brackets), port; ok=false on
+// malformed input.
 func parseNodeSocketAddress(s string) (host, ip string, port int, ok bool) {
-	hostPort := strings.SplitN(s, ":", 2)
-	if len(hostPort) != 2 {
+	slash := strings.Index(s, "/")
+	if slash < 0 {
 		return "", "", 0, false
 	}
-	hostIP := strings.SplitN(hostPort[0], "/", 2)
-	if len(hostIP) != 2 {
-		return "", "", 0, false
+	host = s[:slash]
+	addrPort := s[slash+1:]
+	ipStr, portStr, err := net.SplitHostPort(addrPort)
+	if err != nil {
+		// Older JDKs print IPv6 without brackets ("/2600::a:2000"), which
+		// net.SplitHostPort rejects; take the text after the last colon as
+		// the port.
+		colon := strings.LastIndex(addrPort, ":")
+		if colon < 0 {
+			return "", "", 0, false
+		}
+		ipStr, portStr = addrPort[:colon], addrPort[colon+1:]
 	}
-	p, err := strconv.Atoi(hostPort[1])
+	p, err := strconv.Atoi(portStr)
 	if err != nil {
 		return "", "", 0, false
 	}
-	return hostIP[0], hostIP[1], p, true
+	return host, ipStr, p, true
 }
 
 // fetchReplicaInfo queries the AR's /replica/info endpoint. The AR HTTP

--- a/xdn-cli/cmd/service_test.go
+++ b/xdn-cli/cmd/service_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import "testing"
+
+func TestParseNodeSocketAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		wantHost string
+		wantIP   string
+		wantPort int
+		wantOK   bool
+	}{
+		{
+			name:     "ipv4 with hostname",
+			in:       "c240g5.wisc.cloudlab.us/128.105.144.59:2000",
+			wantHost: "c240g5.wisc.cloudlab.us",
+			wantIP:   "128.105.144.59",
+			wantPort: 2000,
+			wantOK:   true,
+		},
+		{
+			name:     "ipv4 without hostname",
+			in:       "/127.0.0.1:2001",
+			wantHost: "",
+			wantIP:   "127.0.0.1",
+			wantPort: 2001,
+			wantOK:   true,
+		},
+		{
+			name:     "bracketed ipv6",
+			in:       "/[2600:1f18:1376:5a02:0:0:0:a]:2000",
+			wantHost: "",
+			wantIP:   "2600:1f18:1376:5a02:0:0:0:a",
+			wantPort: 2000,
+			wantOK:   true,
+		},
+		{
+			name:     "bracketed ipv6 with hostname",
+			in:       "ar1.xdn.io/[2600:1f18:1376:5a02:0:0:0:a]:2300",
+			wantHost: "ar1.xdn.io",
+			wantIP:   "2600:1f18:1376:5a02:0:0:0:a",
+			wantPort: 2300,
+			wantOK:   true,
+		},
+		{
+			name:     "unbracketed ipv6 (older JDK toString)",
+			in:       "/2600:1f18:1376:5a02:0:0:0:a:2000",
+			wantHost: "",
+			wantIP:   "2600:1f18:1376:5a02:0:0:0:a",
+			wantPort: 2000,
+			wantOK:   true,
+		},
+		{name: "no slash", in: "127.0.0.1:2000", wantOK: false},
+		{name: "no port", in: "/127.0.0.1", wantOK: false},
+		{name: "non-numeric port", in: "/127.0.0.1:http", wantOK: false},
+		{name: "empty", in: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, ip, port, ok := parseNodeSocketAddress(tt.in)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if host != tt.wantHost || ip != tt.wantIP || port != tt.wantPort {
+				t.Errorf("got (%q, %q, %d), want (%q, %q, %d)",
+					host, ip, port, tt.wantHost, tt.wantIP, tt.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`xdn service info` skipped every replica on IPv6 deployments (e.g. the AWS multiregion cluster, where ARs join consensus over global IPv6):

```
warn: skipping replica useast1b: unexpected ADDRESS "/[2600:1f18:1376:5a02:0:0:0:a]:2000"
```

`parseNodeSocketAddress` split on the first `:`, which only works for IPv4. The placement table rendered empty and all service-wide fields showed `unknown`.

## Fix

- Parse the host part up to the first `/`, then use `net.SplitHostPort` for the address:port (handles bracketed IPv6 and IPv4), with a last-colon fallback for unbracketed IPv6 from older JDK `toString()`.
- Build `httpBaseURL` with `net.JoinHostPort` so IPv6 literals are bracketed in the replica URLs.
- Add table-driven unit tests covering IPv4, bracketed/unbracketed IPv6, hostname prefixes, and malformed inputs.

## Verification

Against the live AWS multiregion deployment (`cp.xdnapp.com`), `xdn service info bookcatalog` now renders all 3 replicas with correct addresses and bracketed URLs:

```
| 39.0400,-77.4900  | useast1a | 2600:1f18:1376:5a01:0:0:0:a | 2300 | ... | http://[2600:1f18:1376:5a01:0:0:0:a]:2300/?_xdnsvc=bookcatalog |
```

`gofmt`/`go vet` clean; `go test ./cmd/` passes.