### PR TITLE
AR restart recovery fixes: service re-registration, replay through PB middleware, container readiness gate

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -127,6 +127,7 @@ jobs:
           - XdnGetReplicaInfoTest
           - XdnMultiServiceTest
           - XdnPerReplicaRequestTest
+          - XdnRestartRecoveryTest
           - XdnServiceDestroyRecreateTest
           - XdnSetCoordinatorNodeTest
           - XdnTaggedImageLaunchTest

--- a/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
+++ b/src/edu/umass/cs/primarybackup/PrimaryBackupManager.java
@@ -2432,14 +2432,25 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
         @Override
         public boolean execute(Request request, boolean doNotReplyToClient) {
             if (request == null) return true;
-            assert this.primaryBackupManager != null :
-                    "Ensure to set the manager for this middleware app";
 
+            // The manager can only be wired after PaxosManager's constructor returns
+            // (PrimaryBackupManager needs the PaxosManager, so it cannot exist while
+            // log-recovery replay runs inside that constructor). Requiring it for every
+            // request made each replayed app decision throw AssertionError under -ea;
+            // gigapaxos swallows the error, exhausts its execute retries, force-stops
+            // the instance, and silently drops the committed decision -- leaving the
+            // restarted replica's app state permanently behind its peers. Only the PB
+            // control packets below actually need the manager, so the requirement
+            // lives in those branches; plain app requests pass through during recovery.
             if (request instanceof StartEpochPacket startEpochPacket) {
+                assert this.primaryBackupManager != null :
+                        "Ensure to set the manager for this middleware app";
                 return this.primaryBackupManager.executeStartEpochPacket(startEpochPacket);
             }
 
             if (request instanceof ApplyStateDiffPacket stateDiffPacket) {
+                assert this.primaryBackupManager != null :
+                        "Ensure to set the manager for this middleware app";
                 return this.primaryBackupManager.executeApplyStateDiffPacket(stateDiffPacket);
             }
 
@@ -2448,6 +2459,8 @@ public class PrimaryBackupManager<NodeIDType> implements AppRequestParser {
             // raw InitBackupPacket -- dispatch it the same way as StartEpoch/ApplyStateDiff above.
             // (In legacy RSYNC mode InitBackup never reaches this path; it is messaged directly.)
             if (request instanceof InitBackupPacket initBackupPacket) {
+                assert this.primaryBackupManager != null :
+                        "Ensure to set the manager for this middleware app";
                 return this.primaryBackupManager.executeInitBackupPacket(initBackupPacket);
             }
 

--- a/src/edu/umass/cs/reconfiguration/ActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/ActiveReplica.java
@@ -207,13 +207,17 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 				HttpActiveReplica.debugAppReference = xdnGigapaxosApp;
 			}
 
-			// Initialize HTTP server
-			new HttpActiveReplica(nodeId, this, addr, ssl);
+			// Initialize HTTP server; keep the reference so close() can tear it down
+			// (otherwise the acceptor outlives this node and a same-JVM restart of the
+			// node cannot re-bind the frontend port).
+			this.httpFrontend = new HttpActiveReplica(nodeId, this, addr, ssl);
 		} catch (Exception e) {
 			if (!(e instanceof InterruptedException)) // close
 				e.printStackTrace();
 		}
 	}
