### PR TITLE
Deflake WordPress-cluster CI: supervise GR members, stagger joiners, cache images

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -153,6 +153,23 @@ jobs:
         docker pull fadhilkurnia/xdn-bookcatalog
         docker pull fadhilkurnia/xdn-randstate
 
+    # The WordPress-cluster test needs ~1.2GB of images (mysql:8.0 base + wordpress) that are
+    # otherwise pulled from Docker Hub on every run. Cache them as a tarball: on a hit, docker
+    # load restores them before the test (the test's `docker build` then resolves FROM mysql:8.0
+    # locally and its pre-pull of wordpress is a no-op); on a miss, the post-test step below
+    # saves the freshly pulled images and actions/cache uploads the tarball at job end.
+    - name: 🗄️ Restore docker image cache (WordPress-cluster test)
+      if: matrix.test_class == 'XdnWordPressClusterTest'
+      id: wp-image-cache
+      uses: actions/cache@v4
+      with:
+        path: /tmp/wp-docker-images.tar
+        key: wp-docker-images-mysql8.0-wordpress6.5.4
+
+    - name: 🗄️ Load cached docker images (WordPress-cluster test)
+      if: matrix.test_class == 'XdnWordPressClusterTest' && steps.wp-image-cache.outputs.cache-hit == 'true'
+      run: docker load -i /tmp/wp-docker-images.tar
+
     - name: 🐝 Initialize Docker swarm (for cluster overlay networking)
       # Required by the cluster tests (XdnClusterLaunchTest, XdnWordPressClusterTest), harmless
       # for the others. Single-node swarm; we don't run anything as a swarm service, only use the
@@ -201,6 +218,12 @@ jobs:
       run: |
         set -o pipefail
         bin/run_xdn_tests.sh ${{ matrix.test_class }} 2>&1 | tee junit-test-output.log
+
+    - name: 🗄️ Save docker images for cache (WordPress-cluster test)
+      # Runs even when the test failed — the images are valid either way, and caching them
+      # makes the retry faster. actions/cache uploads the tarball in its post step.
+      if: always() && matrix.test_class == 'XdnWordPressClusterTest' && steps.wp-image-cache.outputs.cache-hit != 'true'
+      run: docker save -o /tmp/wp-docker-images.tar mysql:8.0 wordpress:6.5.4-apache || true
 
     - name: 📝 Reporting the test results ...
       uses: dorny/test-reporter@v2

--- a/services/mysql-cluster/entrypoint.sh
+++ b/services/mysql-cluster/entrypoint.sh
@@ -70,6 +70,11 @@ loose-group_replication_bootstrap_group = OFF
 # over the (non-TLS) recovery connection. This is a system variable — it canNOT be set via
 # CHANGE REPLICATION SOURCE on the recovery channel (that fails with ER 3139).
 loose-group_replication_recovery_get_public_key = ON
+# Slow hosts (CI runners with 3 concurrent members) can exhaust the default
+# distributed-recovery budget (10 tries x 60s apart) and land the joiner in the
+# terminal ERROR state. Retry more times, faster, to ride out a busy donor.
+loose-group_replication_recovery_retry_count        = 30
+loose-group_replication_recovery_reconnect_interval = 10
 # keep memory modest: up to N of these run on one CI runner alongside the JVM
 innodb_buffer_pool_size           = 128M
 performance_schema                = ON
@@ -122,9 +127,23 @@ if [ "$state" != "ONLINE" ] && [ "$state" != "RECOVERING" ]; then
     mysql_tcp "SET GLOBAL group_replication_bootstrap_group=ON;
                START GROUP_REPLICATION;
                SET GLOBAL group_replication_bootstrap_group=OFF;"
-    # Create the app database once, on the primary, so it replicates to the joiners.
-    mysql_tcp "CREATE DATABASE IF NOT EXISTS \`${APP_DB}\`;"
+    # Create the app database once, on the primary, so it replicates to the
+    # joiners. The member stays super-read-only until it reaches ONLINE; a
+    # premature CREATE dies with ER 1290 and, under set -e, would kill this
+    # entrypoint and restart the container mid-formation — which also strands
+    # the netns-sharing sidecars in the dead namespace. Retry until writable.
+    created=0
+    for _ in $(seq 1 90); do
+      if mysql_tcp "CREATE DATABASE IF NOT EXISTS \`${APP_DB}\`;" 2>/dev/null; then created=1; break; fi
+      sleep 2
+    done
+    [ "$created" = 1 ] || \
+      echo "[xdn-mysql] WARNING: app db not created (member never became writable)" >&2
   else
