### PR TITLE
Bandwidth profiling for cluster-mode services

### DIFF
--- a/.github/workflows/ant-build-test.yml
+++ b/.github/workflows/ant-build-test.yml
@@ -82,6 +82,7 @@ jobs:
         bin/run_xdn_tests.sh XdnHttpRequestBatchTest
         bin/run_xdn_tests.sh XdnGeoDemandProfilerTest
         bin/run_xdn_tests.sh XdnPortAllocatorTest
+        bin/run_xdn_tests.sh XdnBwProbeParserTest
 
     - name: 📝 Reporting the test results ...
       uses: dorny/test-reporter@v2
@@ -132,6 +133,7 @@ jobs:
           - XdnSetCoordinatorNodeTest
           - XdnTaggedImageLaunchTest
           - XdnClusterLaunchTest
+          - XdnClusterBandwidthTest
           - XdnWordPressClusterTest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,19 @@ are treated as success.
 replication, so XDN-side state-tar capture is a no-op and FUSE/rsync are
 skipped.
 
+**Bandwidth profiling** (`XdnBandwidthProfiler`, on by default via
+`XDN_CLUSTER_BW_TRACER_ENABLED`): each cluster member gets a tiny probe
+sidecar (`services/bw-probe/`, image `fadhilkurnia/xdn-bw-probe`) in its
+network namespace; the AR polls kernel TCP byte counters through it
+(`docker exec <probe> ss -tinH`) and folds per-connection deltas into
+directed per-peer edges, classified by peer address alone: overlay-alias IPs
+(resolved via embedded DNS `getent hosts replica-N`) are coordination
+traffic, loopback is intra-pod and skipped, everything else aggregates as
+`client`. Snapshots ride the replica-info endpoint as a `bandwidth` JSON
+section. All failures degrade gracefully (missing probe image just logs a
+warning and disables profiling). Tests: `XdnBwProbeParserTest` (unit),
+`XdnClusterBandwidthTest` (integration).
+
 **Reference images** under `services/`:
 - `services/etcd-cluster/` — single-image cluster (etcd), entrypoint maps
   `XDN_CLUSTER_*` → etcd's `--initial-cluster`, `--initial-cluster-state`, etc.

--- a/services/bw-probe/Dockerfile
+++ b/services/bw-probe/Dockerfile
@@ -1,0 +1,17 @@
+# Bandwidth probe sidecar for XDN cluster-mode services.
+#
+# XDN attaches this container to a cluster member's network namespace
+# (--network=container:<member>) and reads per-connection TCP byte counters
+# with `docker exec <probe> ss -tainH`, plus overlay peer addresses with
+# `docker exec <probe> getent hosts replica-0 ...`. The container itself just
+# sleeps; iproute2 provides `ss` with tcp_info support (busybox's does not).
+#
+# Build (tests build this locally as xdn-bw-probe:test):
+#   docker build -t xdn-bw-probe:test services/bw-probe/
+#
+# Publish (multi-arch, required — CI runners are amd64, dev machines arm64):
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     -t fadhilkurnia/xdn-bw-probe:latest --push services/bw-probe/
+FROM alpine:3.20
+RUN apk add --no-cache iproute2-ss
+ENTRYPOINT ["sleep", "infinity"]

