### PR TITLE
Nightly performance runner: interleaved A/B latency + throughput regression check

### DIFF
--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -8,8 +8,8 @@
 # are not comparable night-to-night.
 #
 # Change gating: skipped when main HEAD was already measured, or when nothing
-# perf-relevant (src/, lib/, bin/gpServer.sh, bin/gpEnv.sh, xdn-cli/) changed
-# since the last measured commit. workflow_dispatch always runs. A pull_request
+# perf-relevant (src/, lib/, bin/gpServer.sh, bin/gpEnv.sh, xdn-cli/, xdn-fs/)
+# changed since the last measured commit. workflow_dispatch always runs. A pull_request
 # touching the perf scripts runs the measurement as a self-test (no recording).
 #
 # Results: one JSON line per night appended to perf.jsonl on the perf-results
@@ -95,7 +95,7 @@ jobs:
               exit 0
             fi
             if ! git diff --name-only "$LAST".."$HEAD_SHA" -- \
-                src lib bin/gpServer.sh bin/gpEnv.sh xdn-cli | grep -q .; then
+                src lib bin/gpServer.sh bin/gpEnv.sh xdn-cli xdn-fs | grep -q .; then
               echo "no perf-relevant changes since $LAST; skipping"
               echo "run_mode=skip" >> "$GITHUB_OUTPUT"
               exit 0
@@ -141,17 +141,31 @@ jobs:
       - name: Set up Rsync
         uses: GuillaumeFalourd/setup-rsync@v1.2
 
+      # The perf cluster uses the FUSELOG statediff recorder (the production-
+      # representative one; rsync forks a process per capture and dominates PB
+      # latency). Each tree builds its OWN fuselog binaries so xdn-fs/ changes
+      # are A/B'd; eval/nightly_perf.py installs the measured tree's binaries
+      # to /usr/local/bin at the start of each pass.
+      - name: Set up FUSE
+        run: |
+          set -x
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libfuse3-dev libzstd-dev fuse3
+          sudo modprobe fuse
+          sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf
+          grep user_allow_other /etc/fuse.conf
+
       - name: Pre-pull service images
         run: |
           docker pull fadhilkurnia/xdn-bookcatalog
           docker pull fadhilkurnia/xdn-bookcatalog-nd
 
       - name: Build head
-        run: cd head && ant jar && bash bin/build_xdn_cli.sh
+        run: cd head && ant jar && bash bin/build_xdn_cli.sh && bash bin/build_xdn_fuselog.sh cpp
 
       - name: Build base
         if: needs.gate.outputs.run_mode == 'compare'
-        run: cd base && ant jar && bash bin/build_xdn_cli.sh
+        run: cd base && ant jar && bash bin/build_xdn_cli.sh && bash bin/build_xdn_fuselog.sh cpp
 
       - name: Measure (interleaved A/B rounds)
         env:
@@ -166,14 +180,14 @@ jobs:
               --tput-hint-file "results/hint_${side}.txt" "$@"
           }
           if [ "$RUN_MODE" = "compare" ]; then
-            pass base 1
-            pass head 1
+            pass base 1 --with-instrumented
+            pass head 1 --with-instrumented
             pass head 2
             pass base 2
             pass base 3 --skip-tput
             pass head 3 --skip-tput
           else
-            pass head 1
+            pass head 1 --with-instrumented
             pass head 2
             pass head 3 --skip-tput
           fi

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -1,0 +1,231 @@
+# Nightly performance regression check: low-load latency + max throughput.
+#
+# Runs on GitHub-hosted runners, which are shared and noisy -- so the design is
+# interleaved A/B: the job measures the BASELINE commit (last recorded run on
+# the perf-results branch) and HEAD alternately on the SAME runner, and only the
+# relative head/base deltas are judged (eval/nightly_perf_check.py). Absolute
+# numbers are recorded for the trend page (https://xdn.cs.umass.edu/perf/) but
+# are not comparable night-to-night.
+#
+# Change gating: skipped when main HEAD was already measured, or when nothing
+# perf-relevant (src/, lib/, bin/gpServer.sh, bin/gpEnv.sh, xdn-cli/) changed
+# since the last measured commit. workflow_dispatch always runs. A pull_request
+# touching the perf scripts runs the measurement as a self-test (no recording).
+#
+# Results: one JSON line per night appended to perf.jsonl on the perf-results
+# branch (plus a regenerated perf.json the dashboard fetches); raw per-round
+# JSONs are uploaded as workflow artifacts. On regression, an issue is filed
+# and the job is failed.
+name: Nightly performance
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: "Baseline commit (default: last recorded on perf-results)"
+        required: false
+  pull_request:
+    paths:
+      - "eval/nightly_perf.py"
+      - "eval/nightly_perf_check.py"
+      - ".github/workflows/nightly-perf.yml"
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: nightly-perf
+  cancel-in-progress: false
+
+env:
+  PERF_BRANCH: perf-results
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run_mode: ${{ steps.decide.outputs.run_mode }} # skip | bootstrap | compare
+      base_sha: ${{ steps.decide.outputs.base_sha }}
+      head_sha: ${{ steps.decide.outputs.head_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_BASE: ${{ github.event.inputs.base_sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -x
+          if [ "$EVENT" = "pull_request" ]; then
+            # Self-test on perf-script changes: compare the PR head against its base.
+            echo "run_mode=compare" >> "$GITHUB_OUTPUT"
+            echo "base_sha=$PR_BASE" >> "$GITHUB_OUTPUT"
+            echo "head_sha=$PR_HEAD" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          HEAD_SHA=$(git rev-parse HEAD)
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          LAST=""
+          if git fetch origin "$PERF_BRANCH" 2>/dev/null; then
+            LAST=$(git show FETCH_HEAD:perf.jsonl 2>/dev/null | tail -1 \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["head_sha"])' \
+              2>/dev/null || true)
+          fi
+          if [ "$EVENT" = "workflow_dispatch" ] && [ -n "$INPUT_BASE" ]; then
+            LAST="$INPUT_BASE"
+          fi
+          # A recorded baseline that is no longer in history (force-push) restarts the series.
+          if [ -n "$LAST" ] && ! git cat-file -e "$LAST" 2>/dev/null; then
+            LAST=""
+          fi
+          if [ -z "$LAST" ]; then
+            echo "run_mode=bootstrap" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$EVENT" != "workflow_dispatch" ]; then
+            if [ "$LAST" = "$HEAD_SHA" ]; then
+              echo "HEAD already measured; skipping"
+              echo "run_mode=skip" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if ! git diff --name-only "$LAST".."$HEAD_SHA" -- \
+                src lib bin/gpServer.sh bin/gpEnv.sh xdn-cli | grep -q .; then
+              echo "no perf-relevant changes since $LAST; skipping"
+              echo "run_mode=skip" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "run_mode=compare" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$LAST" >> "$GITHUB_OUTPUT"
+
+  measure:
+    needs: gate
+    if: needs.gate.outputs.run_mode != 'skip'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.head_sha }}
+          path: head
+
+      - name: Checkout base
+        if: needs.gate.outputs.run_mode == 'compare'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.base_sha }}
+          path: base
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "oracle"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: head/xdn-cli/go.mod
+
+      - name: Set up Docker
+        uses: docker-practice/actions-setup-docker@master
+        timeout-minutes: 12
+
+      - name: Set up Rsync
+        uses: GuillaumeFalourd/setup-rsync@v1.2
+
+      - name: Pre-pull service images
+        run: |
+          docker pull fadhilkurnia/xdn-bookcatalog
+          docker pull fadhilkurnia/xdn-bookcatalog-nd
+
+      - name: Build head
+        run: cd head && ant jar && bash bin/build_xdn_cli.sh
+
+      - name: Build base
+        if: needs.gate.outputs.run_mode == 'compare'
+        run: cd base && ant jar && bash bin/build_xdn_cli.sh
+
+      - name: Measure (interleaved A/B rounds)
+        env:
+          RUN_MODE: ${{ needs.gate.outputs.run_mode }}
+        run: |
+          set -e
+          mkdir -p results
+          pass() { # pass <side> <round> [extra args]
+            side=$1; round=$2; shift 2
+            python3 head/eval/nightly_perf.py --repo "$side" \
+              --label "${side}_r${round}" --out "results/${side}_r${round}.json" \
+              --tput-hint-file "results/hint_${side}.txt" "$@"
+          }
+          if [ "$RUN_MODE" = "compare" ]; then
+            pass base 1
+            pass head 1
+            pass head 2
+            pass base 2
+            pass base 3 --skip-tput
+            pass head 3 --skip-tput
+          else
+            pass head 1
+            pass head 2
+            pass head 3 --skip-tput
+          fi
+
+      - name: Compare and summarize
+        id: check
+        run: |
+          python3 head/eval/nightly_perf_check.py \
+            --results results \
+            --head-sha "${{ needs.gate.outputs.head_sha }}" \
+            ${{ needs.gate.outputs.base_sha && format('--base-sha {0}', needs.gate.outputs.base_sha) || '' }} \
+            --summary results/summary.md \
+            --record results/record.json \
+            --github-output "$GITHUB_OUTPUT"
+          cat results/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record result on perf-results branch
+        if: github.event_name != 'pull_request'
+        run: |
+          set -e
+          REPO_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}"
+          if git clone --depth 1 --branch "$PERF_BRANCH" "$REPO_URL" perf; then
+            cd perf
+          else
+            mkdir perf && cd perf
+            git init -b "$PERF_BRANCH"
+            git remote add origin "$REPO_URL"
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          cat ../results/record.json >> perf.jsonl
+          python3 -c "import json; records = [json.loads(l) for l in open('perf.jsonl') if l.strip()]; json.dump(records, open('perf.json', 'w'), indent=1)"
+          git add perf.jsonl perf.json
+          git commit -m "perf: record ${{ needs.gate.outputs.head_sha }}"
+          git push origin "$PERF_BRANCH"
+
+      - name: Upload raw results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-perf-results
+          path: results/
+
+      - name: File issue and fail on regression
+        if: github.event_name != 'pull_request' && steps.check.outputs.regression == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Nightly perf regression at $(echo ${{ needs.gate.outputs.head_sha }} | cut -c1-10)" \
+            --body-file results/summary.md \
+            --label performance || true
+          echo "::error::performance regression detected (see summary)"
+          exit 1

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,6 +21,7 @@ on:
       - "website/**"
       - "docs/**"
       - "dashboard/**"
+      - "eval/perf-dashboard/**"
       - "bin/build_site.sh"
       - ".github/workflows/site.yml"
   workflow_dispatch:

--- a/bin/build_site.sh
+++ b/bin/build_site.sh
@@ -20,4 +20,11 @@ echo "staged $(ls "$REF" | wc -l | tr -d ' ') reference docs"
 MKDOCS="${MKDOCS:-mkdocs}"
 ( cd "$ROOT/website" && "$MKDOCS" build --site-dir "$ROOT/site" )
 
+# 3. Bundle the nightly-perf trend page at /perf/. The page is static; its data
+# is fetched at view time from the perf-results branch (raw.githubusercontent),
+# so nightly data updates need no site rebuild.
+mkdir -p "$ROOT/site/perf"
+cp "$ROOT/eval/perf-dashboard/index.html" "$ROOT/site/perf/index.html"
+echo "bundled perf dashboard -> site/perf/"
+
 echo "built site -> $ROOT/site  (open: python3 -m http.server -d site)"

--- a/eval/nightly_perf.py
+++ b/eval/nightly_perf.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Nightly performance measurement of XDN: low-load latency + max throughput.
 
-Measures ONE checkout of XDN (--repo) on a local loopback cluster (1 RC + 3 ARs
-from conf/gigapaxos.xdn.local.properties) and writes a JSON result:
+Measures ONE checkout of XDN (--repo) on a generated 1-RC + 3-AR loopback
+cluster and writes a JSON result:
 
     python3 eval/nightly_perf.py --repo /path/to/checkout --label head_r1 \
-        --out results/head_r1.json [--skip-tput] [--tput-hint-file hint.txt]
+        --out results/head_r1.json [--skip-tput] [--with-instrumented] \
+        [--tput-hint-file hint.txt]
 
 The nightly-perf workflow invokes this alternately against a baseline checkout
 and the current HEAD in the SAME job (interleaved A/B), so shared-runner noise
@@ -13,20 +14,35 @@ largely cancels in the head/base comparison. Absolute numbers from GitHub-hosted
 runners are NOT comparable across nights -- only the within-job deltas are; see
 eval/nightly_perf_check.py.
 