+
+	private volatile HttpActiveReplica httpFrontend = null;
 
 	protected static AbstractReplicaCoordinator<?> wrapCoordinator(
 			AbstractReplicaCoordinator<?> coordinator) {
@@ -858,6 +862,11 @@ public class ActiveReplica<NodeIDType> implements ReconfiguratorCallback,
 	 * For graceful closure.
 	 */
 	public void close() {
+		HttpActiveReplica frontend = this.httpFrontend;
+		if (frontend != null) {
+			frontend.close();
+			this.httpFrontend = null;
+		}
 		this.protocolExecutor.stop();
 		this.messenger.stop();
 		this.appCoordinator.stop();

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
@@ -109,6 +109,14 @@ public class HttpActiveReplica {
 
     public final static String XDN_HOST_DOMAIN = "xdnapp.com";
 
+    // Held so close() can tear the frontend down; without this the acceptor outlives
+    // ActiveReplica.close() and a replacement node in the same JVM cannot bind the port.
+    private Channel serverChannel;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+    private DefaultEventExecutorGroup readPool;
+    private DefaultEventExecutorGroup writePool;
+
     // FIXME: used to indicate whether a single outstanding request has been executed, might go wrong when there are multiple outstanding requests
     static boolean finished;
 
@@ -219,10 +227,12 @@ public class HttpActiveReplica {
         // worker group (i.e., `workerGroup`).
         int bossThreads = Config.getGlobalInt(ReconfigurationConfig.RC.HTTP_AR_BOSS_THREADS);
         int workerThreads = Config.getGlobalInt(ReconfigurationConfig.RC.HTTP_AR_WORKER_THREADS);
-        EventLoopGroup bossGroup = bossThreads > 0
+        this.bossGroup = bossThreads > 0
                 ? new NioEventLoopGroup(bossThreads) : new NioEventLoopGroup();
-        EventLoopGroup workerGroup = workerThreads > 0
+        this.workerGroup = workerThreads > 0
                 ? new NioEventLoopGroup(workerThreads) : new NioEventLoopGroup();
+        EventLoopGroup bossGroup = this.bossGroup;
+        EventLoopGroup workerGroup = this.workerGroup;
 
         // Dedicated executor group for dispatching requests.
         int threads = Math.max(4, Runtime.getRuntime().availableProcessors());
@@ -233,12 +243,12 @@ public class HttpActiveReplica {
                 ReconfigurationConfig.RC.HTTP_AR_WRITE_POOL_MULTIPLIER);
         int writePoolSize = writePoolMultiplier > 0
                 ? threads * writePoolMultiplier : threads;
-        DefaultEventExecutorGroup writePool =
-                new DefaultEventExecutorGroup(writePoolSize);
+        this.writePool = new DefaultEventExecutorGroup(writePoolSize);
+        DefaultEventExecutorGroup writePool = this.writePool;
 
         // Pool 2: Reads
-        DefaultEventExecutorGroup readPool =
-                new DefaultEventExecutorGroup((int) (threads * 0.4));
+        this.readPool = new DefaultEventExecutorGroup((int) (threads * 0.4));
+        DefaultEventExecutorGroup readPool = this.readPool;
 
         logger.log(Level.INFO,
                 "HttpActiveReplica pools: bossThreads={0} workerThreads={1} "
@@ -287,6 +297,7 @@ public class HttpActiveReplica {
                 sockAddr = new InetSocketAddress(sockAddr.getAddress(), httpsPort);
             }
             Channel channel = b.bind(sockAddr).sync().channel();
+            this.serverChannel = channel;
 
             logger.log(Level.INFO, "HttpActiveReplica is ready on {0}", new Object[]{sockAddr});
 
@@ -307,14 +318,27 @@ public class HttpActiveReplica {
                 }
             }
 
-            channel.closeFuture().sync();
-        } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
-            readPool.shutdownGracefully();
-            writePool.shutdownGracefully();
+            // The server keeps running on the Netty event loops; the constructor returns so
+            // the owning ActiveReplica can hold a reference and close() this frontend on
+            // shutdown. It previously blocked here on closeFuture().sync(), which made the
+            // instance unreachable and left the acceptor alive after ActiveReplica.close():
+            // a replacement node in the same JVM then could not bind the port, and probes
+            // hung against the orphaned frontend.
+        } catch (Exception e) {
+            close();
+            throw e;
         }
+    }
 
+    /** Closes the server channel and releases the event loops and executor pools. */
+    public void close() {
+        if (this.serverChannel != null) {
+            this.serverChannel.close().awaitUninterruptibly(2, TimeUnit.SECONDS);
+        }
+        this.bossGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS);
+        this.workerGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS);
+        this.readPool.shutdownGracefully(0, 2, TimeUnit.SECONDS);
+        this.writePool.shutdownGracefully(0, 2, TimeUnit.SECONDS);
     }
 
     // Tiny plaintext listener on :80 that 308-redirects to the https:// URL.

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -917,6 +917,20 @@ public class XdnGigapaxosApp
    * @return false if failed to initialize the service.
    */
   private boolean initContainerizedService2(String serviceName) {
+    // Init is documented idempotent, but two concurrent invocations (PrimaryBackupManager can
+    // spawn duplicate primary-init threads) interleave destructively: each run wipes and
+    // re-creates the bind-mount source (recorder preInitialization does rm -rf + mkdir), so one
+    // thread's `docker run` keeps landing inside the other's wipe window and both livelock on
+    // "bind source path does not exist". Serialize per service; the initializationSucceed
+    // early-return then turns the duplicate invocation into a no-op.
+    synchronized (this.serviceInitLocks.computeIfAbsent(serviceName, k -> new Object())) {
+      return initContainerizedService2Serialized(serviceName);
+    }
+  }
+
+  private final ConcurrentHashMap<String, Object> serviceInitLocks = new ConcurrentHashMap<>();
+
+  private boolean initContainerizedService2Serialized(String serviceName) {
     int initialPlacementEpoch = this.servicePlacementEpoch.get(serviceName);
     assertNotNull("initialPlacementEpoch must not be null", initialPlacementEpoch);
 
@@ -977,6 +991,22 @@ public class XdnGigapaxosApp
     if (!service.property.isDeterministic()) {
       stateDiffRecorder.preInitialization(serviceName, initialPlacementEpoch);
       stateDiffRecorder.postInitialization(serviceName, initialPlacementEpoch);
+      // Docker Desktop (macOS) validates bind sources eagerly at `docker run` (Linux dockerd
+      // would auto-create them as root), so ensure the mount source exists even when the
+      // recorder implementation did not create it.
+      try {
+        Files.createDirectories(Paths.get(stateDirMountSource));
+      } catch (IOException e) {
+        logger.log(
+            Level.WARNING,
+            "{0}:{1} failed to pre-create bind source {2}: {3}",
+            new Object[] {
+              this.myNodeId.toUpperCase(),
+              this.getClass().getSimpleName(),
+              stateDirMountSource,
+              e.getMessage()
+            });
+      }
     } else {
       Shell.runCommand("rm -rf " + stateDirMountSource);
       Shell.runCommand("mkdir -p " + stateDirMountSource);

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -1066,6 +1066,38 @@ public class XdnGigapaxosApp
       service.initializationSucceed = true;
     }
 
+    // Hold off returning until the entry port answers HTTP, mirroring the cluster path's
+    // gate. This matters most during restart recovery: gigapaxos rolls the paxos log
+    // forward immediately after restore() returns, and an execute() that reaches a
+    // still-booting container fails; after HANDLE_REQUEST_RETRY_LIMIT (10) retries at
+    // 100ms the instance is force-stopped and the committed decision is silently dropped,
+    // leaving this replica's container state permanently diverged from its peers.
+    // Best-effort on timeout: a pathologically slow image keeps today's behavior instead
+    // of failing the epoch start.
+    long readinessStartMs = System.currentTimeMillis();
+    if (waitForHttpReadiness(allocatedPort, 60_000)) {
+      logger.log(
+          Level.INFO,
+          "{0}:{1} service {2} entry port {3} answered HTTP in {4}ms",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            serviceName,
+            String.valueOf(allocatedPort),
+            String.valueOf(System.currentTimeMillis() - readinessStartMs)
+          });
+    } else {
+      logger.log(
+          Level.WARNING,
+          "{0}:{1} service {2} entry port {3} not answering HTTP after 60s; proceeding",
+          new Object[] {
+            this.myNodeId.toUpperCase(),
+            this.getClass().getSimpleName(),
+            serviceName,
+            String.valueOf(allocatedPort)
+          });
+    }
+
     // store all the current service metadata
     this.activeServicePorts.put(serviceName, allocatedPort);
     return true;

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -202,11 +202,13 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
   }
 
   public boolean usesPrimaryBackup(String serviceName) {
-    var coordinator = this.serviceCoordinator.get(serviceName);
+    var coordinator = this.lookupCoordinator(serviceName);
     return coordinator != null && coordinator == this.primaryBackupCoordinator;
   }
 
   public List<RequestMatcher> getRequestMatchersForService(String serviceName) {
+    // lookupCoordinator repopulates serviceProperties after a restart-recovery.
+    this.lookupCoordinator(serviceName);
     ServiceProperty sp = this.serviceProperties.get(serviceName);
     return sp != null ? sp.getRequestMatchers() : null;
   }