--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -610,6 +610,27 @@ public class ReconfigurationConfig {
         XDN_EVENTUAL_CHECKPOINT_INLINE_MAX_BYTES(8_000_000L),
 
         /**
+         * Enables per-replica bandwidth profiling for cluster-mode services: a tiny probe
+         * sidecar joins each cluster member's network namespace and the ActiveReplica
+         * periodically reads kernel TCP byte counters through it, building directed
+         * per-peer traffic edges exposed via the replica-info endpoint.
+         * TODO: this should be specific to XDN, and not Gigapaxos config.
+         */
+        XDN_CLUSTER_BW_TRACER_ENABLED(true),
+
+        /**
+         * Container image for the bandwidth probe sidecar (see services/bw-probe/).
+         * TODO: this should be specific to XDN, and not Gigapaxos config.
+         */
+        XDN_CLUSTER_BW_PROBE_IMAGE("fadhilkurnia/xdn-bw-probe"),
+
+        /**
+         * Poll period (ms) for reading TCP byte counters through the bandwidth probe.
+         * TODO: this should be specific to XDN, and not Gigapaxos config.
+         */
+        XDN_CLUSTER_BW_POLL_INTERVAL_MS(1000L),
+
+        /**
          * A flag to enable/disable batching in HttpActiveReplica.
          */
         HTTP_AR_FRONTEND_BATCH_ENABLED(false),

--- a/src/edu/umass/cs/xdn/XdnBandwidthProfiler.java
+++ b/src/edu/umass/cs/xdn/XdnBandwidthProfiler.java
@@ -1,0 +1,392 @@
+package edu.umass.cs.xdn;
+
+import edu.umass.cs.reconfiguration.ReconfigurationConfig;
+import edu.umass.cs.utils.Config;
+import edu.umass.cs.xdn.utils.Shell;
+import edu.umass.cs.xdn.utils.ShellOutput;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Per-node bandwidth profiler for cluster-mode services.
+ *
+ * <p>Each registered service has a tiny probe sidecar sharing its cluster member's network
+ * namespace. The profiler periodically reads every TCP socket's kernel byte counters through the
+ * probe ({@code docker exec <probe> ss -tainH}; {@code bytes_acked}/{@code bytes_received} from
+ * tcp_info are exact cumulative totals, so polling loses nothing on long-lived connections) and
+ * folds per-connection deltas into directed per-peer edges.
+ *
+ * <p>Edges are classified by peer address and port: an address that Docker's embedded DNS reports
+ * for a {@code replica-N} overlay alias is coordination traffic to that replica; loopback rows on
+ * the entry port's server side are published-port client connections (Docker's userland proxy
+ * injects them into the namespace over loopback); all other loopback is intra-pod chatter and is
+ * skipped; anything else (bridge gateway, host) is aggregated as {@code client} traffic. This
+ * yields the coordinated vs. client-demand split without any protocol knowledge.
+ *
+ * <p>All failures degrade gracefully: a missing probe or failed exec skips the poll and never
+ * affects the service itself.
+ */
+public class XdnBandwidthProfiler {
+
+  /** Aggregate edge label for non-peer, non-loopback traffic. */
+  public static final String CLIENT_EDGE = "client";
+
+  private static final long IP_MAP_REFRESH_MS = 30_000;
+
+  private final Logger logger = Logger.getLogger(XdnBandwidthProfiler.class.getName());
+  private final String myNodeId;
+  private final Map<String, ServiceState> services = new ConcurrentHashMap<>();
+  private ScheduledExecutorService scheduler; // created lazily on first register
+
+  public XdnBandwidthProfiler(String myNodeId) {
+    this.myNodeId = myNodeId;
+  }
+
+  /** One directed edge from this replica to a peer (or the client aggregate). */
+  static final class Edge {
+    volatile long txBytes;
+    volatile long rxBytes;
+    volatile double txRateBps;
+    volatile double rxRateBps;
+  }
+
+  /** Parsed row of {@code ss -tinH}: one established connection with cumulative counters. */
+  record SsConn(String localAddr, int localPort, String peerAddr, int peerPort, long tx, long rx) {
+    String tupleKey() {
+      return localAddr + ":" + localPort + ">" + peerAddr + ":" + peerPort;
+    }
+  }
+
+  private static final class ConnCounters {
+    long tx;
+    long rx;
+  }
+
+  private static final class ServiceState {
+    final String probeContainerName;
+    final int clusterSize;
+    final int entryPort;
+    volatile Map<String, String> ipToReplica = Map.of();
+    long ipMapRefreshedMs;
+    final Map<String, ConnCounters> connState = new HashMap<>(); // poll-thread only
+    final Map<String, Edge> edges = new ConcurrentHashMap<>();
+    long lastPollMs;
+    int emptyPolls;
+    long lastProbeRestartMs;
+
+    ServiceState(String probeContainerName, int clusterSize, int entryPort) {
+      this.probeContainerName = probeContainerName;
+      this.clusterSize = clusterSize;
+      this.entryPort = entryPort;
+    }
+  }
+
+  /** Starts profiling {@code serviceName} through the given probe container. */
+  public synchronized void register(
+      String serviceName, String probeContainerName, int clusterSize, int entryPort) {
+    this.services.put(serviceName, new ServiceState(probeContainerName, clusterSize, entryPort));
+    if (this.scheduler == null) {
+      long intervalMs =
+          Config.getGlobalLong(ReconfigurationConfig.RC.XDN_CLUSTER_BW_POLL_INTERVAL_MS);
+      this.scheduler =
+          Executors.newSingleThreadScheduledExecutor(
+              r -> {
+                Thread t = new Thread(r, "xdn-bw-profiler-" + myNodeId);
+                t.setDaemon(true);
+                return t;
+              });
+      this.scheduler.scheduleWithFixedDelay(
+          this::pollAll, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    }
+    logger.log(
+        Level.INFO,
+        "{0}:{1} bandwidth profiling started for {2} via probe {3}",
+        new Object[] {
+          myNodeId.toUpperCase(), this.getClass().getSimpleName(), serviceName, probeContainerName
+        });
+  }
+
+  public void deregister(String serviceName) {
+    this.services.remove(serviceName);
+  }
+
+  /**
+   * Returns the current edge snapshot for {@code serviceName} as JSON, or null if the service is
+   * not profiled (tracer disabled, probe failed, or not a cluster service).
+   */
+  public JSONObject snapshot(String serviceName) {
+    ServiceState st = this.services.get(serviceName);
+    if (st == null) {
+      return null;
+    }
+    try {
+      JSONArray edges = new JSONArray();
+      for (Map.Entry<String, Edge> e : st.edges.entrySet()) {
+        Edge edge = e.getValue();
+        JSONObject o = new JSONObject();
+        o.put("peer", e.getKey());
+        o.put("txBytes", edge.txBytes);
+        o.put("rxBytes", edge.rxBytes);
+        o.put("txRateBps", Math.round(edge.txRateBps));
+        o.put("rxRateBps", Math.round(edge.rxRateBps));
+        edges.put(o);
+      }
+      JSONObject result = new JSONObject();
+      result.put("edges", edges);
+      result.put("sampledAt", st.lastPollMs);
+      return result;
+    } catch (JSONException e) {
+      logger.log(Level.WARNING, "failed to serialize bandwidth snapshot: " + e);
+      return null;
+    }
+  }
+
+  private void pollAll() {
+    for (Map.Entry<String, ServiceState> entry : this.services.entrySet()) {
+      try {
+        pollService(entry.getKey(), entry.getValue());
+      } catch (Exception e) {
+        logger.log(
+            Level.FINE, "bandwidth poll failed for " + entry.getKey() + ": " + e.getMessage());
+      }
+    }
+  }
+
+  private void pollService(String serviceName, ServiceState st) {
+    long now = System.currentTimeMillis();
+    if (now - st.ipMapRefreshedMs > IP_MAP_REFRESH_MS) {
+      refreshIpMap(st);
+      st.ipMapRefreshedMs = now;
+    }
+
+    ShellOutput out =
+        Shell.runCommandWithOutput("docker exec " + st.probeContainerName + " ss -tainH", true);
+    if (out.exitCode != 0) {
+      logger.log(
+          Level.FINE,
+          "ss probe failed for " + serviceName + " (exit " + out.exitCode + "): " + out.stderr);
+      return;
+    }
+
+    List<SsConn> conns = parseSsOutput(out.stdout);
+    // A namespace with no sockets AT ALL (ss -a shows not even listeners) is almost
+    // certainly abandoned: the member container restarted (readiness heal, crash loop
+    // during first boot) and got a fresh sandbox while the probe kept the old one.
+    // Restarting the probe rejoins the member's current namespace. A quiet-but-live pod
+    // still shows its LISTEN sockets and must not trigger this.
+    if (out.stdout.isBlank()) {
+      st.emptyPolls++;
+      if (st.emptyPolls >= 3 && now - st.lastProbeRestartMs > 60_000) {
+        logger.log(
+            Level.INFO,
+            "{0}:{1} probe {2} sees no sockets; restarting it to rebind the namespace",
+            new Object[] {
+              myNodeId.toUpperCase(), this.getClass().getSimpleName(), st.probeContainerName
+            });
+        Shell.runCommand("docker restart " + st.probeContainerName, true);
+        st.lastProbeRestartMs = now;
+        st.emptyPolls = 0;
+      }
+      st.lastPollMs = now;
+      return;
+    }
+    st.emptyPolls = 0;
+
+    long intervalMs = st.lastPollMs > 0 ? Math.max(1, now - st.lastPollMs) : 0;
+    Map<String, long[]> deltaByPeer = new HashMap<>(); // label -> {txDelta, rxDelta}
+    for (SsConn conn : conns) {
+      String label =
+          classifyPeer(
+              conn.peerAddr(), conn.localPort(), conn.peerPort(), st.entryPort, st.ipToReplica);
+      if (label == null) {
+        continue; // intra-pod traffic
+      }
+      ConnCounters prev = st.connState.get(conn.tupleKey());
+      long txDelta;
+      long rxDelta;
+      if (prev == null || conn.tx() < prev.tx || conn.rx() < prev.rx) {
+        // New connection (or 4-tuple reuse after a counter reset): attribute its full
+        // cumulative counters, which accrued since the previous poll or tracer start.
+        txDelta = conn.tx();
+        rxDelta = conn.rx();
+        prev = new ConnCounters();
+        st.connState.put(conn.tupleKey(), prev);
+      } else {
+        txDelta = conn.tx() - prev.tx;
+        rxDelta = conn.rx() - prev.rx;
+      }
+      prev.tx = conn.tx();
+      prev.rx = conn.rx();
+      deltaByPeer.computeIfAbsent(label, k -> new long[2]);
+      deltaByPeer.get(label)[0] += txDelta;
+      deltaByPeer.get(label)[1] += rxDelta;
+    }
+
+    for (Map.Entry<String, long[]> d : deltaByPeer.entrySet()) {
+      Edge edge = st.edges.computeIfAbsent(d.getKey(), k -> new Edge());
+      edge.txBytes += d.getValue()[0];
+      edge.rxBytes += d.getValue()[1];
+      if (intervalMs > 0) {
+        edge.txRateBps = d.getValue()[0] * 1000.0 / intervalMs;
+        edge.rxRateBps = d.getValue()[1] * 1000.0 / intervalMs;
+      }
+    }
+    // An edge with no connections this poll has zero current rate.
+    for (Map.Entry<String, Edge> e : st.edges.entrySet()) {
+      if (!deltaByPeer.containsKey(e.getKey())) {
+        e.getValue().txRateBps = 0;
+        e.getValue().rxRateBps = 0;
+      }
+    }
+    st.lastPollMs = now;
+  }
+
+  private void refreshIpMap(ServiceState st) {
+    StringBuilder names = new StringBuilder();
+    for (int i = 0; i < st.clusterSize; i++) {
+      names.append(" replica-").append(i);
+    }
+    // busybox getent exits nonzero if any name is unresolved; parse whatever resolved.
+    ShellOutput out =
+        Shell.runCommandWithOutput(
+            "docker exec " + st.probeContainerName + " getent hosts" + names, true);
+    Map<String, String> map = parseGetentOutput(out.stdout);
+    if (!map.isEmpty()) {
+      st.ipToReplica = map;
+    }
+  }
+
+  /**
+   * Returns the edge label for a connection: the replica name for overlay peers, {@link
+   * #CLIENT_EDGE} for external addresses, or null for traffic that must not be counted.
+   *
+   * <p>Loopback needs port awareness: Docker's userland proxy delivers published-port client
+   * connections <em>into</em> the namespace over loopback (dockerd 29+), so a loopback row whose
+   * local port is the service's entry port is real client traffic. Its mirror row (the proxy's
+   * injected socket, peer port == entry port) and every other loopback flow (sidecar-to-member
+   * chatter) are intra-pod and skipped.
+   */
+  static String classifyPeer(
+      String peerAddr,
+      int localPort,
+      int peerPort,
+      int entryPort,
+      Map<String, String> ipToReplica) {
+    boolean loopback = peerAddr.startsWith("127.") || peerAddr.equals("::1");
+    if (loopback) {
+      return entryPort > 0 && localPort == entryPort ? CLIENT_EDGE : null;
+    }
+    String replica = ipToReplica.get(peerAddr);
+    return replica != null ? replica : CLIENT_EDGE;
+  }
+
+  /**
+   * Parses {@code ss -tinH} output: each connection is a state row ({@code ESTAB 0 0 local peer})
+   * followed by an indented tcp_info line carrying {@code bytes_acked}/{@code bytes_received}. Rows
+   * without counters (no payload yet) are kept with zeros; non-TCP noise is skipped.
+   */
+  static List<SsConn> parseSsOutput(String output) {
+    List<SsConn> conns = new ArrayList<>();
+    String pendingLocal = null;
+    String pendingPeer = null;
+    for (String line : output.split("\n")) {
+      if (line.isBlank()) {
+        continue;
+      }
+      boolean isInfoLine = Character.isWhitespace(line.charAt(0));
+      if (!isInfoLine) {
+        String[] tokens = line.trim().split("\\s+");
+        // STATE RECV-Q SEND-Q LOCAL:PORT PEER:PORT
+        if (tokens.length >= 5 && tokens[3].contains(":") && tokens[4].contains(":")) {
+          pendingLocal = tokens[3];
+          pendingPeer = tokens[4];
+        } else {
+          pendingLocal = null;
+          pendingPeer = null;
+        }
+        continue;
+      }
+      if (pendingLocal == null) {
+        continue;
+      }
+      long tx = extractCounter(line, "bytes_acked:");
+      long rx = extractCounter(line, "bytes_received:");
+      // bytes_acked counts the SYN's sequence space; subtract it for pure payload.
+      if (tx > 0) {
+        tx -= 1;
+      }
+      String[] local = splitAddrPort(pendingLocal);
+      String[] peer = splitAddrPort(pendingPeer);
+      if (local != null && peer != null) {
+        conns.add(
+            new SsConn(
+                local[0], Integer.parseInt(local[1]), peer[0], Integer.parseInt(peer[1]), tx, rx));
+      }
+      pendingLocal = null;
+      pendingPeer = null;
+    }
+    return conns;
+  }
+
+  /** Parses {@code getent hosts name...} output ({@code IP name [name...]}) into IP to name. */
+  static Map<String, String> parseGetentOutput(String output) {
+    Map<String, String> map = new HashMap<>();
+    for (String line : output.split("\n")) {
+      String[] tokens = line.trim().split("\\s+");
+      if (tokens.length >= 2 && !tokens[0].isEmpty()) {
+        map.put(normalizeAddr(tokens[0]), tokens[1]);
+      }
+    }
+    return map;
+  }
+
+  /** Splits {@code addr:port} (or {@code [v6addr]:port}) into normalized address and port. */
+  static String[] splitAddrPort(String addrPort) {
+    int idx = addrPort.lastIndexOf(':');
+    if (idx <= 0) {
+      return null;
+    }
+    String addr = normalizeAddr(addrPort.substring(0, idx));
+    String port = addrPort.substring(idx + 1);
+    if (!port.chars().allMatch(Character::isDigit) || port.isEmpty()) {
+      return null;
+    }
+    return new String[] {addr, port};
+  }
+
+  /** Strips brackets and the IPv4-mapped-IPv6 prefix: {@code [::ffff:10.0.3.4]} to 10.0.3.4. */
+  static String normalizeAddr(String addr) {
+    String a = addr;
+    if (a.startsWith("[") && a.endsWith("]")) {
+      a = a.substring(1, a.length() - 1);
+    }
+    if (a.startsWith("::ffff:")) {
+      a = a.substring("::ffff:".length());
+    }
+    return a;
+  }
+
+  private static long extractCounter(String infoLine, String key) {
+    int idx = infoLine.indexOf(key);
+    if (idx < 0) {
+      return 0;
+    }
+    int start = idx + key.length();
+    int end = start;
+    while (end < infoLine.length() && Character.isDigit(infoLine.charAt(end))) {
+      end++;
+    }
+    return end > start ? Long.parseLong(infoLine.substring(start, end)) : 0;
+  }
+}

--- a/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
+++ b/src/edu/umass/cs/xdn/XdnGigapaxosApp.java
@@ -78,6 +78,7 @@ public class XdnGigapaxosApp
 
   private final String myNodeId;
   private final Set<IntegerPacketType> packetTypes;
+  private final XdnBandwidthProfiler bandwidthProfiler;
 
   // TODO: remove this metadata as the port is already stored inside the ServiceInstance.
   private final HashMap<String, Integer> activeServicePorts;
@@ -156,6 +157,7 @@ public class XdnGigapaxosApp
         "{0}:{1} Initializing with args: {2}",
         new Object[] {myNodeId, XdnGigapaxosApp.class.getSimpleName(), Arrays.toString(args)});
 