+    # Stagger joiners by ordinal so they do not all race distributed recovery
+    # against the same donor at once — simultaneous recovery from one donor is
+    # a common way for the loser to exhaust its retries on a slow host.
+    sleep "$(( XDN_CLUSTER_ORDINAL * 5 ))"
     echo "[xdn-mysql] joining the group (retrying until the seed is reachable)"
     joined=0
     for _ in $(seq 1 60); do
@@ -134,6 +153,33 @@ if [ "$state" != "ONLINE" ] && [ "$state" != "RECOVERING" ]; then
     [ "$joined" = 1 ] || echo "[xdn-mysql] WARNING: START GROUP_REPLICATION never succeeded" >&2
   fi
 fi
+
+# Supervise group membership for the life of the container. START GROUP_REPLICATION
+# can be accepted and the member still land in the terminal ERROR state later (e.g.
+# distributed recovery exhausted its retries); nothing in MySQL retries a terminal
+# member, so re-issue STOP/START whenever the member sits outside ONLINE/RECOVERING
+# for two consecutive checks (one bad reading may just be a transient query failure,
+# and needlessly bouncing a healthy member would drop it from the group). Never
+# re-bootstraps — a plain START either rejoins the existing group or fails harmlessly.
+(
+  bad=0
+  while true; do
+    sleep 10
+    st="$(mysql_tcp "SELECT MEMBER_STATE FROM performance_schema.replication_group_members WHERE MEMBER_HOST='${XDN_CLUSTER_SELF}'" 2>/dev/null || true)"
+    case "$st" in
+      ONLINE|RECOVERING) bad=0 ;;
+      *)
+        bad=$((bad + 1))
+        if [ "$bad" -ge 2 ]; then
+          echo "[xdn-mysql] supervisor: member state '${st:-<none>}'; retrying START GROUP_REPLICATION"
+          mysql_tcp "STOP GROUP_REPLICATION;" >/dev/null 2>&1 || true
+          mysql_tcp "START GROUP_REPLICATION;" >/dev/null 2>&1 || true
+          bad=0
+        fi
+        ;;
+    esac
+  done
+) &
 
 # Report final membership state (best effort; informational).
 for _ in $(seq 1 60); do

--- a/test/edu/umass/cs/xdn/XdnWordPressClusterTest.java
+++ b/test/edu/umass/cs/xdn/XdnWordPressClusterTest.java
@@ -46,8 +46,10 @@ public class XdnWordPressClusterTest {
 
   // MySQL GR bootstrap is slow: each member runs a full datadir --initialize (tens of seconds),
   // all 3 concurrently, before the group even forms — so this budget is deliberately large. The
-  // poll exits as soon as the group is up, so the ceiling only matters on failure.
-  private static final Duration GROUP_BUDGET = Duration.ofSeconds(360);
+  // poll exits as soon as the group is up, so the ceiling only matters on failure. The extra
+  // headroom over the original 360s is usable now that the member entrypoint supervises GR and
+  // retries a member that lands in the terminal ERROR state.
+  private static final Duration GROUP_BUDGET = Duration.ofSeconds(480);
   private static final Duration WORDPRESS_BUDGET = Duration.ofSeconds(180);
 
   @Test
@@ -157,12 +159,65 @@ public class XdnWordPressClusterTest {
       }
       Thread.sleep(3000);
     }
+    dumpGroupDiagnostics();
     throw new AssertionError(
         "MySQL Group Replication never reached "
             + expected
             + " ONLINE members (last seen: "
             + last
             + ")");