@@ -228,7 +230,7 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
 
     // gets service name and its coordinator
     var serviceName = request.getServiceName();
-    var coordinator = this.serviceCoordinator.get(serviceName);
+    var coordinator = this.lookupCoordinator(serviceName);
     if (coordinator == null) {
       // Gigapaxos' default group and the reconfigurator's node-config meta-records
       // (AR_AR_NODES, AR_RC_NODES) have no per-service XDN coordinator -- XDN keeps
@@ -391,7 +393,7 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
       return;
     }
 
-    var coordinator = this.serviceCoordinator.get(serviceName);
+    var coordinator = this.lookupCoordinator(serviceName);
     if (coordinator == null) {
       setCoordinatorNodeRequest.setFailed(
           ClientReconfigurationPacket.ResponseCodes.ACTIVE_REPLICA_EXCEPTION);
@@ -537,7 +539,7 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
       callback.executed(request, true);
       return;
     }
-    AbstractReplicaCoordinator<NodeIDType> coordinator = this.serviceCoordinator.get(serviceName);
+    AbstractReplicaCoordinator<NodeIDType> coordinator = this.lookupCoordinator(serviceName);
 
     // prepare for the response
     String protocolName = coordinator != null ? coordinator.getClass().getSimpleName() : "?";
@@ -887,7 +889,7 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
 
   @Override
   public boolean deleteReplicaGroup(String serviceName, int epoch) {
-    AbstractReplicaCoordinator<NodeIDType> coordinator = this.serviceCoordinator.get(serviceName);
+    AbstractReplicaCoordinator<NodeIDType> coordinator = this.lookupCoordinator(serviceName);
     if (coordinator == null) {
       return true;
     }
@@ -916,10 +918,60 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
 
   @Override
   public Set<NodeIDType> getReplicaGroup(String serviceName) {
-    var coordinator = this.serviceCoordinator.get(serviceName);
+    var coordinator = this.lookupCoordinator(serviceName);
     if (coordinator == null) {
       return null;
     }
     return coordinator.getReplicaGroup(serviceName);
+  }
+
+  // Looks up the service's coordinator, lazily re-registering it after a process restart.
+  private AbstractReplicaCoordinator<NodeIDType> lookupCoordinator(String serviceName) {
+    AbstractReplicaCoordinator<NodeIDType> coordinator = this.serviceCoordinator.get(serviceName);
+    if (coordinator != null) {
+      return coordinator;
+    }
+    return this.recoverServiceRegistration(serviceName);
+  }
+
+  // On a process restart, gigapaxos log recovery replays straight into
+  // XdnGigapaxosApp.restore(), which re-creates the service instance (and its containers)
+  // without ever calling createReplicaGroup() -- the only writer of the serviceCoordinator
+  // map -- so the node would 404 every request for a service it still hosts. Rebuild the
+  // mapping from what recovery left behind: the app retains the ServiceProperty, and the
+  // inferred sub-coordinator has already recovered the replica group from its own logs.
+  // Registration is refused while the sub-coordinator has no recovered group (a restore
+  // still in flight, or a service this node truly never hosted) so requests are never
+  // routed into a coordinator that would drop them.
+  private synchronized AbstractReplicaCoordinator<NodeIDType> recoverServiceRegistration(
+      String serviceName) {
+    AbstractReplicaCoordinator<NodeIDType> coordinator = this.serviceCoordinator.get(serviceName);
+    if (coordinator != null) {
+      return coordinator;
+    }
+    ServiceInstance instance = this.xdnGigapaxosApp.getServiceInstance(serviceName);
+    if (instance == null || instance.property == null) {
+      return null;
+    }
+    AbstractReplicaCoordinator<NodeIDType> inferred =
+        this.inferCoordinatorByProperties(instance.property);
+    if (inferred == null) {
+      return null;
+    }
+    Set<NodeIDType> group = inferred.getReplicaGroup(serviceName);
+    if (group == null || group.isEmpty()) {
+      logger.log(
+          Level.WARNING,
+          "{0}:XdnReplicaCoordinator - cannot re-register recovered service {1}: "
+              + "{2} has no replica group for it (yet)",
+          new Object[] {myNodeID, serviceName, inferred.getClass().getSimpleName()});
+      return null;
+    }
+    this.serviceCoordinator.put(serviceName, inferred);
+    this.serviceProperties.put(serviceName, instance.property);
+    System.out.printf(
+        ">> XDNReplicaCoordinator:%s re-registered recovered service %s with %s (group=%s)%n",
+        myNodeID, serviceName, inferred.getClass().getSimpleName(), group);
+    return inferred;
   }
 }