+    this.bandwidthProfiler = new XdnBandwidthProfiler(this.myNodeId);
     this.serviceInstances = new ConcurrentHashMap<>();
     this.servicePlacementEpoch = new ConcurrentHashMap<>();
     this.activeServicePorts = new HashMap<>();
@@ -1264,6 +1266,28 @@ public class XdnGigapaxosApp
       }
     }
 
+    // Attach the bandwidth probe sidecar and start profiling this member's traffic. Any
+    // failure here only disables profiling; the service itself is unaffected.
+    if (Config.getGlobalBoolean(ReconfigurationConfig.RC.XDN_CLUSTER_BW_TRACER_ENABLED)) {
+      String probeImage =
+          Config.getGlobalString(ReconfigurationConfig.RC.XDN_CLUSTER_BW_PROBE_IMAGE);
+      String probeName = "bwprobe." + clusterContainerName;
+      if (startClusterSidecar(probeImage, probeName, clusterContainerName, null)) {
+        this.bandwidthProfiler.register(
+            serviceName,
+            probeName,
+            topology.clusterSize(),
+            publishedContainerPort != null ? publishedContainerPort : 0);
+      } else {
+        logger.log(
+            Level.WARNING,
+            "{0}:{1} bandwidth probe failed to start; profiling disabled for {2}",
+            new Object[] {
+              this.myNodeId.toUpperCase(), this.getClass().getSimpleName(), serviceName
+            });
+      }
+    }
+
     // Hold off marking the service live until the entry port answers HTTP. Without this, a
     // request can reach XdnHttpForwarderClient before the container binds its port; on Linux
     // that fails fast (RST) and the client retries, but Docker Desktop's port forwarder
