### PR TITLE
xdn-cli: show primary-backup backups as standby in service info

### DIFF
--- a/xdn-cli/cmd/service.go
+++ b/xdn-cli/cmd/service.go
@@ -330,17 +330,7 @@ var ServiceInfoCmd = &cobra.Command{
 				svcReplicaURLStr = fmt.Sprintf("%s/?_xdnsvc=%s",
 					r.httpBaseURL, url.QueryEscape(serviceName))
 			}
-			roleStr := "unreachable"
-			createdStr := "unreachable"
-			statusStr := "unreachable"
-			info := replicaInfos[idx]
-			if info.fetchErr == nil && info.raw != nil {
-				roleStr = stringOrDash(info.raw["role"])
-				if c := pickStatefulContainer(info.raw); c != nil {
-					createdStr = stringOrDash(c["createdAt"])
-					statusStr = stringOrDash(c["status"])
-				}
-			}
+			roleStr, createdStr, statusStr := replicaStatusCells(replicaInfos[idx])
 			rows[idx] = replicaRow{
 				geoStr, r.nodeID, displayAddr, webPortStr, roleStr, createdStr, statusStr, svcReplicaURLStr,
 			}
@@ -390,6 +380,16 @@ var ServiceInfoCmd = &cobra.Command{
 				wGeo, row.geolocation, wID, row.machineID, wIP, row.ipAddress,
 				wPort, row.webPort, roleCell, wCreated, row.created,
 				statusCell, wURL, row.svcReplicaURL)
+		}
+
+		for _, row := range rows {
+			if row.status == "standby" {
+				fmt.Printf(
+					" %s\n",
+					footnoteColorPrint.Sprint(
+						"backups run no container; primary-backup activates one on promotion"))
+				break
+			}
 		}
 
 		if primaryInfo == nil {
@@ -950,6 +950,24 @@ func pickStatefulContainer(info map[string]interface{}) map[string]interface{} {
 	return pickNamedContainer(info, "statefulComponent")
 }
 
+// replicaStatusCells renders the ROLE / CREATED / STATUS table cells for one replica.
+// "unreachable" is reserved for replicas whose replica-info fetch actually failed. A replica
+// that answered but runs no container is not unreachable: a primary-backup backup runs the
+// containerized service only after promotion, so it renders as a healthy "standby".
+func replicaStatusCells(info replicaInfo) (role, created, status string) {
+	if info.fetchErr != nil || info.raw == nil {
+		return "unreachable", "unreachable", "unreachable"
+	}
+	role = stringOrDash(info.raw["role"])
+	if c := pickStatefulContainer(info.raw); c != nil {
+		return role, stringOrDash(c["createdAt"]), stringOrDash(c["status"])
+	}
+	if strings.EqualFold(role, "backup") {
+		return role, "-", "standby"
+	}
+	return role, "-", "-"
+}
+
 // pickEntryContainer returns the containers[] entry whose "name" matches
 // info["entryComponent"], falling back to containers[0].
 func pickEntryContainer(info map[string]interface{}) map[string]interface{} {
@@ -1001,6 +1019,9 @@ func colorForStatus(s string) *color.Color {
 		return color.New(color.FgRed)
 	case "created", "starting", "restarting", "paused":
 		return color.New(color.FgYellow)
+	case "standby":
+		// A reachable primary-backup backup awaiting promotion: healthy, not a warning.
+		return color.New(color.FgCyan)
 	default:
 		return color.New()
 	}

--- a/xdn-cli/cmd/service_test.go
+++ b/xdn-cli/cmd/service_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestParseNodeSocketAddress(t *testing.T) {
 	tests := []struct {
@@ -72,3 +75,71 @@ func TestParseNodeSocketAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestReplicaStatusCells(t *testing.T) {
+	container := map[string]interface{}{
+		"name":      "svc",
+		"createdAt": "2 minutes ago",
+		"status":    "running",
+	}
+	tests := []struct {
+		name        string
+		info        replicaInfo
+		wantRole    string
+		wantCreated string
+		wantStatus  string
+	}{
+		{
+			name:        "fetch failed",
+			info:        replicaInfo{fetchErr: errTest},
+			wantRole:    "unreachable",
+			wantCreated: "unreachable",
+			wantStatus:  "unreachable",
+		},
+		{
+			name: "primary with running container",
+			info: replicaInfo{
+				raw: map[string]interface{}{
+					"role":              "primary",
+					"statefulComponent": "svc",
+					"containers":        []interface{}{container},
+				},
+			},
+			wantRole:    "primary",
+			wantCreated: "2 minutes ago",
+			wantStatus:  "running",
+		},
+		{
+			name: "backup without container is standby, not unreachable",
+			info: replicaInfo{
+				raw: map[string]interface{}{
+					"role":       "backup",
+					"containers": []interface{}{},
+				},
+			},
+			wantRole:    "backup",
+			wantCreated: "-",
+			wantStatus:  "standby",
+		},
+		{
+			name: "non-backup role without container falls back to dashes",
+			info: replicaInfo{
+				raw: map[string]interface{}{"role": "follower"},
+			},
+			wantRole:    "follower",
+			wantCreated: "-",
+			wantStatus:  "-",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role, created, status := replicaStatusCells(tt.info)
+			if role != tt.wantRole || created != tt.wantCreated || status != tt.wantStatus {
+				t.Errorf("got (%q, %q, %q), want (%q, %q, %q)",
+					role, created, status, tt.wantRole, tt.wantCreated, tt.wantStatus)
+			}
+		})
+	}
+}
+
+var errTest = errors.New("connection refused")


### PR DESCRIPTION
## Problem

For a primary-backup deployment, `xdn service info` shows every backup as:

```
| AR2 | ... | backup | unreachable | unreachable | ... |
```

The replica answered the replica-info fetch fine (the ROLE cell proves it); CREATED/STATUS just kept their pre-initialized `unreachable` default because `pickStatefulContainer` finds no container -- which is by design: primary-backup runs the containerized service only at the primary, and a backup activates one on promotion.

## Fix

Extract the cell logic into `replicaStatusCells` with honest semantics:

- `unreachable` is reserved for replicas whose replica-info fetch actually failed;
- a reached `backup` with no container renders CREATED `-`, STATUS `standby` (cyan, a healthy state) with a footnote under the table: "backups run no container; primary-backup activates one on promotion";
- any other reached role with no container renders `-`.

```
| NODE ID | ... | ROLE    | CREATED       | STATUS  |
| AR1     | ... | primary | 2 minutes ago | running |
| AR2     | ... | backup  | -             | standby |
```

CLI-only, so it behaves correctly against already-deployed ARs with no server change.

## Verification

- Table-driven unit test for `replicaStatusCells` (fetch failure, primary with container, backup standby, containerless non-backup role).
- Verified against the live AWS deployment that genuine fetch failures still render `unreachable`.
- `gofmt`/`go vet`/`go build`/`go test ./cmd/` clean.