--- a/test/edu/umass/cs/xdn/XdnRestartRecoveryTest.java
+++ b/test/edu/umass/cs/xdn/XdnRestartRecoveryTest.java
@@ -1,0 +1,222 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import edu.umass.cs.xdn.util.XdnTestCluster;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for ActiveReplica restart recovery: a restarted replica must re-register the
+ * services it hosts (no permanent 404s) and roll its container state forward from the paxos log (no
+ * silent divergence from its peers).
+ *
+ * <p>Both bugs shipped together historically: gigapaxos log recovery replays straight into {@code
+ * XdnGigapaxosApp.restore()} without repopulating {@code XdnReplicaCoordinator}'s routing map, and
+ * recovery replay ran through {@code PrimaryBackupMiddlewareApp} before its manager was wired, so
+ * every replayed decision threw under {@code -ea}, exhausted gigapaxos's execute retries, and was
+ * silently dropped -- the restarted replica then executed later writes on empty state (e.g.
+ * assigning {@code id:1} to a write its peers executed as {@code id:2}).
+ *
+ * <p>The restarted replica runs as a separate OS process (see {@code XdnTestCluster#start}); the
+ * restart is SIGTERM + respawn on the same on-disk state, the same recovery path a {@code systemctl
+ * restart xdn-ar} (or crash) takes in production.
+ */
+public class XdnRestartRecoveryTest {
+
+  private static final String IMAGE = "fadhilkurnia/xdn-bookcatalog";
+  // Post-restart probes go through full coordination and can ride out leader-election and
+  // request-retry windows, so this is deliberately more generous than SERVICE_READY_TIMEOUT.
+  private static final Duration CONVERGENCE_TIMEOUT = Duration.ofSeconds(180);
+
+  @Test
+  public void testRestartedReplicaDoesNotDivergeLinearizable() throws Exception {
+    assertTrue(XdnTestCluster.isDockerAvailable(), "Docker is required for this integration test");
+
+    String serviceName = "xdnrestartlin";
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      // AR1 runs as an external OS process so it can be killed and respawned like a real
+      // systemd restart; see the start(...) javadoc for why an in-JVM restart cannot work.
+      cluster.start("AR1");
+      cluster.launchService(serviceName, IMAGE, "/app/data/", "LINEARIZABLE", true);
+      cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      for (int i = 0; i < 3; i++) {
+        cluster.awaitReplicaReady(serviceName, i, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      }
+
+      HttpResponse<String> post =
+          cluster.sendPostRequest(
+              serviceName,
+              0,
+              "/api/books",
+              "{\"title\":\"Committed Before Restart\",\"author\":\"A\"}",
+              null);
+      assertEquals(200, post.statusCode(), "pre-restart write failed: " + post.body());
+
+      // All replicas agree before the restart.
+      String baseline = awaitBooks(cluster, serviceName, 0, 1);
+      for (int i = 1; i < 3; i++) {
+        assertEquals(baseline, awaitBooks(cluster, serviceName, i, 1));
+      }
+
+      // Restart one member; its on-disk paxos logs and XDN state survive, so the fresh
+      // process recovers via log replay.
+      int restartedIdx = 1;
+      cluster.restartActiveReplica(restartedIdx);
+
+      // The recovered replica must serve the committed item (routing repaired) with content
+      // identical to a non-restarted peer (state rolled forward, not re-initialized empty).
+      String restartedView = awaitBooks(cluster, serviceName, restartedIdx, 1);
+      String peerView = awaitBooks(cluster, serviceName, 0, 1);
+      assertEquals(peerView, restartedView, "restarted replica diverged from its peer");
+
+      // A write through the restarted replica must sequence on top of the recovered state
+      // (the divergence bug surfaced as this write getting id:1 instead of id:2).
+      HttpResponse<String> postAfter =
+          cluster.sendPostRequest(
+              serviceName,
+              restartedIdx,
+              "/api/books",
+              "{\"title\":\"Committed After Restart\",\"author\":\"B\"}",
+              null);
+      assertEquals(200, postAfter.statusCode(), "post-restart write failed: " + postAfter.body());
+
+      String finalView = awaitBooks(cluster, serviceName, 0, 2);
+      assertDistinctIds(finalView);
+      for (int i = 0; i < 3; i++) {
+        assertEquals(finalView, awaitBooks(cluster, serviceName, i, 2));
+      }
+    }
+  }
+
+  @Test
+  @Disabled(
+      "Primary-backup LAUNCH never completes in this environment: duplicate xdn-pb-init threads"
+          + " race the recorder's wipe-and-recreate of the bind-mount source, so `docker run`"
+          + " livelocks on 'bind source path does not exist' (Docker Desktop validates bind"
+          + " sources eagerly). Enable once the PB launch path is fixed; see issue #82.")
+  public void testRestartedPrimaryKeepsCommittedStatePrimaryBackup() throws Exception {
+    assertTrue(XdnTestCluster.isDockerAvailable(), "Docker is required for this integration test");
+
+    String serviceName = "xdnrestartpbx";
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+      // deterministic=false selects the primary-backup coordinator.
+      cluster.launchService(serviceName, IMAGE, "/app/data/", "LINEARIZABLE", false);
+      cluster.awaitServiceReady(serviceName, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      for (int i = 0; i < 3; i++) {
+        cluster.awaitReplicaReady(serviceName, i, XdnTestCluster.SERVICE_READY_TIMEOUT);
+      }
+
+      HttpResponse<String> post =
+          cluster.sendPostRequest(
+              serviceName,
+              0,
+              "/api/books",
+              "{\"title\":\"Committed Before Restart\",\"author\":\"A\"}",
+              null);
+      assertEquals(200, post.statusCode(), "pre-restart write failed: " + post.body());
+      String baseline = awaitBooks(cluster, serviceName, 0, 1);
+
+      // Restarting the PRIMARY is the interesting case for primary-backup: committed state
+      // must survive whether the old primary recovers or a backup takes over.
+      int primaryIdx = findPrimaryIdx(cluster, serviceName);
+      cluster.restartActiveReplica(primaryIdx);
+
+      // Committed data must remain readable through every frontend, byte-identical.
+      for (int i = 0; i < 3; i++) {
+        assertEquals(
+            baseline,
+            awaitBooks(cluster, serviceName, i, 1),
+            "replica " + i + " lost or diverged committed state after primary restart");
+      }
+
+      // And the group must still accept writes that sequence on the surviving state.
+      HttpResponse<String> postAfter =
+          cluster.sendPostRequest(
+              serviceName,
+              0,
+              "/api/books",
+              "{\"title\":\"Committed After Restart\",\"author\":\"B\"}",
+              null);
+      assertEquals(200, postAfter.statusCode(), "post-restart write failed: " + postAfter.body());
+
+      String finalView = awaitBooks(cluster, serviceName, 0, 2);
+      assertDistinctIds(finalView);
+      for (int i = 0; i < 3; i++) {
+        assertEquals(finalView, awaitBooks(cluster, serviceName, i, 2));
+      }
+    }
+  }
+
+  /**
+   * Polls one replica's frontend until {@code GET /api/books} returns 200 with at least {@code
+   * minBooks} entries, returning the body. Connection errors are retried: the replica may be
+   * mid-recovery when polling starts.
+   */
+  private static String awaitBooks(
+      XdnTestCluster cluster, String serviceName, int replicaIdx, int minBooks) throws Exception {
+    long deadline = System.nanoTime() + CONVERGENCE_TIMEOUT.toNanos();
+    String lastSeen = null;
+    while (System.nanoTime() < deadline) {
+      try {
+        HttpResponse<String> response =
+            cluster.sendGetRequest(serviceName, replicaIdx, "/api/books");
+        lastSeen = response.statusCode() + " " + response.body();
+        if (response.statusCode() == 200) {
+          JSONArray books = new JSONArray(response.body());
+          if (books.length() >= minBooks) {
+            return response.body();
+          }
+        }
+      } catch (Exception ignored) {
+        // replica still recovering; retry below
+      }
+      TimeUnit.MILLISECONDS.sleep(500);
+    }
+    fail(
+        "replica %d never served >=%d book(s) within %s; last seen: %s"
+            .formatted(replicaIdx, minBooks, CONVERGENCE_TIMEOUT, lastSeen));
+    return null; // unreachable
+  }
+
+  /** Asserts every book in the JSON array carries a unique id (catches restart re-sequencing). */
+  private static void assertDistinctIds(String booksJson) throws Exception {
+    JSONArray books = new JSONArray(booksJson);
+    java.util.Set<Integer> ids = new java.util.HashSet<>();
+    for (int i = 0; i < books.length(); i++) {
+      int id = books.getJSONObject(i).getInt("id");
+      assertTrue(ids.add(id), "duplicate book id " + id + " in " + booksJson);
+    }
+  }
+
+  private static int findPrimaryIdx(XdnTestCluster cluster, String serviceName) throws Exception {
+    long deadline = System.nanoTime() + CONVERGENCE_TIMEOUT.toNanos();
+    while (System.nanoTime() < deadline) {
+      for (int i = 0; i < 3; i++) {
+        try {
+          HttpResponse<String> response =
+              cluster.sendGetRequest(
+                  serviceName, i, "/api/v2/services/" + serviceName + "/replica/info");
+          if (response.statusCode() == 200) {
+            JSONObject info = new JSONObject(response.body());
+            if ("primary".equalsIgnoreCase(info.optString("role"))) {
+              return i;
+            }
+          }
+        } catch (Exception ignored) {
+          // keep probing
+        }
+      }
+      TimeUnit.MILLISECONDS.sleep(500);
+    }
+    throw new AssertionError("no replica reported role=primary within " + CONVERGENCE_TIMEOUT);
+  }
+}

--- a/test/edu/umass/cs/xdn/util/XdnTestCluster.java
+++ b/test/edu/umass/cs/xdn/util/XdnTestCluster.java
@@ -60,6 +60,7 @@ public class XdnTestCluster implements AutoCloseable {
   private final Map<String, InetSocketAddress> reconfigurators =
       Map.of(RECONFIGURATOR_ID, new InetSocketAddress(LOOPBACK, RECONFIGURATOR_BASE_PORT));
   private final List<ReconfigurableNode<String>> nodes = new ArrayList<>();
+  private final Map<String, ReconfigurableNode<String>> nodesById = new LinkedHashMap<>();
   private final List<String> createdServices = new ArrayList<>();
   private static volatile boolean loggingConfigured = false;
 
@@ -70,21 +71,37 @@ public class XdnTestCluster implements AutoCloseable {
     }
   }
 
-  /** Boots the Reconfigurator and ActiveReplica nodes required for an XDN cluster. */
-  public void start() throws Exception {
+  /**
+   * Boots the Reconfigurator and ActiveReplica nodes required for an XDN cluster. Replicas named in
+   * {@code externalActiveIds} run as separate OS processes (required for tests that restart a
+   * replica via {@link #restartActiveReplica}); all other nodes run in-process as before.
+   */
+  public void start(String... externalActiveIds) throws Exception {
     // TODO: enable logging for better debugging in Github action runners.
     //   configureLogging();
     configureGigapaxos();
     cleanDirectory(GP_DATA_DIR);
     cleanDirectory(XDN_WORK_DIR);
 
-    nodes.add(startNode(RECONFIGURATOR_ID));
+    registerNode(RECONFIGURATOR_ID, startNode(RECONFIGURATOR_ID));
+    List<String> external = List.of(externalActiveIds);
     for (String activeId : ACTIVE_REPLICA_IDS) {
-      nodes.add(startNode(activeId));
+      if (external.contains(activeId)) {
+        // A replica that a test will restart must run as its own OS process from birth:
+        // in-process teardown leaks shared-JVM state (embedded Derby keeps the paxos DB
+        // locked for the whole JVM; run_xdn_tests.sh's per-method-JVM isolation exists for
+        // the same reason), while killing and respawning a subprocess matches the
+        // production systemd-restart shape exactly.
+        spawnNodeProcess(activeId);
+      } else {
+        registerNode(activeId, startNode(activeId));
+      }
     }
 
     waitForPort(LOOPBACK, getReconfiguratorHttpPort(), PORT_WAIT_TIMEOUT);
-    waitForPort(LOOPBACK, getActiveHttpPort(ACTIVE_REPLICA_IDS.getFirst()), PORT_WAIT_TIMEOUT);
+    for (String activeId : ACTIVE_REPLICA_IDS) {
+      waitForPort(LOOPBACK, getActiveHttpPort(activeId), PORT_WAIT_TIMEOUT);
+    }
   }
 
   /** Launches a service using default SEQUENTIAL consistency and deterministic=true. */
@@ -397,6 +414,12 @@ public class XdnTestCluster implements AutoCloseable {
       }
     }
     nodes.clear();
+    nodesById.clear();
+
+    for (Process process : nodeProcesses.values()) {
+      process.destroyForcibly();
+    }
+    nodeProcesses.clear();
 
     try {
       TimeUnit.SECONDS.sleep(2);
@@ -486,6 +509,101 @@ public class XdnTestCluster implements AutoCloseable {
         new DefaultNodeConfig<>(activeReplicas, reconfigurators);
     return new ReconfigurableNode.DefaultReconfigurableNode(
         nodeId, nodeConfig, new String[] {nodeId}, false);
+  }
+
+  private void registerNode(String nodeId, ReconfigurableNode<String> node) {
+    nodes.add(node);
+    nodesById.put(nodeId, node);
+  }
+
+  /**
+   * Restarts a single ActiveReplica, preserving its on-disk paxos logs and XDN state so the new
+   * process goes through the log-recovery path -- the scenario where a restarted replica must
+   * re-register its services and roll its container state forward without diverging from its peers
+   * (the AR-restart recovery bugs fixed alongside this helper). The replica must have been started
+   * as an external process (see {@link #start(String...)}); SIGTERM + respawn then mirrors a
+   * production systemd restart exactly.
+   */
+  public void restartActiveReplica(int replicaIdx) throws Exception {
+    String activeId = ACTIVE_REPLICA_IDS.get(replicaIdx);
+    Process process = nodeProcesses.get(activeId);
+    if (process == null) {
+      throw new IllegalStateException(
+          "Replica "
+              + activeId
+              + " is not an external process; pass it to start(...) as an external replica");
+    }
+    process.destroy(); // SIGTERM, same signal systemd's try-restart sends
+    if (!process.waitFor(20, TimeUnit.SECONDS)) {
+      process.destroyForcibly();
+      process.waitFor(10, TimeUnit.SECONDS);
+    }
+    // The old process's listeners must actually be gone before the replacement binds; fail
+    // loudly if a port lingers so a teardown leak surfaces instead of a hung test.
+    waitForPortClose(LOOPBACK, ACTIVE_REPLICA_BASE_PORT + replicaIdx, Duration.ofSeconds(15));
+    waitForPortClose(LOOPBACK, getActiveHttpPort(activeId), Duration.ofSeconds(15));
+
+    spawnNodeProcess(activeId);
+    waitForPort(LOOPBACK, getActiveHttpPort(activeId), PORT_WAIT_TIMEOUT);
+  }
+
+  private final Map<String, Process> nodeProcesses = new LinkedHashMap<>();
+
+  /** Spawns a node as a separate OS process on the shared local config and /tmp state dirs. */
+  private void spawnNodeProcess(String activeId) throws IOException {
+    String javaBin = Paths.get(System.getProperty("java.home"), "bin", "java").toString();
+    Path configPath = Paths.get("conf", "gigapaxos.xdn.local.properties").toAbsolutePath();
+    Path logPath = Paths.get("out", "junit5-test-output", "node-process-" + activeId + ".log");
+    Files.createDirectories(logPath.getParent());
+    ProcessBuilder builder =
+        new ProcessBuilder(
+            javaBin,
+            "-ea",
+            "-D" + PaxosConfig.GIGAPAXOS_CONFIG_FILE_KEY + "=" + configPath,
+            "-cp",
+            System.getProperty("java.class.path"),
+            "edu.umass.cs.reconfiguration.ReconfigurableNode",
+            activeId);
+    builder.redirectErrorStream(true);
+    // Append so the pre- and post-restart incarnations land in one readable log.
+    builder.redirectOutput(ProcessBuilder.Redirect.appendTo(logPath.toFile()));
+    Process previous = this.nodeProcesses.put(activeId, builder.start());
+    if (previous != null && previous.isAlive()) {
+      previous.destroyForcibly();
+    }
+  }
+
+  private static void waitForPortClose(String host, int port, Duration timeout)
+      throws InterruptedException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      try (Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress(host, port), 500);
+      } catch (IOException closedOrRefused) {
+        return;
+      }
+      TimeUnit.MILLISECONDS.sleep(250);
+    }
+    throw new IllegalStateException(
+        "Port %s:%d is still accepting connections after node close(); the old node's listener leaked"
+            .formatted(host, port));
+  }
+
+  /** Issues an HTTP POST with a JSON body to a specific replica's frontend. */
+  public HttpResponse<String> sendPostRequest(
+      String serviceName, int replicaIdx, String endpoint, String jsonBody, Duration timeout)
+      throws IOException, InterruptedException {
+    Duration effectiveTimeout = timeout != null ? timeout : REQUEST_TIMEOUT;
+    int httpPort = getActiveHttpPort(ACTIVE_REPLICA_IDS.get(replicaIdx));
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create("http://%s:%d%s".formatted(LOOPBACK, httpPort, endpoint)))
+            .timeout(effectiveTimeout)
+            .header("XDN", serviceName)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+            .build();
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
   private static void waitForPort(String host, int port, Duration timeout)


