### PR TITLE
Fix service destroy: clear paxos final state on drop, unhang CLI confirmation

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -127,6 +127,7 @@ jobs:
           - XdnGetReplicaInfoTest
           - XdnMultiServiceTest
           - XdnPerReplicaRequestTest
+          - XdnServiceDestroyRecreateTest
           - XdnSetCoordinatorNodeTest
           - XdnTaggedImageLaunchTest
           - XdnClusterLaunchTest

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -1581,6 +1581,9 @@ public class XdnGigapaxosApp
     String removeDirCommand = String.format("rm -rf %s", toBeRemovedMountDir);
     int code = Shell.runCommand(removeDirCommand);
     assert code == 0;
+    // prune the now-empty per-service parent; rmdir refuses non-empty dirs, so
+    // this is a no-op while another epoch's state still lives here
+    Shell.runCommand("rmdir " + Paths.get(toBeRemovedMountDir).getParent());
 
     logger.log(
         Level.FINE,

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -896,6 +896,25 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
   }
 
   @Override
+  public boolean deleteFinalState(String serviceName, int epoch) {
+    // App-level cleanup: remove this epoch's containers and state directories.
+    boolean isAppStateDeleted = this.xdnGigapaxosApp.deleteFinalState(serviceName, epoch);
+
+    // Paxos-level cleanup: remove the epoch-final checkpoint from the paxos logger.
+    // Without this, re-creating a destroyed service under the same name is refused
+    // forever: the on-disk stopped epoch trips gigapaxos' going-back-in-time check
+    // (createPaxosInstanceFinal's equalOrHigherVersionStopped), every AR throws
+    // PaxosInstanceCreationException, and the reconfigurator resends START_EPOCH
+    // indefinitely. The paxos, primary-backup, and sequential (Aw) coordinators all
+    // share one PaxosManager, so delegating to paxosCoordinator covers every
+    // paxos-backed service; for services without paxos state this is a no-op that
+    // returns true.
+    boolean isPaxosStateDeleted = this.paxosCoordinator.deleteFinalState(serviceName, epoch);
+
+    return isAppStateDeleted && isPaxosStateDeleted;
+  }
+
+  @Override
   public Set<NodeIDType> getReplicaGroup(String serviceName) {
     var coordinator = this.serviceCoordinator.get(serviceName);
     if (coordinator == null) {

--- a/src/edu/umass/cs/xdn/recorder/FuseRustStateDiffRecorder.java
+++ b/src/edu/umass/cs/xdn/recorder/FuseRustStateDiffRecorder.java
@@ -395,6 +395,19 @@ public class FuseRustStateDiffRecorder extends AbstractStateDiffRecorder {
     int umountRetCode = Shell.runCommand("fusermount -u " + targetDir, false);
     int rmRetCode = Shell.runCommand("rm -rf " + targetDir, false);
     assert rmRetCode == 0;
+    // prune this epoch's socket and stateDiff files, which otherwise outlive the service
+    Shell.runCommand(
+        String.format(
+            "rm -f %s%s::%d.sock %s%s::%d::apply.sock %s%s::%d.diff",
+            baseSocketDirPath,
+            serviceName,
+            placementEpoch,
+            baseSocketDirPath,
+            serviceName,
+            placementEpoch,
+            baseDiffDirPath,
+            serviceName,
+            placementEpoch));
     return true;
   }
 

--- a/src/edu/umass/cs/xdn/recorder/FuselogStateDiffRecorder.java
+++ b/src/edu/umass/cs/xdn/recorder/FuselogStateDiffRecorder.java
@@ -831,6 +831,17 @@ public class FuselogStateDiffRecorder extends AbstractStateDiffRecorder {
       return false;
     }
 
+    // prune this epoch's socket and stateDiff files, which otherwise outlive the service
+    Shell.runCommand(
+        String.format(
+            "rm -f %s%s::%d.sock %s%s::%d.diff",
+            baseSocketDirPath,
+            serviceName,
+            placementEpoch,
+            baseDiffDirPath,
+            serviceName,
+            placementEpoch));
+
     return true;
   }
 

--- a/src/edu/umass/cs/xdn/recorder/RsyncStateDiffRecorder.java
+++ b/src/edu/umass/cs/xdn/recorder/RsyncStateDiffRecorder.java
@@ -258,6 +258,17 @@ public class RsyncStateDiffRecorder extends AbstractStateDiffRecorder {
     String targetDir = this.getTargetDirectory(serviceName, placementEpoch);
     int retCode = Shell.runCommand("rm -rf " + targetDir);
     assert retCode == 0;
+    // prune the now-empty per-service parents; rmdir refuses non-empty dirs, so
+    // this is a no-op while another epoch's state still lives here
+    Shell.runCommand(
+        String.format(
+            "rmdir %s%s %s%s %s%s",
+            baseMountDirPath,
+            serviceName,
+            baseSnapshotDirPath,
+            serviceName,
+            baseDiffDirPath,
+            serviceName));
     return true;
   }
 

--- a/test/edu/umass/cs/xdn/XdnServiceDestroyRecreateTest.java
+++ b/test/edu/umass/cs/xdn/XdnServiceDestroyRecreateTest.java
@@ -1,0 +1,108 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.xdn.util.XdnTestCluster;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class XdnServiceDestroyRecreateTest {
+
+  private static final Duration DELETE_COMPLETION_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration RECREATE_TIMEOUT = Duration.ofSeconds(90);
+
+  /**
+   * Regression test: destroying a service and re-creating it under the same name used to wedge
+   * forever. The reconfiguration drop deleted the app-level state (containers, state dirs) but
+   * never removed the paxos-level epoch-final checkpoint, so re-creating {@code name:0} tripped
+   * gigapaxos' going-back-in-time check (equalOrHigherVersionStopped) on every node that hosted the
+   * previous incarnation, each threw PaxosInstanceCreationException, and the reconfigurator re-sent
+   * START_EPOCH indefinitely. Fixed by {@code XdnReplicaCoordinator#deleteFinalState} delegating to
+   * the paxos coordinator in addition to the app-level cleanup.
+   */
+  @Test
+  public void testDestroyThenRecreateSameName() throws Exception {
+    boolean isDockerAvailable = XdnTestCluster.isDockerAvailable();
+    assertTrue(isDockerAvailable, "Docker is required for this XDN integration test");
+
+    String serviceName = "xdnsvcrecreate";
+
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+
+      // first incarnation: on a 3-AR cluster the service is placed on every node,
+      // so the re-create below hits nodes that hosted the previous incarnation.
+      cluster.launchService(
+          serviceName, "fadhilkurnia/xdn-bookcatalog", "/app/data/", "LINEARIZABLE", true);
+      HttpResponse<String> response =
+          cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      assertEquals(308, response.statusCode(), "Service did not return HTTP 308");
+
+      // destroy it and wait until the name record is fully removed
+      cluster.deleteService(serviceName);
+      awaitServiceDeleted(cluster, serviceName);
+
+      // Second incarnation under the same name must come up again. The record lingers in
+      // WAIT_DELETE for a moment after the GET above starts reporting NONEXISTENT, and a
+      // create that lands in that window is dropped without a response -- so retry until
+      // the reconfigurator accepts it. Pre-fix, the accepted re-create wedged forever
+      // (START_EPOCH re-sent indefinitely), so every attempt here kept failing.
+      long deadline = System.currentTimeMillis() + RECREATE_TIMEOUT.toMillis();
+      Exception lastLaunchFailure = null;
+      boolean isRecreated = false;
+      while (System.currentTimeMillis() < deadline) {
+        try {
+          cluster.launchService(
+              serviceName, "fadhilkurnia/xdn-bookcatalog", "/app/data/", "LINEARIZABLE", true);
+          isRecreated = true;
+          break;
+        } catch (Exception e) {
+          lastLaunchFailure = e;
+          Thread.sleep(1000);
+        }
+      }
+      assertTrue(
+          isRecreated,
+          "Re-creating the destroyed service was never accepted; last failure: "
+              + lastLaunchFailure);
+      HttpResponse<String> recreateResponse =
+          cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      assertEquals(
+          308, recreateResponse.statusCode(), "Re-created service did not return HTTP 308");
+
+      HttpResponse<String> apiResponse = cluster.sendGetRequest(serviceName, "/api/books");
+      assertEquals(200, apiResponse.statusCode(), "Re-created service did not return HTTP 200");
+      assertEquals("[]", apiResponse.body(), "Re-created service did not start from empty state");
+    }
+  }
+
+  /** Polls the reconfigurator until the service name record no longer exists. */
+  private void awaitServiceDeleted(XdnTestCluster cluster, String serviceName) throws Exception {
+    HttpClient httpClient = HttpClient.newHttpClient();
+    String endpoint =
+        "http://127.0.0.1:%d/api/v2/services/%s"
+            .formatted(cluster.getReconfiguratorHttpPort(), serviceName);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(endpoint))
+            .timeout(XdnTestCluster.REQUEST_TIMEOUT)
+            .GET()
+            .build();
+    long deadline = System.currentTimeMillis() + DELETE_COMPLETION_TIMEOUT.toMillis();
+    String lastBody = "";
+    while (System.currentTimeMillis() < deadline) {
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      lastBody = response.body();
+      if (lastBody.contains("NONEXISTENT_NAME_ERROR")) {
+        return;
+      }
+      Thread.sleep(1000);
+    }
+    fail("Service " + serviceName + " was not deleted in time; last response: " + lastBody);
+  }
+}