-Measured per service (bookcatalog -> paxos, bookcatalog-nd -> primary-backup):
-  - low-load latency: open-loop Poisson at --low-rate for --low-duration seconds
-    (median/p95/p99/avg), after a warmup.
-  - max throughput (unless --skip-tput): a geometric rate ladder; a rate passes
-    while achieved >= 93% of offered AND avg latency <= --tput-slo-ms. One
-    midpoint refinement after the first failure. Seeded from --tput-hint-file
-    when present so later rounds converge quickly.
+Measured per service (bookcatalog -> paxos, bookcatalog-nd -> primary-backup,
+FUSELOG statediff recorder with its working tree on /dev/shm):
+  - low-load latency: SEQUENTIAL closed loop (one outstanding request at a
+    time over a persistent connection) for --low-duration seconds, with the
+    default WARNING-level logging -- this is the clean, gated latency number.
+  - max throughput (unless --skip-tput): a geometric rate ladder driven by the
+    open-loop Poisson generator (eval/get_latency_at_rate.go); a rate passes
+    while achieved >= 93% of offered AND avg latency <= max(--tput-slo-ms,
+    3x the service's own unloaded average). Seeded from --tput-hint-file.
+  - with --with-instrumented: a SECOND cluster cycle with -DXDN_TIMING_HEADERS
+    and -DPB_SAMPLE_LATENCY, repeating the sequential run while harvesting the
+    X-XDN-Pipeline / X-XDN-Timing / X-XDN-Forward response headers (and, for
+    primary-backup, the PBM pipeline samples in /tmp/pbm_samples.log) into a
+    per-stage latency breakdown of the request flow. Recorded for diagnosis,
+    never gated: the instrumentation itself adds overhead.
+
+The measured tree's own fuselog/fuselog-apply binaries (bin/) are installed to
+/usr/local/bin at the start of the pass, so changes under xdn-fs/ are A/B'd
+like everything else.
 """
 
 import argparse
+import http.client
 import json
 import os
+import re
 import shlex
 import socket
+import statistics
 import subprocess
 import sys
 import tempfile
@@ -38,7 +54,16 @@ from pathlib import Path
 
 RC_PORT = 3000
 AR_HTTP_PORTS = [2300, 2301, 2302]
-ENTRY_URL = "http://127.0.0.1:2300/api/books"
+ENTRY_HOST, ENTRY_PORT = "127.0.0.1", 2300
+ENTRY_PATH = "/api/books"
+ENTRY_URL = f"http://{ENTRY_HOST}:{ENTRY_PORT}{ENTRY_PATH}"
+
+# FUSELOG working tree on tmpfs: fuselog is the production-representative
+# recorder (rsync forks a process per capture and dominated PB latency), and
+# /dev/shm keeps its snapshot/diff/apply I/O off the runner's disk.
+FUSELOG_BASE_DIR = "/dev/shm/xdn-perf/fuselog/"
+PBM_SAMPLES_LOG = "/tmp/pbm_samples.log"
+INSTRUMENTATION_JVM_ARGS = ["-DXDN_TIMING_HEADERS=true", "-DPB_SAMPLE_LATENCY=true"]
 
 # Generated into the measured checkout at runtime (so baseline commits need no
 # new checked-in file). Exactly 3 ARs: the default replication factor is 3, so
@@ -46,7 +71,7 @@ ENTRY_URL = "http://127.0.0.1:2300/api/books"
 # with more ARs the placement picks a subset and a fixed frontend may 404.
 # String node ids match XdnTestCluster's proven loopback shape.
 LOCAL_CONFIG = "conf/gigapaxos.nightlyperf.generated.properties"
-CONFIG_TEXT = """\
+CONFIG_TEXT = f"""\
 APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp
 GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
 ENABLE_ACTIVE_REPLICA_HTTP=true
@@ -59,7 +84,8 @@ SYNC=true
 NIO_MAX_PAYLOAD_SIZE=805306368
 INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator
 INITIAL_STATE_NUM_REPLICAS_EXTRACTOR_CLASS=edu.umass.cs.xdn.XdnServiceNumReplicasExtractor
-XDN_PB_STATEDIFF_RECORDER_TYPE=RSYNC
+XDN_PB_STATEDIFF_RECORDER_TYPE=FUSELOG
+XDN_FUSELOG_BASE_DIR={FUSELOG_BASE_DIR}
 XDN_PB_ENABLE_NON_DETERMINISTIC_INIT=true
 REPLICATE_ALL=false
 EMULATE_UNREPLICATED=false
@@ -72,7 +98,7 @@ active.AR2=127.0.0.1:2002
 
 SERVICES = [
     # (service name, image, deterministic) -- deterministic=True -> paxos,
-    # False -> primary-backup (rsync statediff recorder on the runner).
+    # False -> primary-backup (fuselog statediff recorder).
     ("perfcatalog", "fadhilkurnia/xdn-bookcatalog", True),
     ("perfcatalognd", "fadhilkurnia/xdn-bookcatalog-nd", False),
 ]
@@ -104,6 +130,16 @@ def wait_ports(ports, timeout_s=120):
         raise TimeoutError(f"ports never opened: {sorted(pending)}")
 
 
+def install_fuselog(repo: Path):
+    """Points /usr/local/bin at THIS tree's fuselog binaries so xdn-fs/ changes
+    are part of the A/B (the recorder hardcodes the /usr/local/bin paths)."""
+    for tool in ("fuselog", "fuselog-apply"):
+        src = repo / "bin" / tool
+        if not src.exists():
+            raise RuntimeError(f"{src} missing; build with bin/build_xdn_fuselog.sh cpp")
+        run(f"sudo ln -sf {shlex.quote(str(src))} /usr/local/bin/{tool}")
+
+
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, *args, **kwargs):
         return None
@@ -117,7 +153,8 @@ def wait_service_ready(service: str, timeout_s=120):
     deadline = time.time() + timeout_s
     last = None
     while time.time() < deadline:
-        request = urllib.request.Request("http://127.0.0.1:2300/", headers={"XDN": service})
+        request = urllib.request.Request(
+            f"http://{ENTRY_HOST}:{ENTRY_PORT}/", headers={"XDN": service})
         try:
             with opener.open(request, timeout=5) as resp:
                 last = resp.status
@@ -149,15 +186,22 @@ class Cluster:
             shell=True, cwd=self.repo, check=False, timeout=180,
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         subprocess.run("pkill -9 -f '[R]econfigurableNode' || true", shell=True, check=False)
-        subprocess.run("sudo rm -rf /tmp/gigapaxos /tmp/xdn || rm -rf /tmp/gigapaxos /tmp/xdn",
-                       shell=True, check=False)
+        # release any stray fuselog FUSE mounts before removing their trees
+        subprocess.run(
+            "mount | grep fuse.fuselog | awk '{print $3}' | xargs -r sudo umount -l",
+            shell=True, check=False)
+        subprocess.run(
+            "sudo rm -rf /tmp/gigapaxos /tmp/xdn /dev/shm/xdn-perf"
+            " || rm -rf /tmp/gigapaxos /tmp/xdn /dev/shm/xdn-perf",
+            shell=True, check=False)
 
-    def start(self):
-        log(f"starting cluster from {self.repo}")
+    def start(self, jvm_args=()):
+        log(f"starting cluster from {self.repo} jvm_args={list(jvm_args)}")
         logfile = self.repo / "nightly_perf_cluster.log"
+        extra = " ".join(jvm_args)
         with open(logfile, "w") as fh:
             subprocess.run(
-                f"{shlex.quote(str(self.gp))} -DgigapaxosConfig={self.config} start all",
+                f"{shlex.quote(str(self.gp))} -DgigapaxosConfig={self.config} {extra} start all",
                 shell=True, cwd=self.repo, check=True, timeout=300, stdout=fh, stderr=fh)
         wait_ports([RC_PORT] + AR_HTTP_PORTS, timeout_s=180)
         time.sleep(5)  # let the HTTP frontends finish wiring after the ports open
@@ -168,7 +212,7 @@ class Cluster:
             f" --image={image} --state=/app/data/ --consistency=linearizability"
             f" --deterministic={'true' if deterministic else 'false'} --env ENABLE_WAL=true")
         run(cmd, cwd=self.repo, timeout=240)
-        time.sleep(5)
+        wait_service_ready(name)
 
     def destroy(self, name: str):
         subprocess.run(
@@ -176,6 +220,122 @@ class Cluster:
             shell=True, cwd=self.repo, check=False, timeout=180,
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         time.sleep(3)
+
+
+# ── sequential closed-loop client (low-load latency) ─────────────────────────
+
+
+def run_sequential(service: str, duration_s: int, collect_headers=False):
+    """One outstanding request at a time over one persistent connection.
+    Returns (sorted latencies ms, list of parsed timing-header dicts, errors)."""
+    conn = None
+    latencies = []
+    header_samples = []
+    errors = 0
+    headers = {"XDN": service, "Content-Type": "application/json",
+               "Content-Length": str(len(PAYLOAD))}
+    deadline = time.time() + duration_s
+    while time.time() < deadline:
+        try:
+            if conn is None:
+                conn = http.client.HTTPConnection(ENTRY_HOST, ENTRY_PORT, timeout=15)
+            start = time.perf_counter()
+            conn.request("POST", ENTRY_PATH, body=PAYLOAD, headers=headers)
+            resp = conn.getresponse()
+            resp.read()
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            if resp.status >= 400:
+                errors += 1
+                continue
+            latencies.append(elapsed_ms)
+            if collect_headers:
+                parsed = parse_timing_headers(dict(resp.getheaders()))
+                if parsed:
+                    header_samples.append(parsed)
+        except Exception:  # noqa: BLE001 - reconnect and continue
+            errors += 1
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+            conn = None
+            time.sleep(0.2)
+    if conn is not None:
+        conn.close()
+    latencies.sort()
+    return latencies, header_samples, errors
+
+
+def percentile(sorted_values, fraction):
+    if not sorted_values:
+        return None
+    index = min(len(sorted_values) - 1, int(fraction * (len(sorted_values) - 1) + 0.5))
+    return round(sorted_values[index], 2)
+
+
+def sequential_stats(latencies, errors):
+    if not latencies:
+        return None
+    return {
+        "mode": "sequential-closed-loop",
+        "requests": len(latencies),
+        "errors": errors,
+        "avg_ms": round(statistics.fmean(latencies), 2),
+        "p50_ms": percentile(latencies, 0.50),
+        "p95_ms": percentile(latencies, 0.95),
+        "p99_ms": percentile(latencies, 0.99),
+    }
+
+
+# ── instrumentation parsing ──────────────────────────────────────────────────
+
+
+def parse_timing_headers(headers: dict) -> dict:
+    """X-XDN-Pipeline: callback=12ms / X-XDN-Timing: exec=..;fwd=.. /
+    X-XDN-Forward: container=..;proxy=..;copyreq=.. -> {stage: ms}."""
+    out = {}
+    for name in ("X-XDN-Pipeline", "X-XDN-Timing", "X-XDN-Forward"):
+        value = headers.get(name)
+        if not value:
+            continue
+        for part in value.split(";"):
+            key, _, raw = part.partition("=")
+            raw = raw.strip().removesuffix("ms")
+            try:
+                out[key.strip()] = float(raw)
+            except ValueError:
+                pass
+    return out
+
+
+PBM_SAMPLE_RE = re.compile(
+    r"FIRST queueWait=([\d.]+) exec=([\d.]+) captureWait=([\d.]+) capture=([\d.]+) "
+    r"proposePrep=([\d.]+) paxos=([\d.]+) total=([\d.]+)ms")
+PBM_STAGES = ("queue_wait", "exec", "capture_wait", "capture", "propose_prep", "paxos", "total")
+
+
+def parse_pbm_samples(path: str) -> dict:
+    """Medians of the PBM capture-pipeline stage samples (primary-backup only)."""
+    stage_values = {stage: [] for stage in PBM_STAGES}
+    try:
+        text = Path(path).read_text()
+    except OSError:
+        return {}
+    for match in PBM_SAMPLE_RE.finditer(text):
+        for stage, value in zip(PBM_STAGES, match.groups()):
+            stage_values[stage].append(float(value))
+    return {stage: round(statistics.median(values), 2)
+            for stage, values in stage_values.items() if values}
+
+
+def stage_medians(header_samples: list) -> dict:
+    keys = set().union(*header_samples) if header_samples else set()
+    return {key: round(statistics.median(
+        [sample[key] for sample in header_samples if key in sample]), 2)
+        for key in sorted(keys)}
+
+
+# ── open-loop load generator wrapper (throughput ladder) ─────────────────────
 
 
 class LoadGen:
@@ -200,20 +360,6 @@ class LoadGen:
         if "median_latency_ms" not in stats:
             raise RuntimeError(f"load generator produced no stats:\n{proc.stdout[-2000:]}")
         return stats
-
-
-def measure_low_load(gen: LoadGen, service: str, rate: int, duration_s: int) -> dict:
-    stats = gen.run(service, rate, duration_s)
-    return {
-        "rate": rate,
-        "achieved_rps": stats.get("actual_throughput_rps"),
-        "avg_ms": stats.get("average_latency_ms"),
-        "p50_ms": stats.get("median_latency_ms"),
-        "p95_ms": stats.get("p95_latency_ms"),
-        "p99_ms": stats.get("p99_latency_ms"),
-        "success": stats.get("total_successful_responses"),
-        "sent": stats.get("total_requests_sent"),
-    }
 
 
 def rate_passes(stats: dict, offered: int, slo_ms: float) -> bool:
@@ -285,41 +431,12 @@ def calibration_probe() -> dict:
     return {"fsync_avg_ms": round(fsync_ms, 3), "cpu_loops_per_500ms": acc}
 
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repo", required=True, help="XDN checkout to measure")
-    parser.add_argument("--label", required=True)
-    parser.add_argument("--out", required=True)
-    parser.add_argument("--low-rate", type=int, default=25)
-    parser.add_argument("--low-duration", type=int, default=45)
-    parser.add_argument("--warmup", type=int, default=15)
-    parser.add_argument("--tput-slo-ms", type=float, default=100.0)
-    parser.add_argument("--tput-step-duration", type=int, default=20)
-    parser.add_argument("--skip-tput", action="store_true")
-    parser.add_argument("--tput-hint-file", default=None,
-                        help="File with 'service=rate' hints; updated after each ladder")
-    args = parser.parse_args()
+# ── measurement phases ───────────────────────────────────────────────────────
 
-    repo = Path(args.repo).resolve()
-    hints = {}
-    if args.tput_hint_file and Path(args.tput_hint_file).exists():
-        for line in Path(args.tput_hint_file).read_text().splitlines():
-            key, _, value = line.partition("=")
-            if value.strip().isdigit():
-                hints[key.strip()] = int(value.strip())
 
-    sha = subprocess.run("git rev-parse HEAD", shell=True, cwd=repo, check=False,
-                         stdout=subprocess.PIPE, text=True).stdout.strip()
-    result = {
-        "label": args.label,
-        "sha": sha,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "calibration": calibration_probe(),
-        "services": {},
-    }
-
-    cluster = Cluster(repo)
-    gen = LoadGen(repo)
+def quiet_phase(cluster: Cluster, gen: LoadGen, args, hints: dict) -> dict:
+    """Default WARNING-level logging, no instrumentation: the gated numbers."""
+    services = {}
     cluster.clean()
     try:
         cluster.start()
@@ -327,11 +444,13 @@ def main():
             svc = {"image": image, "protocol": "paxos" if deterministic else "primary-backup"}
             try:
                 cluster.launch(name, image, deterministic)
-                wait_service_ready(name)
-                log(f"warmup {name} @{args.low_rate}rps x{args.warmup}s")
-                gen.run(name, args.low_rate, args.warmup)
-                log(f"low-load {name} @{args.low_rate}rps x{args.low_duration}s")
-                svc["low_load"] = measure_low_load(gen, name, args.low_rate, args.low_duration)
+                log(f"warmup {name} (sequential x{args.warmup}s)")
+                run_sequential(name, args.warmup)
+                log(f"low-load {name} (sequential x{args.low_duration}s)")
+                latencies, _, errors = run_sequential(name, args.low_duration)
+                svc["low_load"] = sequential_stats(latencies, errors)
+                if svc["low_load"] is None:
+                    raise RuntimeError(f"sequential run produced no successes ({errors} errors)")
                 if not args.skip_tput:
                     # SLO is relative to this service's own unloaded latency so
                     # slow-pipeline protocols (primary-backup's capture/propose
@@ -347,9 +466,92 @@ def main():
                 svc["error"] = str(exc)
             finally:
                 cluster.destroy(name)
-            result["services"][name] = svc
+            services[name] = svc
     finally:
         cluster.clean()
+    return services
+
+
+def instrumented_phase(cluster: Cluster, args) -> dict:
+    """Second cluster cycle with timing headers + PBM sampling: a per-stage
+    latency breakdown of the request flow. Diagnostic only, never gated."""
+    flows = {}
+    cluster.clean()
+    Path(PBM_SAMPLES_LOG).unlink(missing_ok=True)
+    try:
+        cluster.start(jvm_args=INSTRUMENTATION_JVM_ARGS)
+        for name, image, deterministic in SERVICES:
+            flow = {}
+            try:
+                cluster.launch(name, image, deterministic)
+                run_sequential(name, min(args.warmup, 10))
+                Path(PBM_SAMPLES_LOG).unlink(missing_ok=True)
+                log(f"instrumented low-load {name} (sequential x{args.low_duration}s)")
+                latencies, header_samples, errors = run_sequential(
+                    name, args.low_duration, collect_headers=True)
+                stats = sequential_stats(latencies, errors)
+                if stats is None:
+                    raise RuntimeError(f"no successful instrumented requests ({errors} errors)")
+                flow["client_p50_ms"] = stats["p50_ms"]
+                flow["requests"] = stats["requests"]
+                flow["stages_p50_ms"] = stage_medians(header_samples)
+                if not deterministic:
+                    pbm = parse_pbm_samples(PBM_SAMPLES_LOG)
+                    if pbm:
+                        flow["pbm_p50_ms"] = pbm
+            except Exception as exc:  # noqa: BLE001
+                log(f"WARNING: instrumented run for {name} failed: {exc}")
+                flow["error"] = str(exc)
+            finally:
+                cluster.destroy(name)
+            flows[name] = flow
+    finally:
+        cluster.clean()
+    return flows
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="XDN checkout to measure")
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--low-duration", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--tput-slo-ms", type=float, default=100.0)
+    parser.add_argument("--tput-step-duration", type=int, default=20)
+    parser.add_argument("--skip-tput", action="store_true")
+    parser.add_argument("--with-instrumented", action="store_true",
+                        help="Add a second, instrumented cluster cycle recording "
+                             "the per-stage request-flow latency breakdown")
+    parser.add_argument("--tput-hint-file", default=None,
+                        help="File with 'service=rate' hints; updated after each ladder")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    install_fuselog(repo)
+    hints = {}
+    if args.tput_hint_file and Path(args.tput_hint_file).exists():
+        for line in Path(args.tput_hint_file).read_text().splitlines():
+            key, _, value = line.partition("=")
+            if value.strip().isdigit():
+                hints[key.strip()] = int(value.strip())
+
+    sha = subprocess.run("git rev-parse HEAD", shell=True, cwd=repo, check=False,
+                         stdout=subprocess.PIPE, text=True).stdout.strip()
+    result = {
+        "label": args.label,
+        "sha": sha,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "calibration": calibration_probe(),
+    }
+
+    cluster = Cluster(repo)
+    gen = LoadGen(repo)
+    result["services"] = quiet_phase(cluster, gen, args, hints)
+    if args.with_instrumented:
+        flows = instrumented_phase(cluster, args)
+        for name, flow in flows.items():
+            result["services"].setdefault(name, {})["instrumented"] = flow
 
     if args.tput_hint_file:
         Path(args.tput_hint_file).write_text(

--- a/eval/nightly_perf.py
+++ b/eval/nightly_perf.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Nightly performance measurement of XDN: low-load latency + max throughput.
+
+Measures ONE checkout of XDN (--repo) on a local loopback cluster (1 RC + 3 ARs
+from conf/gigapaxos.xdn.local.properties) and writes a JSON result:
+
+    python3 eval/nightly_perf.py --repo /path/to/checkout --label head_r1 \
+        --out results/head_r1.json [--skip-tput] [--tput-hint-file hint.txt]
+
+The nightly-perf workflow invokes this alternately against a baseline checkout
+and the current HEAD in the SAME job (interleaved A/B), so shared-runner noise
+largely cancels in the head/base comparison. Absolute numbers from GitHub-hosted
+runners are NOT comparable across nights -- only the within-job deltas are; see
+eval/nightly_perf_check.py.
+
+Measured per service (bookcatalog -> paxos, bookcatalog-nd -> primary-backup):
+  - low-load latency: open-loop Poisson at --low-rate for --low-duration seconds
+    (median/p95/p99/avg), after a warmup.
+  - max throughput (unless --skip-tput): a geometric rate ladder; a rate passes
+    while achieved >= 93% of offered AND avg latency <= --tput-slo-ms. One
+    midpoint refinement after the first failure. Seeded from --tput-hint-file
+    when present so later rounds converge quickly.
+"""
+
+import argparse
+import json
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+RC_PORT = 3000
+AR_HTTP_PORTS = [2300, 2301, 2302]
+ENTRY_URL = "http://127.0.0.1:2300/api/books"
+
+# Generated into the measured checkout at runtime (so baseline commits need no
+# new checked-in file). Exactly 3 ARs: the default replication factor is 3, so
+# every service is placed on ALL ARs and any frontend can serve the load --
+# with more ARs the placement picks a subset and a fixed frontend may 404.
+# String node ids match XdnTestCluster's proven loopback shape.
+LOCAL_CONFIG = "conf/gigapaxos.nightlyperf.generated.properties"
+CONFIG_TEXT = """\
+APPLICATION=edu.umass.cs.xdn.XdnGigapaxosApp
+GIGAPAXOS_DATA_DIR=/tmp/gigapaxos
+ENABLE_ACTIVE_REPLICA_HTTP=true
+ENABLE_RECONFIGURATOR_HTTP=true
+BATCHING_ENABLED=true
+REPLICA_COORDINATOR_CLASS=edu.umass.cs.xdn.XdnReplicaCoordinator
+ENABLE_STARTUP_LEADER_ELECTION=false
+HIBERNATE_OPTION=true
+SYNC=true
+NIO_MAX_PAYLOAD_SIZE=805306368
+INITIAL_STATE_VALIDATOR_CLASS=edu.umass.cs.xdn.XdnServiceInitialStateValidator
+INITIAL_STATE_NUM_REPLICAS_EXTRACTOR_CLASS=edu.umass.cs.xdn.XdnServiceNumReplicasExtractor
+XDN_PB_STATEDIFF_RECORDER_TYPE=RSYNC
+XDN_PB_ENABLE_NON_DETERMINISTIC_INIT=true
+REPLICATE_ALL=false
+EMULATE_UNREPLICATED=false
+HTTP_AR_FRONTEND_BATCH_ENABLED=true
+reconfigurator.RC0=127.0.0.1:3000
+active.AR0=127.0.0.1:2000
+active.AR1=127.0.0.1:2001
+active.AR2=127.0.0.1:2002
+"""
+
+SERVICES = [
+    # (service name, image, deterministic) -- deterministic=True -> paxos,
+    # False -> primary-backup (rsync statediff recorder on the runner).
+    ("perfcatalog", "fadhilkurnia/xdn-bookcatalog", True),
+    ("perfcatalognd", "fadhilkurnia/xdn-bookcatalog-nd", False),
+]
+PAYLOAD = '{"author": "abc", "title": "xyz"}'
+
+
+def log(msg: str):
+    print(f"[nightly-perf {datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def run(cmd: str, cwd=None, check=True, timeout=600) -> subprocess.CompletedProcess:
+    log(f"$ {cmd}")
+    return subprocess.run(
+        cmd, shell=True, cwd=cwd, check=check, timeout=timeout,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+
+def wait_ports(ports, timeout_s=120):
+    deadline = time.time() + timeout_s
+    pending = set(ports)
+    while pending and time.time() < deadline:
+        for port in list(pending):
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
+                    pending.discard(port)
+            except OSError:
+                time.sleep(1)
+    if pending:
+        raise TimeoutError(f"ports never opened: {sorted(pending)}")
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *args, **kwargs):
+        return None
+
+
+def wait_service_ready(service: str, timeout_s=120):
+    """Polls an AR frontend until the service answers anything but 404: right
+    after CREATE, the frontend returns 404 until service registration has
+    propagated (the same race XdnServiceDestroyRecreateTest works around)."""
+    opener = urllib.request.build_opener(_NoRedirect)
+    deadline = time.time() + timeout_s
+    last = None
+    while time.time() < deadline:
+        request = urllib.request.Request("http://127.0.0.1:2300/", headers={"XDN": service})
+        try:
+            with opener.open(request, timeout=5) as resp:
+                last = resp.status
+                if resp.status != 404:
+                    return
+        except urllib.error.HTTPError as exc:
+            last = exc.code
+            if exc.code != 404:
+                return  # any app-generated response means the service is wired
+        except Exception as exc:  # noqa: BLE001 - frontend not up yet
+            last = str(exc)
+        time.sleep(2)
+    raise TimeoutError(f"service {service} never became ready; last response: {last}")
+
+
+class Cluster:
+    """A loopback 1-RC + 3-AR cluster run from one checkout."""
+
+    def __init__(self, repo: Path):
+        self.repo = repo
+        self.config = repo / LOCAL_CONFIG
+        self.config.write_text(CONFIG_TEXT)
+        self.gp = repo / "bin" / "gpServer.sh"
+        self.xdn = repo / "bin" / "xdn"
+
+    def clean(self):
+        subprocess.run(
+            f"{shlex.quote(str(self.gp))} -DgigapaxosConfig={self.config} forceclear all",
+            shell=True, cwd=self.repo, check=False, timeout=180,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run("pkill -9 -f '[R]econfigurableNode' || true", shell=True, check=False)
+        subprocess.run("sudo rm -rf /tmp/gigapaxos /tmp/xdn || rm -rf /tmp/gigapaxos /tmp/xdn",
+                       shell=True, check=False)
+
+    def start(self):
+        log(f"starting cluster from {self.repo}")
+        logfile = self.repo / "nightly_perf_cluster.log"
+        with open(logfile, "w") as fh:
+            subprocess.run(
+                f"{shlex.quote(str(self.gp))} -DgigapaxosConfig={self.config} start all",
+                shell=True, cwd=self.repo, check=True, timeout=300, stdout=fh, stderr=fh)
+        wait_ports([RC_PORT] + AR_HTTP_PORTS, timeout_s=180)
+        time.sleep(5)  # let the HTTP frontends finish wiring after the ports open
+
+    def launch(self, name: str, image: str, deterministic: bool):
+        cmd = (
+            f"XDN_CONTROL_PLANE=localhost {shlex.quote(str(self.xdn))} launch {name}"
+            f" --image={image} --state=/app/data/ --consistency=linearizability"
+            f" --deterministic={'true' if deterministic else 'false'} --env ENABLE_WAL=true")
+        run(cmd, cwd=self.repo, timeout=240)
+        time.sleep(5)
+
+    def destroy(self, name: str):
+        subprocess.run(
+            f"XDN_CONTROL_PLANE=localhost {shlex.quote(str(self.xdn))} service destroy {name} --yes",
+            shell=True, cwd=self.repo, check=False, timeout=180,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(3)
+
+
+class LoadGen:
+    """Wrapper around eval/get_latency_at_rate.go (open-loop Poisson client)."""
+
+    def __init__(self, repo: Path):
+        self.tool = repo / "eval" / "get_latency_at_rate.go"
+
+    def run(self, service: str, rate: int, duration_s: int) -> dict:
+        cmd = (
+            f"go run {shlex.quote(str(self.tool))} -H 'XDN: {service}'"
+            f" {ENTRY_URL} {shlex.quote(PAYLOAD)} {duration_s} {rate}")
+        proc = run(cmd, timeout=duration_s + 120, check=False)
+        stats = {}
+        for line in proc.stdout.splitlines():
+            if ":" in line and not line.startswith(("---", " ")):
+                key, _, value = line.partition(":")
+                try:
+                    stats[key.strip()] = float(value.strip())
+                except ValueError:
+                    pass
+        if "median_latency_ms" not in stats:
+            raise RuntimeError(f"load generator produced no stats:\n{proc.stdout[-2000:]}")
+        return stats
+
+
+def measure_low_load(gen: LoadGen, service: str, rate: int, duration_s: int) -> dict:
+    stats = gen.run(service, rate, duration_s)
+    return {
+        "rate": rate,
+        "achieved_rps": stats.get("actual_throughput_rps"),
+        "avg_ms": stats.get("average_latency_ms"),
+        "p50_ms": stats.get("median_latency_ms"),
+        "p95_ms": stats.get("p95_latency_ms"),
+        "p99_ms": stats.get("p99_latency_ms"),
+        "success": stats.get("total_successful_responses"),
+        "sent": stats.get("total_requests_sent"),
+    }
+
+
+def rate_passes(stats: dict, offered: int, slo_ms: float) -> bool:
+    achieved = stats.get("actual_throughput_rps") or 0.0
+    avg = stats.get("average_latency_ms") or float("inf")
+    return achieved >= 0.93 * offered and avg <= slo_ms
+
+
+def measure_max_tput(gen: LoadGen, service: str, hint, slo_ms: float, step_s: int) -> dict:
+    ladder = []
+    rate = max(25, int(hint * 0.6)) if hint else 50
+    best = None
+    first_bad = None
+    for _ in range(10):
+        stats = gen.run(service, rate, step_s)
+        ok = rate_passes(stats, rate, slo_ms)
+        entry = {"offered": rate, "achieved_rps": stats.get("actual_throughput_rps"),
+                 "avg_ms": stats.get("average_latency_ms"), "ok": ok}
+        ladder.append(entry)
+        log(f"ladder {service}: {entry}")
+        if ok:
+            best = entry
+            rate = int(rate * 1.4)
+        elif best is None and rate > 10:
+            # first rung already failed: descend to find the passing region
+            rate = max(10, int(rate / 1.4))
+            first_bad = entry
+        else:
+            first_bad = entry
+            break
+        time.sleep(3)
+    if best and first_bad and first_bad["offered"] > best["offered"]:
+        mid = (best["offered"] + first_bad["offered"]) // 2
+        if mid > best["offered"]:
+            stats = gen.run(service, mid, step_s)
+            ok = rate_passes(stats, mid, slo_ms)
+            entry = {"offered": mid, "achieved_rps": stats.get("actual_throughput_rps"),
+                     "avg_ms": stats.get("average_latency_ms"), "ok": ok}
+            ladder.append(entry)
+            log(f"ladder {service} (refine): {entry}")
+            if ok:
+                best = entry
+    # A ladder that ran out of steps while every rung still passed did NOT find
+    # the saturation knee -- recording its top rung as "max throughput" would
+    # understate by up to the growth factor and pollute cross-round medians.
+    # Record max_tput only when a failing rung brackets the knee; the highest
+    # passing rung is still exported as the next round's starting hint.
+    knee_found = best is not None and first_bad is not None \
+        and first_bad["offered"] > best["offered"]
+    return {"ladder": ladder,
+            "tput_hint": int(best["offered"]) if best else None,
+            "max_tput": {"offered": best["offered"], "achieved_rps": best["achieved_rps"],
+                         "avg_ms": best["avg_ms"]} if knee_found else None}
+
+
+def calibration_probe() -> dict:
+    """Cheap runner-speed fingerprint, recorded alongside every measurement."""
+    with tempfile.NamedTemporaryFile(dir="/tmp", delete=True) as fh:
+        start = time.perf_counter()
+        for _ in range(100):
+            fh.write(b"x" * 4096)
+            fh.flush()
+            os.fsync(fh.fileno())
+        fsync_ms = (time.perf_counter() - start) * 1000 / 100
+    start = time.perf_counter()
+    acc = 0
+    while time.perf_counter() - start < 0.5:
+        acc += 1
+    return {"fsync_avg_ms": round(fsync_ms, 3), "cpu_loops_per_500ms": acc}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="XDN checkout to measure")
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--low-rate", type=int, default=25)
+    parser.add_argument("--low-duration", type=int, default=45)
+    parser.add_argument("--warmup", type=int, default=15)
+    parser.add_argument("--tput-slo-ms", type=float, default=100.0)
+    parser.add_argument("--tput-step-duration", type=int, default=20)
+    parser.add_argument("--skip-tput", action="store_true")
+    parser.add_argument("--tput-hint-file", default=None,
+                        help="File with 'service=rate' hints; updated after each ladder")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    hints = {}
+    if args.tput_hint_file and Path(args.tput_hint_file).exists():
+        for line in Path(args.tput_hint_file).read_text().splitlines():
+            key, _, value = line.partition("=")
+            if value.strip().isdigit():
+                hints[key.strip()] = int(value.strip())
+
+    sha = subprocess.run("git rev-parse HEAD", shell=True, cwd=repo, check=False,
+                         stdout=subprocess.PIPE, text=True).stdout.strip()
+    result = {
+        "label": args.label,
+        "sha": sha,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "calibration": calibration_probe(),
+        "services": {},
+    }
+
+    cluster = Cluster(repo)
+    gen = LoadGen(repo)
+    cluster.clean()
+    try:
+        cluster.start()
+        for name, image, deterministic in SERVICES:
+            svc = {"image": image, "protocol": "paxos" if deterministic else "primary-backup"}
+            try:
+                cluster.launch(name, image, deterministic)
+                wait_service_ready(name)
+                log(f"warmup {name} @{args.low_rate}rps x{args.warmup}s")
+                gen.run(name, args.low_rate, args.warmup)
+                log(f"low-load {name} @{args.low_rate}rps x{args.low_duration}s")
+                svc["low_load"] = measure_low_load(gen, name, args.low_rate, args.low_duration)
+                if not args.skip_tput:
+                    # SLO is relative to this service's own unloaded latency so
+                    # slow-pipeline protocols (primary-backup's capture/propose
+                    # path) get a saturation knee too, not an unreachable bound.
+                    slo = max(args.tput_slo_ms, 3 * (svc["low_load"]["avg_ms"] or 0))
+                    svc.update(measure_max_tput(
+                        gen, name, hints.get(name), slo, args.tput_step_duration))
+                    hint = svc.pop("tput_hint", None)
+                    if hint:
+                        hints[name] = hint
+            except Exception as exc:  # a service failing must not kill the whole pass
+                log(f"WARNING: measuring {name} failed: {exc}")
+                svc["error"] = str(exc)
+            finally:
+                cluster.destroy(name)
+            result["services"][name] = svc
+    finally:
+        cluster.clean()
+
+    if args.tput_hint_file:
+        Path(args.tput_hint_file).write_text(
+            "".join(f"{key}={value}\n" for key, value in sorted(hints.items())))
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(result, indent=2) + "\n")
+    log(f"wrote {args.out}")
+    errors = [n for n, s in result["services"].items() if "error" in s]
+    if len(errors) == len(result["services"]):
+        log("all services failed to measure")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/nightly_perf.py
+++ b/eval/nightly_perf.py
@@ -270,7 +270,7 @@ def percentile(sorted_values, fraction):
     if not sorted_values:
         return None
     index = min(len(sorted_values) - 1, int(fraction * (len(sorted_values) - 1) + 0.5))
-    return round(sorted_values[index], 2)
+    return round(sorted_values[index], 3)
 
 
 def sequential_stats(latencies, errors):
@@ -280,7 +280,7 @@ def sequential_stats(latencies, errors):
         "mode": "sequential-closed-loop",
         "requests": len(latencies),
         "errors": errors,
-        "avg_ms": round(statistics.fmean(latencies), 2),
+        "avg_ms": round(statistics.fmean(latencies), 3),
         "p50_ms": percentile(latencies, 0.50),
         "p95_ms": percentile(latencies, 0.95),
         "p99_ms": percentile(latencies, 0.99),
@@ -324,14 +324,14 @@ def parse_pbm_samples(path: str) -> dict:
     for match in PBM_SAMPLE_RE.finditer(text):
         for stage, value in zip(PBM_STAGES, match.groups()):
             stage_values[stage].append(float(value))
-    return {stage: round(statistics.median(values), 2)
+    return {stage: round(statistics.median(values), 3)
             for stage, values in stage_values.items() if values}
 
 
 def stage_medians(header_samples: list) -> dict:
     keys = set().union(*header_samples) if header_samples else set()
     return {key: round(statistics.median(
-        [sample[key] for sample in header_samples if key in sample]), 2)
+        [sample[key] for sample in header_samples if key in sample]), 3)
         for key in sorted(keys)}
 
 

--- a/eval/nightly_perf_check.py
+++ b/eval/nightly_perf_check.py
@@ -39,6 +39,9 @@ def median_metrics(rounds: list) -> dict:
             slot = services.setdefault(name, {"p50": [], "p99": [], "tput": [], "errors": []})
             if "error" in svc:
                 slot["errors"].append(svc["error"])
+            if svc.get("instrumented") and "error" not in svc["instrumented"]:
+                # per-stage request-flow breakdown (diagnostic, never gated)
+                slot.setdefault("flow", svc["instrumented"])
             low = svc.get("low_load") or {}
             if low.get("p50_ms") is not None:
                 slot["p50"].append(low["p50_ms"])
@@ -58,6 +61,7 @@ def median_metrics(rounds: list) -> dict:
             "max_tput_rps": round(max(slot["tput"]), 1) if slot["tput"] else None,
             "rounds": {"p50": len(slot["p50"]), "tput": len(slot["tput"])},
             "errors": slot["errors"],
+            "flow": slot.get("flow"),
         }
     return out
 