+  }
+
+  /**
+   * On formation failure, print each member container's view of the group plus its recent logs, so
+   * a CI flake shows whether a member is in the terminal ERROR state, still RECOVERING, or its
+   * mysqld never came up — the bare ONLINE count cannot distinguish these.
+   */
+  private void dumpGroupDiagnostics() {
+    try {
+      ProcResult ps =
+          runProcess(
+              List.of(
+                  "docker",
+                  "ps",
+                  "-a",
+                  "--filter",
+                  "ancestor=" + MYSQL_IMAGE,
+                  "--format",
+                  "{{.Names}}\t{{.Status}}"));
+      System.out.println("[gr-diagnostics] member containers:\n" + ps.stdout());
+      for (String line : ps.stdout().split("\\R")) {
+        if (line.isBlank()) {
+          continue;
+        }
+        String name = line.split("\t")[0].trim();
+        ProcResult view =
+            runProcess(
+                List.of(
+                    "docker",
+                    "exec",
+                    name,
+                    "mysql",
+                    "-uroot",
+                    "-p" + ROOT_PW,
+                    "-e",
+                    "SELECT MEMBER_HOST, MEMBER_STATE"
+                        + " FROM performance_schema.replication_group_members"));
+        System.out.println(
+            "[gr-diagnostics] "
+                + name
+                + " group view (exit "
+                + view.exitCode()
+                + "):\n"
+                + view.stdout()
+                + view.stderr());
+        ProcResult logs = runProcess(List.of("docker", "logs", "--tail", "60", name));
+        System.out.println(
+            "[gr-diagnostics] " + name + " last logs:\n" + logs.stdout() + logs.stderr());
+      }
+    } catch (Exception e) {
+      System.out.println("[gr-diagnostics] failed to collect diagnostics: " + e);
+    }
   }
 
   /** Returns the count of ONLINE GR members, or null if no member container is queryable yet. */


### PR DESCRIPTION
## Problem

`XdnWordPressClusterTest` is slow (~9 min) and flaky ("MySQL Group Replication never reached 3 ONLINE members"). The dominant flake is a **terminal** failure mode: a joiner's `START GROUP_REPLICATION` is accepted, distributed recovery then fails on a slow runner (e.g. two joiners racing the same donor), and the member lands in the `ERROR` state — which nothing in MySQL or the entrypoint ever retries. The test then burns its whole formation budget against a permanently dead member.

## Changes

**`services/mysql-cluster/entrypoint.sh`** (deflake at the source):
- **Supervise membership for the container's lifetime**: a background loop re-issues `STOP/START GROUP_REPLICATION` whenever the member sits outside `ONLINE`/`RECOVERING` for two consecutive checks (one bad reading may be a transient query failure). It never re-bootstraps, so there is no split-brain risk — a plain START either rejoins the existing group or fails harmlessly and is retried.
- **Stagger joiners by ordinal** (`ordinal * 5s`) so they don't race distributed recovery against the same donor simultaneously.
- **Tune recovery retries** (`group_replication_recovery_retry_count = 30`, `reconnect_interval = 10s`) so MySQL's own recovery rides out a busy donor instead of erroring out.
- **Retry the bootstrap-side `CREATE DATABASE` until the member is writable**: the member is `super_read_only` until it reaches ONLINE, and a premature CREATE dies with ER 1290 — under `set -e` that kills the entrypoint and restarts the container mid-formation, stranding the netns-sharing WordPress sidecar in the dead namespace.

**`XdnWordPressClusterTest`** (diagnosability + budget):
- On formation timeout, dump every member container's view of `replication_group_members` plus its last 60 log lines — the bare ONLINE count cannot distinguish `ERROR` vs `RECOVERING` vs mysqld-still-initializing, which is what made past flakes undebuggable from artifacts alone.
- Raise `GROUP_BUDGET` 360s → 480s; the headroom is actually usable now that a failed member retries instead of staying dead.

**`ant-build-test.yml`** (speed):
- Cache the ~1.2GB of docker images (`mysql:8.0` base + `wordpress:6.5.4-apache`) across runs of the WordPress job via `actions/cache`, restored with `docker load` — instead of pulling them from Docker Hub on every run. The save step runs even on test failure so retries also benefit.

## Verification

- `bash -n` on the entrypoint, YAML parse of the workflow, `ant jar xdn-compile-tests`, formatter check — all clean.
- `XdnWordPressClusterTest` **passes with the new entrypoint** on a clean Linux host (full run: image build, 3-member GR formation, WordPress serving on all replicas).