--- a/test/edu/umass/cs/xdn/XdnServiceDestroyRecreateTest.java
+++ b/test/edu/umass/cs/xdn/XdnServiceDestroyRecreateTest.java
@@ -38,9 +38,7 @@ public class XdnServiceDestroyRecreateTest {
       // so the re-create below hits nodes that hosted the previous incarnation.
       cluster.launchService(
           serviceName, "fadhilkurnia/xdn-bookcatalog", "/app/data/", "LINEARIZABLE", true);
-      HttpResponse<String> response =
-          cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
-      assertEquals(308, response.statusCode(), "Service did not return HTTP 308");
+      awaitServiceServing(cluster, serviceName);
 
       // destroy it and wait until the name record is fully removed
       cluster.deleteService(serviceName);
@@ -69,15 +67,44 @@ public class XdnServiceDestroyRecreateTest {
           isRecreated,
           "Re-creating the destroyed service was never accepted; last failure: "
               + lastLaunchFailure);
-      HttpResponse<String> recreateResponse =
-          cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
-      assertEquals(
-          308, recreateResponse.statusCode(), "Re-created service did not return HTTP 308");
+      awaitServiceServing(cluster, serviceName);
 
       HttpResponse<String> apiResponse = cluster.sendGetRequest(serviceName, "/api/books");
       assertEquals(200, apiResponse.statusCode(), "Re-created service did not return HTTP 200");
       assertEquals("[]", apiResponse.body(), "Re-created service did not start from empty state");
     }