@@ -144,6 +148,23 @@ def main():
                      f"| {fmt(h['max_tput_rps'], ' rps')} | {fmt(d.get('tput_pct'), '%')} |")
         for err in h["errors"]:
             lines.append(f"| {name} | error | | `{err[:80]}` | |")
+    lines.append("")
+    for name, h in head.items():
+        flow = h.get("flow")
+        if not flow:
+            continue
+        lines.append(f"<details><summary>{name} request-flow breakdown "
+                     f"(instrumented run, head; p50 per stage)</summary>")
+        lines.append("")
+        lines.append("| stage | p50 (ms) |")
+        lines.append("|---|---|")
+        lines.append(f"| client total | {flow.get('client_p50_ms', 'n/a')} |")
+        for stage, value in (flow.get("stages_p50_ms") or {}).items():
+            lines.append(f"| {stage} | {value} |")
+        for stage, value in (flow.get("pbm_p50_ms") or {}).items():
+            lines.append(f"| pbm: {stage} | {value} |")
+        lines.append("")
+        lines.append("</details>")
     lines.append("")
     if regressions:
         lines.append("### REGRESSION detected")

--- a/eval/nightly_perf_check.py
+++ b/eval/nightly_perf_check.py
@@ -153,16 +153,19 @@ def main():
         flow = h.get("flow")
         if not flow:
             continue
