### PR TITLE
Performance tab: embed the perf page in the site template at /performance

### DIFF
--- a/bin/build_site.sh
+++ b/bin/build_site.sh
@@ -20,11 +20,20 @@ echo "staged $(ls "$REF" | wc -l | tr -d ' ') reference docs"
 MKDOCS="${MKDOCS:-mkdocs}"
 ( cd "$ROOT/website" && "$MKDOCS" build --site-dir "$ROOT/site" )
 
-# 3. Bundle the nightly-perf trend page at /perf/. The page is static; its data
-# is fetched at view time from the perf-results branch (raw.githubusercontent),
-# so nightly data updates need no site rebuild.
-mkdir -p "$ROOT/site/perf"
-cp "$ROOT/eval/perf-dashboard/index.html" "$ROOT/site/perf/index.html"
-echo "bundled perf dashboard -> site/perf/"
+# 3. Bundle the nightly-perf trend page at /performance/app/, embedded by the
+# Performance tab (website/docs/performance.md) the same way the dashboard SPA
+# is. The page is static; its data is fetched at view time from the
+# perf-results branch (raw.githubusercontent), so nightly data updates need no
+# site rebuild. /perf/ redirects to the tab for links minted before the move.
+mkdir -p "$ROOT/site/performance/app" "$ROOT/site/perf"
+cp "$ROOT/eval/perf-dashboard/index.html" "$ROOT/site/performance/app/index.html"
+cat > "$ROOT/site/perf/index.html" <<'REDIR'
+<!DOCTYPE html><html><head><meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/performance/">
+<link rel="canonical" href="https://xdn.cs.umass.edu/performance/">
+<title>Moved</title></head>
+<body>Moved to <a href="/performance/">/performance/</a>.</body></html>
+REDIR
+echo "bundled perf dashboard -> site/performance/app/ (redirect at /perf/)"
 
 echo "built site -> $ROOT/site  (open: python3 -m http.server -d site)"

--- a/website/docs/performance.md
+++ b/website/docs/performance.md
@@ -1,0 +1,29 @@
+---
+title: Performance
+hide:
+  - navigation
+  - toc
+---
+
+# Performance
+
+Nightly performance measurements of XDN: low-load latency and max throughput
+for Paxos active replication and primary-backup replication, with a per-stage
+latency breakdown of the request flow. Measured by the
+[nightly-perf workflow](https://github.com/fadhilkurnia/xdn/actions/workflows/nightly-perf.yml)
+as an interleaved A/B of each night's HEAD against the last measured commit.
+
+<style>
+  /* Embed the perf trend page full-width under the site's header/footer/tabs,
+     same treatment as the dashboard SPA. */
+  .xdn-perf-frame {
+    width: 100%;
+    height: calc(100vh - 11rem);
+    min-height: 720px;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 6px;
+  }
+</style>
+
+<iframe class="xdn-perf-frame" src="app/" title="XDN nightly performance"
+        loading="lazy" referrerpolicy="no-referrer"></iframe>

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -74,5 +74,5 @@ nav:
       - 'GigaPaxos — log compaction': 'reference/paxos-compaction.md'
       - 'WordPress primary-backup investigation': 'reference/wordpress-pb-investigation.md'
   - Dashboard: 'dashboard.md'
-  # Bundled by bin/build_site.sh from eval/perf-dashboard/ (nightly-perf data).
-  - Performance: 'https://xdn.cs.umass.edu/perf/'
+  # Embeds eval/perf-dashboard/, bundled at /performance/app/ by bin/build_site.sh.
+  - Performance: 'performance.md'


### PR DESCRIPTION
Gives the **Performance** tab the same treatment as the Dashboard tab: instead of a bare external link to a standalone page, it is now a MkDocs page — so it carries the site's normal header, tab bar, and styling — that embeds the nightly-perf trend page in a full-width iframe (the exact pattern `dashboard.md` uses for the dashboard SPA).

- `website/docs/performance.md` — the tab page (`hide: navigation/toc`, iframe to `app/`)
- `bin/build_site.sh` — bundles `eval/perf-dashboard/index.html` at **/performance/app/** (was /perf/); leaves a meta-refresh redirect at **/perf/** → /performance/ for links minted before the move
- `website/mkdocs.yml` — nav entry becomes `performance.md` instead of the absolute URL

Verified with a local `build_site.sh` run: /performance/ renders in the site template, the app bundles beside it, the redirect stub is in place, and the homepage tab links to `performance/`. Deploys automatically via `site.yml` on merge (all three files are in its trigger paths).