+  }
+
+  /**
+   * Polls the AR frontend until bookcatalog answers its HTTP 308 redirect, i.e. the service is
+   * registered and its container is serving. {@link XdnTestCluster#awaitServiceReady} returns on
+   * any status below 500 -- including the 404 an AR answers while service registration is still
+   * propagating on a slow runner -- so poll for the expected status explicitly.
+   */
+  private void awaitServiceServing(XdnTestCluster cluster, String serviceName) throws Exception {
+    long deadline = System.currentTimeMillis() + XdnTestCluster.SERVICE_READY_TIMEOUT.toMillis();
+    Integer lastStatus = null;
+    Exception lastError = null;
+    while (System.currentTimeMillis() < deadline) {
+      try {
+        HttpResponse<String> response = cluster.invokeService(serviceName);
+        lastStatus = response.statusCode();
+        if (lastStatus == 308) {
+          assertFalse(response.body().isEmpty(), "Service returned empty body");
+          return;
+        }
+      } catch (Exception e) {
+        lastError = e;
+      }
+      Thread.sleep(1000);
+    }
+    fail(
+        "Service "
+            + serviceName
+            + " never returned HTTP 308; last status: "
+            + lastStatus
+            + ", last error: "
+            + lastError);
   }
 
   /** Polls the reconfigurator until the service name record no longer exists. */

--- a/xdn-cli/cmd/service.go
+++ b/xdn-cli/cmd/service.go
@@ -462,20 +462,24 @@ var ServiceDestroyCmd = &cobra.Command{
 		}
 
 		serviceName := args[0]