### PR DESCRIPTION
## Problem

After any `xdn-ar` process restart (cert rotation via `xdn-tls-pull`, crash, OOM, deploy), the restarted ActiveReplica had two independent failures, both reproduced deterministically on a local 5-AR cluster (launch bookcatalog, SIGTERM a member AR, restart it):

**1. Permanent 404s.** The node answers "Service '<name>' does not exist in this XDN deployment" for every service it hosts, even though its Paxos state recovered and its container is running. Observed in production on the AWS multiregion cluster (useast2a stuck after the Aug 19 cert rotation).

**2. Silent state divergence.** Recovery roll-forward drops committed decisions: the restarted replica came back with an empty store and executed a replicated write as `id:1` while its peers executed the same decision as `id:2`.

## Root causes and fixes (one commit each)

**Commit 1: `serviceCoordinator` map never repopulated after restart.** gigapaxos log recovery replays straight into `XdnGigapaxosApp.restore()`, but the wrapper's routing map is only written by `initializeReplicaGroup()` (RC-driven create/epoch-start). Smoking gun: `404 for name=bookcatalog known=[]` right after a successful `restore`. Fix: `lookupCoordinator()` wraps every map lookup; on miss it rebuilds the registration from the app's recovered `ServiceProperty`, gated on the inferred sub-coordinator already holding a recovered replica group.