@@ -1630,6 +1654,12 @@ public class XdnGigapaxosApp
         assert exitCode == 0 : "failed to remove compose directory " + composeDir;
       }
     } else {
+      if (serviceInstance.property.isClusterManaged()) {
+        this.bandwidthProfiler.deregister(serviceName);
+        for (String containerName : toBeRemovedContainerNames) {
+          Shell.runCommand("docker container rm --force bwprobe." + containerName, true);
+        }
+      }
       for (String containerName : toBeRemovedContainerNames) {
         boolean isSuccess = this.removeContainer(containerName);
         assert isSuccess : "failed to remove container " + containerName;
@@ -2787,6 +2817,14 @@ public class XdnGigapaxosApp
   public boolean hostsService(String serviceName) {
     Map<Integer, ServiceInstance> instances = this.serviceInstances.get(serviceName);
     return instances != null && !instances.isEmpty();
+  }
+
+  /**
+   * Returns this replica's bandwidth edge snapshot for a profiled cluster service, or null when the
+   * service is not profiled (tracer disabled, probe failed, or not cluster-managed).
+   */
+  public org.json.JSONObject getBandwidthSnapshot(String serviceName) {
+    return this.bandwidthProfiler.snapshot(serviceName);
   }
 
   /**********************************************************************************************

--- a/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
+++ b/src/edu/umass/cs/xdn/XdnReplicaCoordinator.java
@@ -616,6 +616,10 @@ public class XdnReplicaCoordinator<NodeIDType> extends AbstractReplicaCoordinato
     }
 
     request.setRequestBehaviors(currServiceProperty.getRequestMatchers());
+    if (coordinator instanceof StatefulClusterReplicaCoordinator<NodeIDType>
+        && this.xdnGigapaxosApp != null) {
+      request.setBandwidth(this.xdnGigapaxosApp.getBandwidthSnapshot(serviceName));
+    }
     request.setResponse(
         this.myNodeID, protocolName, requestedConsistency, offeredConsistency, roleName);
     callback.executed(request, true);

--- a/src/edu/umass/cs/xdn/request/XdnGetReplicaInfoRequest.java
+++ b/src/edu/umass/cs/xdn/request/XdnGetReplicaInfoRequest.java
@@ -32,6 +32,7 @@ public class XdnGetReplicaInfoRequest extends XdnRequest implements ClientReques
   List<String> createdAtInfo;
   List<String> containerStatus;
   List<RequestMatcher> requestBehaviors;
+  JSONObject bandwidth; // per-peer traffic edges for profiled cluster services
 
   // fields for the error response
   Integer httpErrorCode;
@@ -108,6 +109,10 @@ public class XdnGetReplicaInfoRequest extends XdnRequest implements ClientReques
 
   public void setRequestBehaviors(List<RequestMatcher> requestBehaviors) {
     this.requestBehaviors = requestBehaviors;
+  }
+
+  public void setBandwidth(JSONObject bandwidth) {
+    this.bandwidth = bandwidth;
   }
 
   public String getErrorMessage() {
@@ -196,6 +201,10 @@ public class XdnGetReplicaInfoRequest extends XdnRequest implements ClientReques
           behaviors.put(matcherJson);
         }
         json.put("requestBehaviors", behaviors);
+      }
+
+      if (this.bandwidth != null) {
+        json.put("bandwidth", this.bandwidth);
       }
 
       return json.toString();

--- a/test/edu/umass/cs/xdn/XdnBwProbeParserTest.java
+++ b/test/edu/umass/cs/xdn/XdnBwProbeParserTest.java
@@ -1,0 +1,88 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Docker-free unit tests for {@link XdnBandwidthProfiler}'s parsers, against fixture text captured
+ * from a real {@code ss -tinH} / busybox {@code getent hosts} run inside an alpine container.
+ */
+public class XdnBwProbeParserTest {
+
+  // Two connections: an IPv4 row and a bracketed IPv4-mapped-IPv6 row, each followed by its
+  // tcp_info continuation line, exactly as `ss -tinH` prints them.
+  private static final String SS_FIXTURE =
+      "LISTEN 0      4096            0.0.0.0:2379            0.0.0.0:*\n"
+          + "ESTAB 0      0               10.0.3.2:52912          10.0.3.4:2380\n"
+          + "\t cubic wscale:7,7 rto:201 rtt:0.076/0.015 ato:40 mss:32768 pmtu:65535 rcvmss:536"
+          + " advmss:65483 cwnd:10 bytes_sent:84 bytes_acked:85 bytes_received:1024 segs_out:17"
+          + " segs_in:16 data_segs_out:14 send 34492631579bps lastsnd:139 rcv_space:65495\n"
+          + "ESTAB 0      0      [::ffff:10.0.3.2]:2379  [::ffff:172.17.0.1]:39118\n"
+          + "\t cubic wscale:7,7 rto:201 rtt:0.193/0.206 ato:40 mss:32768 pmtu:65535 rcvmss:536"
+          + " advmss:65483 cwnd:10 bytes_acked:501 bytes_received:84 segs_out:15 segs_in:17\n"
+          + "CLOSE-WAIT 0      0               127.0.0.1:40261          127.0.0.1:9000\n"
+          + "\t cubic wscale:7,7 rto:201 bytes_sent:84 bytes_acked:85 bytes_received:1\n";
+
+  private static final String GETENT_FIXTURE =
+      "10.0.3.2  replica-0  replica-0\n10.0.3.4  replica-1  replica-1\n";
+
+  @Test
+  public void testParseSsOutput() {
+    List<XdnBandwidthProfiler.SsConn> conns = XdnBandwidthProfiler.parseSsOutput(SS_FIXTURE);
+    assertEquals(3, conns.size());
+
+    XdnBandwidthProfiler.SsConn peerConn = conns.get(0);
+    assertEquals("10.0.3.2", peerConn.localAddr());
+    assertEquals(52912, peerConn.localPort());
+    assertEquals("10.0.3.4", peerConn.peerAddr());
+    assertEquals(2380, peerConn.peerPort());
+    assertEquals(84, peerConn.tx(), "bytes_acked must be corrected for the SYN sequence byte");
+    assertEquals(1024, peerConn.rx());
+
+    XdnBandwidthProfiler.SsConn clientConn = conns.get(1);
+    assertEquals("10.0.3.2", clientConn.localAddr(), "v4-mapped v6 addresses must normalize");
+    assertEquals("172.17.0.1", clientConn.peerAddr());
+    assertEquals(2379, clientConn.localPort());
+    assertEquals(500, clientConn.tx());
+    assertEquals(84, clientConn.rx());
+  }
+
+  @Test
+  public void testParseGetentOutput() {
+    Map<String, String> map = XdnBandwidthProfiler.parseGetentOutput(GETENT_FIXTURE);
+    assertEquals(2, map.size());
+    assertEquals("replica-0", map.get("10.0.3.2"));
+    assertEquals("replica-1", map.get("10.0.3.4"));
+  }
+
+  @Test
+  public void testClassifyPeer() {
+    Map<String, String> map = Map.of("10.0.3.4", "replica-1");
+    int entryPort = 2379;
+    assertEquals(
+        "replica-1", XdnBandwidthProfiler.classifyPeer("10.0.3.4", 2380, 51000, entryPort, map));
+    assertEquals(
+        XdnBandwidthProfiler.CLIENT_EDGE,
+        XdnBandwidthProfiler.classifyPeer("172.17.0.1", 2379, 39000, entryPort, map),
+        "bridge-side peers aggregate as client traffic");
+    assertEquals(
+        XdnBandwidthProfiler.CLIENT_EDGE,
+        XdnBandwidthProfiler.classifyPeer("127.0.0.1", 2379, 36694, entryPort, map),
+        "proxy-injected loopback on the entry port's server side is client traffic");
+    assertNull(
+        XdnBandwidthProfiler.classifyPeer("127.0.0.1", 36694, 2379, entryPort, map),
+        "the proxy's mirror row must be skipped to avoid double counting");
+    assertNull(
+        XdnBandwidthProfiler.classifyPeer("127.0.0.1", 3306, 41000, 80, map),
+        "sidecar-to-member loopback off the entry port stays intra-pod");
+  }
+
+  @Test
+  public void testMalformedLinesAreSkipped() {
+    String noise = "garbage line\nESTAB 0 0 broken\n\t bytes_acked:10 bytes_received:5\n";
+    assertTrue(XdnBandwidthProfiler.parseSsOutput(noise).isEmpty());
+  }
+}

--- a/test/edu/umass/cs/xdn/XdnClusterBandwidthTest.java
+++ b/test/edu/umass/cs/xdn/XdnClusterBandwidthTest.java
@@ -1,0 +1,150 @@
+package edu.umass.cs.xdn;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.umass.cs.utils.Config;
+import edu.umass.cs.xdn.util.XdnTestCluster;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test for the integrated cluster-mode bandwidth profiler.
+ *
+ * <p>Launches a 3-replica etcd ensemble, drives writes through replica 0, then asserts the
+ * replica-info endpoint's {@code bandwidth} section reports nonzero directed traffic to exactly the
+ * two overlay peers plus a client-side aggregate. Assertions target names and cumulative bytes, not
+ * rates, for stability.
+ */
+public class XdnClusterBandwidthTest {
+
+  private static final String SERVICE = "etcd-bw-test";
+  private static final int CLIENT_PORT = 2379;
+  private static final int PEER_PORT = 2380;
+  private static final Duration HEALTH_BUDGET = Duration.ofSeconds(120);
+  private static final Duration BW_BUDGET = Duration.ofSeconds(60);
+
+  private final HttpClient http =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+  @Test
+  public void testBandwidthEdgesReported() throws Exception {
+    assertTrue(XdnTestCluster.isDockerAvailable(), "docker is required for this test");
+    assertTrue(
+        XdnTestCluster.ensureDockerSwarm(),
+        "cluster services need Swarm overlay networking — `docker swarm init` failed");
+    assertTrue(
+        XdnTestCluster.buildEtcdClusterImage(),
+        "could not build xdn-etcd-cluster:test from services/etcd-cluster/");
+    assertTrue(
+        XdnTestCluster.buildImage("xdn-bw-probe:test", "services/bw-probe/"),
+        "could not build xdn-bw-probe:test from services/bw-probe/");
+
+    // Use the locally built probe image and a fast poll so edges appear quickly.
+    Config.register(
+        new String[] {
+          "XDN_CLUSTER_BW_PROBE_IMAGE=xdn-bw-probe:test", "XDN_CLUSTER_BW_POLL_INTERVAL_MS=500"
+        });
+
+    try (XdnTestCluster cluster = new XdnTestCluster()) {
+      cluster.start();
+
+      cluster.launchClusterService(
+          SERVICE, "xdn-etcd-cluster:test", "/etcd-data/", CLIENT_PORT, PEER_PORT, 3);
+
+      for (int idx = 0; idx < 3; idx++) {
+        waitForHealth(cluster, idx, System.nanoTime() + HEALTH_BUDGET.toNanos());
+      }
+
+      // Drive some writes through replica 0 so peer replication traffic is guaranteed
+      // beyond raft heartbeats.
+      for (int i = 0; i < 5; i++) {
+        assertEquals(200, putKey(cluster, 0, "bw-key-" + i, "value-" + i).statusCode());
+      }
+
+      // Replica 0 must eventually report nonzero traffic to replica-1, replica-2, and a
+      // client aggregate (our own health polls and PUTs arrive via the bridge).
+      long deadline = System.nanoTime() + BW_BUDGET.toNanos();
+      JSONObject lastBandwidth = null;
+      while (System.nanoTime() < deadline) {
+        HttpResponse<String> info =
+            cluster.sendGetRequest(SERVICE, 0, "/api/v2/services/" + SERVICE + "/replica/info");
+        if (info.statusCode() == 200) {
+          JSONObject json = new JSONObject(info.body());
+          if (json.has("bandwidth")) {
+            lastBandwidth = json.getJSONObject("bandwidth");
+            if (hasExpectedEdges(lastBandwidth)) {
+              return;
+            }
+          }
+        }
+        Thread.sleep(1000);
+      }
+      fail("bandwidth edges never complete; last snapshot: " + lastBandwidth);
+    }
+  }
+
+  /** True when both overlay peers and the client aggregate show nonzero cumulative bytes. */
+  private boolean hasExpectedEdges(JSONObject bandwidth) throws Exception {
+    JSONArray edges = bandwidth.getJSONArray("edges");
+    Set<String> nonzeroPeers = new HashSet<>();
+    for (int i = 0; i < edges.length(); i++) {
+      JSONObject edge = edges.getJSONObject(i);
+      String peer = edge.getString("peer");
+      assertTrue(
+          peer.equals("replica-1")
+              || peer.equals("replica-2")
+              || peer.equals(XdnBandwidthProfiler.CLIENT_EDGE),
+          "unexpected edge peer '" + peer + "' on replica 0 (self must never appear)");
+      if (edge.getLong("txBytes") > 0 && edge.getLong("rxBytes") > 0) {
+        nonzeroPeers.add(peer);
+      }
+    }
+    return nonzeroPeers.contains("replica-1")
+        && nonzeroPeers.contains("replica-2")
+        && nonzeroPeers.contains(XdnBandwidthProfiler.CLIENT_EDGE);
+  }
+
+  private void waitForHealth(XdnTestCluster cluster, int replicaIdx, long deadlineNs)
+      throws Exception {
+    Exception last = null;
+    while (System.nanoTime() < deadlineNs) {
+      try {
+        HttpResponse<String> r = cluster.sendGetRequest(SERVICE, replicaIdx, "/health");
+        if (r.statusCode() == 200 && r.body().contains("\"true\"")) {
+          return;
+        }
+        last = new IllegalStateException("replica " + replicaIdx + " not healthy: " + r.body());
+      } catch (Exception e) {
+        last = e;
+      }
+      Thread.sleep(1000);
+    }
+    throw new AssertionError("etcd replica " + replicaIdx + " never reported healthy", last);
+  }
+
+  private HttpResponse<String> putKey(XdnTestCluster cluster, int replicaIdx, String k, String v)
+      throws Exception {
+    JSONObject body = new JSONObject();
+    body.put("key", Base64.getEncoder().encodeToString(k.getBytes()));
+    body.put("value", Base64.getEncoder().encodeToString(v.getBytes()));
+    int port = cluster.getActiveHttpPort("AR" + replicaIdx);
+    HttpRequest req =
+        HttpRequest.newBuilder()
+            .uri(URI.create("http://127.0.0.1:" + port + "/v3/kv/put"))
+            .timeout(Duration.ofSeconds(10))
+            .header("XDN", SERVICE)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+            .build();
+    return http.send(req, HttpResponse.BodyHandlers.ofString());
+  }
+}


### PR DESCRIPTION
## What

Per-replica **bandwidth profiling** for cluster-mode services, extracted from the quorum-probe measurement branch as a standalone feature. It answers *who talks to whom, and how much* for a blackbox self-clustering service — the coordinated-traffic vs client-demand split — with **zero protocol knowledge and zero data-path impact**.

## How it works

- **Probe sidecar** (`services/bw-probe/`: alpine + `iproute2-ss` + `sleep infinity`) joins each cluster member's network namespace via `--network=container:<member>`. It is *not* a proxy: no added hop, no sockets of its own — just a vantage point.
- The AR polls `docker exec <probe> ss -tainH` (default 1s, `XDN_CLUSTER_BW_POLL_INTERVAL_MS`). `bytes_acked`/`bytes_received` from tcp_info are exact cumulative kernel counters, so polling loses nothing on long-lived connections; new/reset connections are detected by counters going backwards and attributed in full.
- Per-connection deltas fold into **directed per-peer edges**, classified by peer address alone: overlay-alias IPs (embedded DNS via `getent hosts replica-N`, refreshed every 30s) = coordination traffic to that named replica; loopback rows on the entry port's server side = published-port client connections (dockerd 29+'s userland proxy injects them over loopback); other loopback = intra-pod chatter, skipped; everything else aggregates as `client`.
- Snapshots (`txBytes/rxBytes` cumulative + current `tx/rxRateBps`) ride the existing **replica-info endpoint** as a `bandwidth` JSON section.

## Behavior & safety

- **On by default** (`XDN_CLUSTER_BW_TRACER_ENABLED=true`), cluster-mode services only — regular replicated services are untouched.
- **Everything degrades gracefully**: missing probe image or failed exec logs and disables profiling; the service itself is never affected.
- **Namespace-abandonment heal**: a probe seeing *no sockets at all* (not even LISTENers) is bound to a dead sandbox from a member restart — after 3 empty polls it is restarted to rejoin the member's current namespace (rate-limited; a quiet-but-live pod still shows LISTEN sockets and never triggers this).

## Tests (both wired into CI)

- **`XdnBwProbeParserTest`** (unit, JDK-only job): `ss -tinH` and `getent` parsing, including IPv6-mapped/bracketed addresses and malformed-line tolerance — 4 tests, pass locally.
- **`XdnClusterBandwidthTest`** (end to end, own integration-matrix runner): builds the probe + etcd images, launches a real 3-replica etcd ensemble on the overlay, drives writes through replica 0, and asserts the replica-info `bandwidth` section reports nonzero directed traffic to **exactly** `replica-1`, `replica-2`, and the `client` aggregate (self must never appear). **Passes on a clean Linux host** (docker + swarm).

Also documents the feature in CLAUDE.md's cluster-mode section.