-		isValidInput := false
-		isRemoveConfirmed := false
-		for !isValidInput {
+		isRemoveConfirmed, _ := cmd.Flags().GetBool("yes")
+		input := bufio.NewScanner(os.Stdin)
+		for !isRemoveConfirmed {
 			fmt.Printf(
 				"Are you sure you want to remove `%s` service? [yes/no]\n > ",
 				serviceName)
-			input := bufio.NewScanner(os.Stdin)
-			input.Scan()
+			// Scan() returning false means stdin is closed (EOF, e.g. piped
+			// input ran out) -- treat as "no" instead of looping forever.
+			if !input.Scan() {
+				fmt.Printf("\n")
+				break
+			}
 			isSureText := input.Text()
-			if isSureText == "yes" || isSureText == "no" {
-				isValidInput = true
-				if isSureText == "yes" {
-					isRemoveConfirmed = true
-				}
+			if isSureText == "yes" {
+				isRemoveConfirmed = true
+				break
+			}
+			if isSureText == "no" {
 				break
 			}
 			fmt.Printf(
@@ -578,20 +582,24 @@ var ServiceLeaderCmd = &cobra.Command{
 		serviceName := args[0]
 		nodeID := args[1]
 
-		isValidInput := false
 		isChangeConfirmed := false
-		for !isValidInput {
+		input := bufio.NewScanner(os.Stdin)
+		for {
 			fmt.Printf(
 				"Are you sure you want to change the leader of `%s` to `%s`? [yes/no]\n > ",
 				serviceName, nodeID)
-			input := bufio.NewScanner(os.Stdin)
-			input.Scan()
+			// Scan() returning false means stdin is closed (EOF, e.g. piped
+			// input ran out) -- treat as "no" instead of looping forever.
+			if !input.Scan() {
+				fmt.Printf("\n")
+				break
+			}
 			isSureText := input.Text()
-			if isSureText == "yes" || isSureText == "no" {
-				isValidInput = true
-				if isSureText == "yes" {
-					isChangeConfirmed = true
-				}
+			if isSureText == "yes" {
+				isChangeConfirmed = true
+				break
+			}
+			if isSureText == "no" {
 				break
 			}
 			fmt.Printf(
@@ -853,6 +861,9 @@ func init() {
 	ServiceMoveCmd.Flags().StringP("leader", "l", "",
 		"Optional coordinator node ID; must be one of --nodes")
 	_ = ServiceMoveCmd.MarkFlagRequired("nodes")
+
+	ServiceDestroyCmd.Flags().BoolP("yes", "y", false,
+		"Skip the confirmation prompt (for non-interactive use)")
 }
 
 type placementReplica struct {


### PR DESCRIPTION
## Problem

`xdn service destroy` was broken in two independent ways:

**1. Server: destroy-then-recreate of the same name wedged forever.**
The reconfiguration drop (`ActiveReplica.handleDropEpochFinalState` → `appCoordinator.deleteFinalState`) only ran the app-level cleanup, because `XdnReplicaCoordinator` had no `deleteFinalState` override and fell through to `AbstractReplicaCoordinator`'s default (`app.deleteFinalState`, which removes containers and state dirs). The paxos-level epoch-final checkpoint was never removed from the paxos logger. Re-creating the destroyed name at epoch 0 then tripped gigapaxos' going-back-in-time check (`PaxosManager.createPaxosInstanceFinal`'s `equalOrHigherVersionStopped`) on every node that hosted the previous incarnation:

```
PaxosInstanceCreationException: PaxosReplicaCoordinator:3 failed to create bookcatalog:0 ...; existing_version=0
WaitAckStartEpoch0:bookcatalog:0 re-starting START_EPOCH:bookcatalog:0   (every 16s, forever)
```

**2. CLI: the confirmation prompt hung forever on stdin EOF.**
The `yes/no` loops in `service destroy` and `service leader` ignored `bufio.Scanner.Scan()`'s return value, so piped input (`echo y | xdn service destroy ...`) or ctrl-D spun the process in an infinite re-prompt loop without ever sending the request.

## Fix

- `XdnReplicaCoordinator#deleteFinalState` now runs the app-level cleanup **and** delegates to the paxos coordinator, whose `PaxosManager.deleteFinalState` removes the on-disk epoch-final checkpoint. The paxos, primary-backup, and sequential (Aw) coordinators share one `PaxosManager`, so this single delegation covers every paxos-backed service; for services without paxos state it is a documented no-op that returns true.
- CLI: `destroy` and `leader` adopt the EOF-safe confirmation pattern `service move` already uses (EOF ⇒ abort as "no"), and `destroy` gains `--yes/-y` for non-interactive use.

## Verification

- New integration test `XdnServiceDestroyRecreateTest` (launch → destroy → re-create same name → assert it serves), added to the CI integration matrix. It **fails on the pre-fix code and passes with the fix** (verified both ways on a clean host).
- Verified live on a 1-RC + 7-AR CloudLab deployment: launch → `destroy --yes` → relaunch same name succeeds, replicas serve, zero START_EPOCH retries and zero `PaxosInstanceCreationException` across all nodes.
- The test's relaunch is a retry loop by design: right after destroy the RC record briefly lingers in `WAIT_DELETE`, and a CREATE landing in that window is dropped without a response (client-side timeout); retrying until accepted is also the correct client pattern.