**Commit 2: recovery replay threw on every app decision.** Replay runs inside `PaxosManager`'s constructor, before `PrimaryBackupManager` exists (it needs the PaxosManager), and `PrimaryBackupMiddlewareApp.execute`'s blanket `assert primaryBackupManager != null` made every replayed decision throw `AssertionError` under `-ea` (which production runs). gigapaxos swallows the error, retries `HANDLE_REQUEST_RETRY_LIMIT=10` times at 100ms, then force-stops the instance and permanently drops the committed decision. Fix: the manager requirement moves into the three PB control-packet branches (`StartEpoch`/`ApplyStateDiff`/`InitBackup`); plain app requests pass through to the app during recovery.

**Commit 3: roll-forward can race container boot.** Even with commit 2, an `execute()` reaching a still-booting container fails and hits the same ~1s retry-exhaustion drop. Fix: the regular service path now gates on the container answering HTTP (60s budget, best-effort on timeout), mirroring the existing cluster-path readiness gate.

## Verification

Local 5-AR cluster, clean build:

- Pre-fix: restart a member AR → permanent 404 (`known=[]`); with routing repaired, state diverges (`AssertionError: Ensure to set the manager`, 22 swallowed replay failures, empty store, conflicting ids).
- Post-fix: SIGTERM + restart AR1 → zero replay failures, `re-registered recovered service bookrepro with PaxosReplicaCoordinator (group=[AR1, AR3, AR0])`, restarted replica's state byte-identical to peers, next write sequences correctly on all replicas.
- `ant xdn-regular-unit-tests` passes on the full stack of fixes; google-java-format clean.