+        def as_us(value_ms):
+            return f"{round(value_ms * 1000):,}" if value_ms is not None else "n/a"
+
         lines.append(f"<details><summary>{name} request-flow breakdown "
-                     f"(instrumented run, head; p50 per stage)</summary>")
+                     f"(instrumented run, head; p50 per stage, µs)</summary>")
         lines.append("")
-        lines.append("| stage | p50 (ms) |")
+        lines.append("| stage | p50 (µs) |")
         lines.append("|---|---|")
-        lines.append(f"| client total | {flow.get('client_p50_ms', 'n/a')} |")
+        lines.append(f"| client total | {as_us(flow.get('client_p50_ms'))} |")
         for stage, value in (flow.get("stages_p50_ms") or {}).items():
-            lines.append(f"| {stage} | {value} |")
+            lines.append(f"| {stage} | {as_us(value)} |")
         for stage, value in (flow.get("pbm_p50_ms") or {}).items():
-            lines.append(f"| pbm: {stage} | {value} |")
+            lines.append(f"| pbm: {stage} | {as_us(value)} |")
         lines.append("")
         lines.append("</details>")
     lines.append("")

--- a/eval/nightly_perf_check.py
+++ b/eval/nightly_perf_check.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Compare interleaved A/B results from eval/nightly_perf.py and detect regressions.
+
+Reads results/{base,head}_r*.json produced by the nightly-perf workflow, takes
+per-metric medians across rounds, and compares head against base RELATIVELY --
+the runs were interleaved on the same runner in the same job, so the ratio is
+meaningful even though absolute numbers from shared runners are not.
+
+Thresholds (head vs base): low-load p50 +15%, low-load p99 +25%, max tput -15%.
+A metric missing on either side (e.g. a service failed to measure) is reported
+but never flagged as a regression on its own.
+
+Outputs: a markdown summary (--summary), a single-line JSON record (--record)
+to append to the perf-results branch, and 'regression=true|false' appended to
+--github-output when given. Exit code is always 0; the workflow decides how to
+react so the record is pushed before the job is failed.
+"""
+
+import argparse
+import json
+import statistics
+from datetime import datetime, timezone
+from pathlib import Path
+
+P50_UP_LIMIT = 0.15
+P99_UP_LIMIT = 0.25
+TPUT_DOWN_LIMIT = 0.15
+
+
+def load_side(results_dir: Path, side: str) -> list:
+    return [json.loads(p.read_text()) for p in sorted(results_dir.glob(f"{side}_r*.json"))]
+
+
+def median_metrics(rounds: list) -> dict:
+    """Per-service medians across rounds: p50/p99 low-load latency + max tput."""
+    services = {}
+    for rnd in rounds:
+        for name, svc in rnd.get("services", {}).items():
+            slot = services.setdefault(name, {"p50": [], "p99": [], "tput": [], "errors": []})
+            if "error" in svc:
+                slot["errors"].append(svc["error"])
+            low = svc.get("low_load") or {}
+            if low.get("p50_ms") is not None:
+                slot["p50"].append(low["p50_ms"])
+            if low.get("p99_ms") is not None:
+                slot["p99"].append(low["p99_ms"])
+            tput = svc.get("max_tput") or {}
+            if tput.get("achieved_rps") is not None:
+                slot["tput"].append(tput["achieved_rps"])
+    out = {}
+    for name, slot in services.items():
+        out[name] = {
+            "p50_ms": round(statistics.median(slot["p50"]), 2) if slot["p50"] else None,
+            "p99_ms": round(statistics.median(slot["p99"]), 2) if slot["p99"] else None,
+            # max (not median): a round can only undershoot the true knee (noise
+            # makes rungs fail early), so the best demonstrated rate is the
+            # stable estimator across rounds.
+            "max_tput_rps": round(max(slot["tput"]), 1) if slot["tput"] else None,
+            "rounds": {"p50": len(slot["p50"]), "tput": len(slot["tput"])},
+            "errors": slot["errors"],
+        }
+    return out
+
+
+def pct(new, old):
+    if new is None or old is None or old == 0:
+        return None
+    return round((new - old) / old * 100, 1)
+
+
+def fmt(value, unit=""):
+    return f"{value}{unit}" if value is not None else "n/a"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--base-sha", default=None)
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--record", required=True)
+    parser.add_argument("--github-output", default=None)
+    args = parser.parse_args()
+
+    results_dir = Path(args.results)
+    head_rounds = load_side(results_dir, "head")
+    base_rounds = load_side(results_dir, "base")
+    if not head_rounds:
+        raise SystemExit("no head_r*.json results found")
+    head = median_metrics(head_rounds)
+    base = median_metrics(base_rounds) if base_rounds else None
+
+    regressions = []
+    deltas = {}
+    if base:
+        for name, h in head.items():
+            b = base.get(name, {})
+            d = {
+                "p50_pct": pct(h["p50_ms"], b.get("p50_ms")),
+                "p99_pct": pct(h["p99_ms"], b.get("p99_ms")),
+                "tput_pct": pct(h["max_tput_rps"], b.get("max_tput_rps")),
+            }
+            deltas[name] = d
+            if d["p50_pct"] is not None and d["p50_pct"] > P50_UP_LIMIT * 100:
+                regressions.append(
+                    f"{name}: low-load p50 {b['p50_ms']}ms -> {h['p50_ms']}ms (+{d['p50_pct']}%)")
+            if d["p99_pct"] is not None and d["p99_pct"] > P99_UP_LIMIT * 100:
+                regressions.append(
+                    f"{name}: low-load p99 {b['p99_ms']}ms -> {h['p99_ms']}ms (+{d['p99_pct']}%)")
+            if d["tput_pct"] is not None and d["tput_pct"] < -TPUT_DOWN_LIMIT * 100:
+                regressions.append(
+                    f"{name}: max throughput {b['max_tput_rps']} -> {h['max_tput_rps']} rps"
+                    f" ({d['tput_pct']}%)")
+
+    record = {
+        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "head_sha": args.head_sha,
+        "base_sha": args.base_sha,
+        "head": head,
+        "base": base,
+        "delta_pct": deltas or None,
+        "regression": bool(regressions),
+        "regressions": regressions,
+        "calibration": head_rounds[0].get("calibration"),
+    }
+    Path(args.record).write_text(json.dumps(record) + "\n")
+
+    lines = ["## Nightly XDN performance", ""]
+    lines.append(f"head `{args.head_sha[:10]}`"
+                 + (f" vs base `{args.base_sha[:10]}` (interleaved A/B, same runner)"
+                    if base else " (bootstrap run, no baseline yet)"))
+    lines.append("")
+    lines.append("| service | metric | base | head | delta |")
+    lines.append("|---|---|---|---|---|")
+    for name, h in head.items():
+        b = base.get(name, {}) if base else {}
+        d = deltas.get(name, {})
+        lines.append(f"| {name} | low-load p50 | {fmt(b.get('p50_ms'), 'ms')} "
+                     f"| {fmt(h['p50_ms'], 'ms')} | {fmt(d.get('p50_pct'), '%')} |")
+        lines.append(f"| {name} | low-load p99 | {fmt(b.get('p99_ms'), 'ms')} "
+                     f"| {fmt(h['p99_ms'], 'ms')} | {fmt(d.get('p99_pct'), '%')} |")
+        lines.append(f"| {name} | max tput | {fmt(b.get('max_tput_rps'), ' rps')} "
+                     f"| {fmt(h['max_tput_rps'], ' rps')} | {fmt(d.get('tput_pct'), '%')} |")
+        for err in h["errors"]:
+            lines.append(f"| {name} | error | | `{err[:80]}` | |")
+    lines.append("")
+    if regressions:
+        lines.append("### REGRESSION detected")
+        lines.extend(f"- {r}" for r in regressions)
+    elif base:
+        lines.append("No regression beyond thresholds "
+                     f"(p50 +{int(P50_UP_LIMIT*100)}%, p99 +{int(P99_UP_LIMIT*100)}%, "
+                     f"tput -{int(TPUT_DOWN_LIMIT*100)}%).")
+    summary = "\n".join(lines) + "\n"
+    Path(args.summary).write_text(summary)
+    print(summary)
+
+    if args.github_output:
+        with open(args.github_output, "a") as fh:
+            fh.write(f"regression={'true' if regressions else 'false'}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/perf-dashboard/index.html
+++ b/eval/perf-dashboard/index.html
@@ -127,11 +127,11 @@ function flowBar(meta, flow) {
   const used = segments.reduce((a, s) => a + s[2], 0);
   if (total > used) segments.push(["frontend & respond (rest)", "none", total - used]);
   const cells = segments.map(([label, colorKey, ms]) =>
-    `<div title="${label}: ${ms.toFixed(2)} ms" style="flex:${Math.max(ms, total * 0.015)} 0 0;
+    `<div title="${label}: ${us(ms)} µs" style="flex:${Math.max(ms, total * 0.015)} 0 0;
        background:${STAGE_COLORS[colorKey]};height:16px;border-radius:3px"></div>`).join("");
   return `<div style="display:flex;gap:2px;max-width:640px;margin:.3rem 0 .5rem">${cells}</div>
     <div style="font-size:.78rem;color:var(--muted)">latest night's p50 proportions
-      (client total ${total} ms; hover segments)</div>`;
+      (client total ${us(total)} µs; hover segments)</div>`;
 }
 
 function lineChart(points, label, width = 300, height = 160) {
@@ -159,6 +159,8 @@ function lineChart(points, label, width = 300, height = 160) {
 }
 
 function fmt(v, digits = 1) { return v == null ? "n/a" : (+v).toFixed(digits); }
+// breakdown stages are sub-millisecond; show them in microseconds
+function us(vMs) { return vMs == null ? "n/a" : Math.round(vMs * 1000).toLocaleString(); }
 
 async function main() {
   const status = document.getElementById("status");
@@ -208,7 +210,7 @@ async function main() {
     const flowRecords = records.filter(r => r.head?.[svc]?.flow).slice(-6);
     if (flowRecords.length && meta.rows.length) {
       const latest = flowRecords[flowRecords.length - 1].head[svc].flow;
-      html += `<h3 style="font-size:.95rem;margin-top:1.2rem">request-flow latency breakdown (instrumented run, p50 per stage)</h3>`;
+      html += `<h3 style="font-size:.95rem;margin-top:1.2rem">request-flow latency breakdown (instrumented run, p50 per stage, µs)</h3>`;
       html += flowGuide(meta);
       html += flowBar(meta, latest);
       html += `<table><tr><th>stage</th>`;
@@ -217,7 +219,7 @@ async function main() {
       html += `</tr>`;
       for (const [label, colorKey, get, indent] of meta.rows) {
         html += `<tr><td style="padding-left:${0.6 + indent * 1.1}rem">${dot(colorKey)}${label}</td>`;
-        for (const r of flowRecords) html += `<td>${fmt(get(r.head[svc].flow))}</td>`;
+        for (const r of flowRecords) html += `<td>${us(get(r.head[svc].flow))}</td>`;
         html += `</tr>`;
       }
       html += `</table>`;

--- a/eval/perf-dashboard/index.html
+++ b/eval/perf-dashboard/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>XDN Nightly Performance</title>
+<style>
+  :root { --fg:#1a1a2e; --muted:#6b7280; --line:#e5e7eb; --accent:#2563eb; --bad:#dc2626; --ok:#059669; }
+  body { font:15px/1.55 -apple-system, "Segoe UI", Roboto, sans-serif; color:var(--fg);
+         max-width:1000px; margin:2rem auto; padding:0 1.25rem; background:#fff; }
+  h1 { font-size:1.5rem; } h2 { font-size:1.15rem; margin-top:2.2rem; }
+  .note { color:var(--muted); font-size:.9rem; max-width:46rem; }
+  .charts { display:flex; flex-wrap:wrap; gap:1.5rem; }
+  figure { margin:0; } figcaption { font-size:.85rem; color:var(--muted); text-align:center; }
+  svg { background:#fafafa; border:1px solid var(--line); border-radius:6px; }
+  table { border-collapse:collapse; margin-top:.75rem; font-size:.9rem; }
+  th, td { border:1px solid var(--line); padding:.3rem .6rem; text-align:right; }
+  th:first-child, td:first-child { text-align:left; }
+  .regress { color:var(--bad); font-weight:600; } .fine { color:var(--ok); }
+  #status { color:var(--muted); }
+</style>
+</head>
+<body>
+<h1>XDN Nightly Performance</h1>
+<p class="note">
+Nightly interleaved A/B measurement of XDN's low-load latency and max throughput
+(bookcatalog on Paxos, bookcatalog-nd on primary-backup), run on GitHub-hosted
+runners. The baseline and current HEAD are measured alternately on the <em>same</em>
+runner, so the head/base <strong>delta</strong> is the trustworthy signal; absolute
+values vary with runner hardware and are plotted only for context. Data:
+<a id="datalink" href="#">perf.json</a> on the <code>perf-results</code> branch.
+</p>
+<div id="status">Loading…</div>
+<div id="root"></div>
+<script>
+const DATA_URL = "https://raw.githubusercontent.com/fadhilkurnia/xdn/perf-results/perf.json";
+document.getElementById("datalink").href = DATA_URL;
+
+const METRICS = [
+  ["p50_ms", "low-load p50 (ms)"],
+  ["p99_ms", "low-load p99 (ms)"],
+  ["max_tput_rps", "max throughput (rps)"],
+];
+
+function lineChart(points, label, width = 300, height = 160) {
+  const pad = { l: 42, r: 8, t: 8, b: 22 };
+  const xs = points.map((_, i) => i);
+  const ys = points.map(p => p.v);
+  const ymax = Math.max(...ys) * 1.1 || 1, ymin = 0;
+  const px = i => pad.l + (width - pad.l - pad.r) * (xs.length > 1 ? i / (xs.length - 1) : 0.5);
+  const py = v => pad.t + (height - pad.t - pad.b) * (1 - (v - ymin) / (ymax - ymin));
+  let path = points.map((p, i) => `${i ? "L" : "M"}${px(i).toFixed(1)},${py(p.v).toFixed(1)}`).join(" ");
+  const dots = points.map((p, i) =>
+    `<circle cx="${px(i).toFixed(1)}" cy="${py(p.v).toFixed(1)}" r="3"
+       fill="${p.reg ? "var(--bad)" : "var(--accent)"}"><title>${p.date} — ${p.v}${p.reg ? " (regression flagged)" : ""}</title></circle>`).join("");
+  const gridY = [0.25, 0.5, 0.75, 1].map(f => {
+    const v = ymin + (ymax - ymin) * f, y = py(v).toFixed(1);
+    return `<line x1="${pad.l}" y1="${y}" x2="${width - pad.r}" y2="${y}" stroke="var(--line)"/>
+            <text x="${pad.l - 4}" y="${y}" font-size="9" fill="var(--muted)" text-anchor="end" dy="3">${v >= 100 ? v.toFixed(0) : v.toFixed(1)}</text>`;
+  }).join("");
+  const xlabels = points.length ? `
+    <text x="${pad.l}" y="${height - 6}" font-size="9" fill="var(--muted)">${points[0].date}</text>
+    <text x="${width - pad.r}" y="${height - 6}" font-size="9" fill="var(--muted)" text-anchor="end">${points[points.length - 1].date}</text>` : "";
+  return `<figure><svg width="${width}" height="${height}" role="img" aria-label="${label}">
+    ${gridY}<path d="${path}" fill="none" stroke="var(--accent)" stroke-width="1.5"/>${dots}${xlabels}
+  </svg><figcaption>${label}</figcaption></figure>`;
+}
+
+function fmt(v, digits = 1) { return v == null ? "n/a" : (+v).toFixed(digits); }
+
+async function main() {
+  const status = document.getElementById("status");
+  let records;
+  try {
+    const resp = await fetch(DATA_URL, { cache: "no-store" });
+    if (!resp.ok) throw new Error("HTTP " + resp.status);
+    records = await resp.json();
+  } catch (e) {
+    status.textContent = "No data yet (" + e.message + "). The perf-results branch is created by the first nightly run.";
+    return;
+  }
+  if (!records.length) { status.textContent = "No records yet."; return; }
+  status.remove();
+  const root = document.getElementById("root");
+  const services = [...new Set(records.flatMap(r => Object.keys(r.head || {})))];
+
+  for (const svc of services) {
+    const section = document.createElement("section");
+    let html = `<h2>${svc}</h2><div class="charts">`;
+    for (const [key, label] of METRICS) {
+      const pts = records
+        .filter(r => r.head?.[svc]?.[key] != null)
+        .map(r => ({ date: r.date, v: +r.head[svc][key], reg: r.regression }));
+      if (pts.length) html += lineChart(pts, label);
+    }
+    html += `</div>`;
+
+    const recent = records.slice(-10).reverse();
+    html += `<table><tr><th>date</th><th>head</th><th>p50 (ms)</th><th>Δp50</th>
+             <th>p99 (ms)</th><th>Δp99</th><th>tput (rps)</th><th>Δtput</th><th></th></tr>`;
+    for (const r of recent) {
+      const h = r.head?.[svc] || {}, d = r.delta_pct?.[svc] || {};
+      const dp = v => v == null ? "" : `<span class="${v > 0 ? "" : "fine"}">${v > 0 ? "+" : ""}${v}%</span>`;
+      html += `<tr><td>${r.date}</td><td><code>${(r.head_sha || "").slice(0, 8)}</code></td>
+        <td>${fmt(h.p50_ms)}</td><td>${dp(d.p50_pct)}</td>
+        <td>${fmt(h.p99_ms)}</td><td>${dp(d.p99_pct)}</td>
+        <td>${fmt(h.max_tput_rps, 0)}</td><td>${dp(d.tput_pct)}</td>
+        <td>${r.regression ? '<span class="regress">regression</span>' : ""}</td></tr>`;
+    }
+    html += `</table>`;
+    section.innerHTML = html;
+    root.appendChild(section);
+  }
+}
+main();
+</script>
+</body>
+</html>

--- a/eval/perf-dashboard/index.html
+++ b/eval/perf-dashboard/index.html
@@ -43,6 +43,97 @@ const METRICS = [
   ["max_tput_rps", "max throughput (rps)"],
 ];
 
+// Stage colors: validated categorical palette, assigned in flow order (fixed,
+// never cycled); schematic-only steps that carry no measurement are gray.
+const STAGE_COLORS = {
+  queue: "#2a78d6", exec: "#eb6834", capwait: "#1baf7a", capture: "#eda100",
+  prep: "#e87ba4", paxos: "#008300", callback: "#4a3aa7", none: "#9ca3af",
+};
+
+// Per-service presentation: display title, the request-flow steps (the
+// waterfall guide above the breakdown table), and the measured stage rows.
+// Row spec: [label, color key, accessor(flow), indent]
+const SERVICE_META = {
+  perfcatalog: {
+    title: "Paxos Active Replication",
+    subtitle: "client → AR HTTP frontend → Paxos coordination → execute → container → respond",
+    steps: [
+      ["HTTP frontend", "none"], ["Paxos coordination", "callback"],
+      ["execute", "exec"], ["container fwd", "exec"], ["respond", "none"],
+    ],
+    rows: [
+      ["client total (measured at client)", null, f => f.client_p50_ms, 0],
+      ["callback (coordination → execute → respond ready)", "callback", f => (f.stages_p50_ms || {}).callback, 0],
+      ["container round-trip", "exec", f => (f.stages_p50_ms || {}).container, 1],
+      ["proxy (forwarder client)", "exec", f => (f.stages_p50_ms || {}).proxy, 1],
+      ["request copy", "exec", f => (f.stages_p50_ms || {}).copyreq, 1],
+    ],
+    bar: f => [["callback", "callback", (f.stages_p50_ms || {}).callback]],
+  },
+  perfcatalognd: {
+    title: "Primary Backup Replication",
+    subtitle: "client → AR HTTP frontend → PBM queue → execute → container → statediff capture → Paxos commit → respond",
+    steps: [
+      ["HTTP frontend", "none"], ["PBM queue", "queue"], ["execute", "exec"],
+      ["container fwd", "exec"], ["capture wait", "capwait"],
+      ["statediff capture", "capture"], ["propose prep", "prep"],
+      ["Paxos commit", "paxos"], ["respond", "none"],
+    ],
+    rows: [
+      ["client total (measured at client)", null, f => f.client_p50_ms, 0],
+      ["callback (spans PBM queue → Paxos commit)", "callback", f => (f.stages_p50_ms || {}).callback, 0],
+      ["container round-trip", "exec", f => (f.stages_p50_ms || {}).container, 1],
+      ["proxy (forwarder client)", "exec", f => (f.stages_p50_ms || {}).proxy, 1],
+      ["request copy", "exec", f => (f.stages_p50_ms || {}).copyreq, 1],
+      ["PBM: queue wait", "queue", f => (f.pbm_p50_ms || {}).queue_wait, 0],
+      ["PBM: execute (incl. container fwd)", "exec", f => (f.pbm_p50_ms || {}).exec, 0],
+      ["PBM: capture wait", "capwait", f => (f.pbm_p50_ms || {}).capture_wait, 0],
+      ["PBM: statediff capture (fuselog)", "capture", f => (f.pbm_p50_ms || {}).capture, 0],
+      ["PBM: propose prep", "prep", f => (f.pbm_p50_ms || {}).propose_prep, 0],
+      ["PBM: Paxos commit", "paxos", f => (f.pbm_p50_ms || {}).paxos, 0],
+      ["PBM: pipeline total", null, f => (f.pbm_p50_ms || {}).total, 0],
+    ],
+    bar: f => {
+      const p = f.pbm_p50_ms || {};
+      return [["queue wait", "queue", p.queue_wait], ["execute", "exec", p.exec],
+              ["capture wait", "capwait", p.capture_wait], ["capture", "capture", p.capture],
+              ["propose prep", "prep", p.propose_prep], ["paxos", "paxos", p.paxos]];
+    },
+  },
+};
+
+function dot(colorKey) {
+  return colorKey
+    ? `<span style="display:inline-block;width:9px;height:9px;border-radius:2px;`
+      + `background:${STAGE_COLORS[colorKey]};margin-right:.4rem"></span>`
+    : `<span style="display:inline-block;width:9px;margin-right:.4rem"></span>`;
+}
+
+function flowGuide(meta) {
+  const chips = meta.steps.map(([label, colorKey]) =>
+    `<span style="display:inline-block;padding:.15rem .5rem;border-radius:4px;margin:.1rem 0;
+       background:${STAGE_COLORS[colorKey]}${colorKey === "none" ? "22" : "26"};
+       border:1.5px solid ${STAGE_COLORS[colorKey]};font-size:.8rem;white-space:nowrap">${label}</span>`
+  ).join(`<span style="color:var(--muted);margin:0 .15rem">→</span>`);
+  return `<div style="margin:.4rem 0 .2rem">${chips}</div>`;
+}
+
+function flowBar(meta, flow) {
+  // proportional stacked bar of the latest digest's measured stages; the
+  // unattributed remainder (frontend + response write) is gray.
+  const segments = meta.bar(flow).filter(s => s[2] != null && s[2] > 0);
+  const total = flow.client_p50_ms;
+  if (!segments.length || !total) return "";
+  const used = segments.reduce((a, s) => a + s[2], 0);
+  if (total > used) segments.push(["frontend & respond (rest)", "none", total - used]);
+  const cells = segments.map(([label, colorKey, ms]) =>
+    `<div title="${label}: ${ms.toFixed(2)} ms" style="flex:${Math.max(ms, total * 0.015)} 0 0;
+       background:${STAGE_COLORS[colorKey]};height:16px;border-radius:3px"></div>`).join("");
+  return `<div style="display:flex;gap:2px;max-width:640px;margin:.3rem 0 .5rem">${cells}</div>
+    <div style="font-size:.78rem;color:var(--muted)">latest night's p50 proportions
+      (client total ${total} ms; hover segments)</div>`;
+}
+
 function lineChart(points, label, width = 300, height = 160) {
   const pad = { l: 42, r: 8, t: 8, b: 22 };
   const xs = points.map((_, i) => i);
@@ -86,8 +177,10 @@ async function main() {
   const services = [...new Set(records.flatMap(r => Object.keys(r.head || {})))];
 
   for (const svc of services) {
+    const meta = SERVICE_META[svc] || { title: svc, steps: [], rows: [], bar: () => [] };
     const section = document.createElement("section");
-    let html = `<h2>${svc}</h2><div class="charts">`;
+    let html = `<h2>${meta.title} <code style="font-size:.75rem;color:var(--muted);font-weight:400">${svc}</code></h2>`;
+    html += `<div class="charts">`;
     for (const [key, label] of METRICS) {
       const pts = records
         .filter(r => r.head?.[svc]?.[key] != null)
@@ -110,15 +203,23 @@ async function main() {
     }
     html += `</table>`;
 
-    const latestFlow = [...records].reverse().find(r => r.head?.[svc]?.flow)?.head[svc].flow;
-    if (latestFlow) {
-      html += `<h3 style="font-size:.95rem;margin-top:1rem">latest request-flow breakdown (instrumented run, p50 per stage)</h3>`;
-      html += `<table><tr><th>stage</th><th>p50 (ms)</th></tr>`;
-      html += `<tr><td>client total</td><td>${fmt(latestFlow.client_p50_ms)}</td></tr>`;
-      for (const [k, v] of Object.entries(latestFlow.stages_p50_ms || {}))
-        html += `<tr><td>${k}</td><td>${fmt(v)}</td></tr>`;
-      for (const [k, v] of Object.entries(latestFlow.pbm_p50_ms || {}))
-        html += `<tr><td>pbm: ${k}</td><td>${fmt(v)}</td></tr>`;
+    // Request-flow breakdown: waterfall guide of the protocol's steps, the
+    // latest night's proportional bar, then one column per measured digest.
+    const flowRecords = records.filter(r => r.head?.[svc]?.flow).slice(-6);
+    if (flowRecords.length && meta.rows.length) {
+      const latest = flowRecords[flowRecords.length - 1].head[svc].flow;
+      html += `<h3 style="font-size:.95rem;margin-top:1.2rem">request-flow latency breakdown (instrumented run, p50 per stage)</h3>`;
+      html += flowGuide(meta);
+      html += flowBar(meta, latest);
+      html += `<table><tr><th>stage</th>`;
+      for (const r of flowRecords)
+        html += `<th>${r.date}<br><code style="font-weight:400">${(r.head_sha || "").slice(0, 7)}</code></th>`;
+      html += `</tr>`;
+      for (const [label, colorKey, get, indent] of meta.rows) {
+        html += `<tr><td style="padding-left:${0.6 + indent * 1.1}rem">${dot(colorKey)}${label}</td>`;
+        for (const r of flowRecords) html += `<td>${fmt(get(r.head[svc].flow))}</td>`;
+        html += `</tr>`;
+      }
       html += `</table>`;
     }
     section.innerHTML = html;

--- a/eval/perf-dashboard/index.html
+++ b/eval/perf-dashboard/index.html
@@ -23,9 +23,10 @@
 <body>
 <h1>XDN Nightly Performance</h1>
 <p class="note">
-Nightly interleaved A/B measurement of XDN's low-load latency and max throughput
-(bookcatalog on Paxos, bookcatalog-nd on primary-backup), run on GitHub-hosted
-runners. The baseline and current HEAD are measured alternately on the <em>same</em>
+Nightly interleaved A/B measurement of XDN's low-load latency (sequential
+closed loop, one outstanding request) and max throughput (open-loop rate
+ladder) for bookcatalog on Paxos and bookcatalog-nd on primary-backup with the
+fuselog statediff recorder on /dev/shm, run on GitHub-hosted runners. The baseline and current HEAD are measured alternately on the <em>same</em>
 runner, so the head/base <strong>delta</strong> is the trustworthy signal; absolute
 values vary with runner hardware and are plotted only for context. Data:
 <a id="datalink" href="#">perf.json</a> on the <code>perf-results</code> branch.
@@ -108,6 +109,18 @@ async function main() {
         <td>${r.regression ? '<span class="regress">regression</span>' : ""}</td></tr>`;
     }
     html += `</table>`;
+
+    const latestFlow = [...records].reverse().find(r => r.head?.[svc]?.flow)?.head[svc].flow;
+    if (latestFlow) {
+      html += `<h3 style="font-size:.95rem;margin-top:1rem">latest request-flow breakdown (instrumented run, p50 per stage)</h3>`;
+      html += `<table><tr><th>stage</th><th>p50 (ms)</th></tr>`;
+      html += `<tr><td>client total</td><td>${fmt(latestFlow.client_p50_ms)}</td></tr>`;
+      for (const [k, v] of Object.entries(latestFlow.stages_p50_ms || {}))
+        html += `<tr><td>${k}</td><td>${fmt(v)}</td></tr>`;
+      for (const [k, v] of Object.entries(latestFlow.pbm_p50_ms || {}))
+        html += `<tr><td>pbm: ${k}</td><td>${fmt(v)}</td></tr>`;
+      html += `</table>`;
+    }
     section.innerHTML = html;
     root.appendChild(section);
   }

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
@@ -629,9 +629,10 @@ public class HttpActiveReplica {
                 } else {
                     if (edu.umass.cs.xdn.XdnGigapaxosApp.TIMING_HEADERS_ENABLED
                             && httpResponse != null) {
-                        long callbackElapsedMs = (System.nanoTime() - rctx.startExecTimeNs()) / 1_000_000;
+                        double callbackElapsedMs =
+                                (System.nanoTime() - rctx.startExecTimeNs()) / 1_000_000.0;
                         httpResponse.headers().set("X-XDN-Pipeline",
-                                String.format("callback=%dms", callbackElapsedMs));
+                                String.format("callback=%.3fms", callbackElapsedMs));
                     }
                     httpRequest.maybeAddXdnCookieToResponse(httpResponse);
                     HttpActiveReplicaHandler.writeHttpResponse(

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -74,3 +74,5 @@ nav:
       - 'GigaPaxos — log compaction': 'reference/paxos-compaction.md'
       - 'WordPress primary-backup investigation': 'reference/wordpress-pb-investigation.md'
   - Dashboard: 'dashboard.md'
+  # Bundled by bin/build_site.sh from eval/perf-dashboard/ (nightly-perf data).
+  - Performance: 'https://xdn.cs.umass.edu/perf/'


### PR DESCRIPTION
## What

A nightly GitHub Actions workflow that measures XDN's **low-load latency** and **max throughput** and flags regressions — running entirely on GitHub-hosted runners.

## Design

**Interleaved A/B, not absolute trends.** Hosted runners are shared and noisy, so absolute numbers are not comparable night-to-night. Each run measures the **baseline commit** (last recorded run, from the `perf-results` branch) and **HEAD** alternately on the *same* runner in the same job, and judges only the relative deltas: low-load p50 +15%, p99 +25%, max-tput −15%. Absolute values are recorded for the trend page but never gate anything.

**What is measured** (per side, 3 interleaved rounds): `bookcatalog` (deterministic → Paxos) and `bookcatalog-nd` (→ primary-backup, rsync recorder) on a generated 1-RC + 3-AR loopback cluster (generated so baseline commits need no new checked-in config; 3 ARs exactly so every service lands on all frontends):
- **Low-load latency**: open-loop Poisson at 25 rps via `eval/get_latency_at_rate.go`, p50/p95/p99, median across rounds.
- **Max throughput**: geometric rate ladder to the saturation knee (achieved ≥93% of offered AND avg latency ≤ max(100ms, 3× the service's own unloaded avg) — the relative SLO is what lets PB's slower pipeline get a knee too). Ladder rounds seed each other through a hint file; a ladder that never observes a failing rung records *no* max-tput (it capped out, it didn't saturate); the comparator takes the max across rounds since ladder noise is one-sided.

**Change gating**: skips when HEAD is already measured or nothing under `src/`, `lib/`, `bin/gpServer.sh`, `xdn-cli/` changed since the last measured commit. `workflow_dispatch` always runs (optional `base_sha` input).

**Results & dashboard**: one JSON line per night on the `perf-results` branch (`perf.jsonl` + regenerated `perf.json`); raw per-round JSONs as artifacts. A static trend page is bundled at **https://xdn.cs.umass.edu/perf/** by `build_site.sh` — it fetches `perf.json` from the branch at view time, so nightly data updates need no site rebuild. On regression: an issue is filed with the summary table and the job fails.

**Self-test**: a PR touching the perf scripts (like this one) runs the full measurement as `pull_request` (comparing PR head vs base) without recording — check this PR's *Nightly performance* check for a live sample summary.