## Follow-up

#80 tracks the remaining recovery landmine: `checkpoint()` is a dummy stub, so the first real checkpoint would GC the log with nothing saved, and `restore()` on that checkpoint format throws unimplemented.

## Update: regression test + three more lifecycle fixes (commits 4-5)

**`XdnRestartRecoveryTest`** (wired into the CI integration matrix): launches bookcatalog on 3 replicas with one replica as an external OS process, writes, SIGTERM+respawns that replica, and asserts the recovered replica serves byte-identical state and that post-restart writes sequence correctly on all replicas. Passing locally end to end. The primary-backup variant is committed `@Disabled`: PB launch itself livelocks before any restart (#82).

Building the test surfaced three more lifecycle bugs, fixed here:

1. **`HttpActiveReplica` was unclosable**: it blocked forever inside its own constructor (`closeFuture().sync()`) and `ActiveReplica.close()` never stopped it, orphaning the acceptor. The constructor now returns after bind and `ActiveReplica.close()` tears the frontend down.
2. **`initContainerizedService2` races itself**: duplicate `xdn-pb-init` threads each wipe and re-create the container's bind-mount source, livelocking `docker run` (#82). Init is now serialized per service.
3. **Bind-source pre-creation** for the non-deterministic branch, matching the cluster path's handling of Docker Desktop's eager bind validation.

Test-infra notes: `XdnTestCluster.start(...)` now accepts external replica ids (a restartable replica must be its own OS process; in-JVM node re-creation trips shared-JVM leftovers like the embedded Derby lock), and gained `restartActiveReplica`/`sendPostRequest` helpers. `XdnGetReplicaInfoTest` re-verified green on top of the frontend refactor.