### PR TITLE
Advertise the effective AR HTTP port; probe https/:80 in the CLI

### DIFF
--- a/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
+++ b/src/edu/umass/cs/reconfiguration/ReconfigurationConfig.java
@@ -867,6 +867,27 @@ public class ReconfigurationConfig {
     }
 
     /**
+     * The port an ActiveReplica's HTTP frontend actually binds, mirroring the
+     * precedence in {@link edu.umass.cs.reconfiguration.http.HttpActiveReplica}:
+     * HTTPS (443 by default) overrides port 80, which overrides the cleartext
+     * offset port. Used when the reconfigurator advertises {@code HTTP_ADDRESS}
+     * so the placement reports the port clients can actually reach, not just the
+     * offset-derived one.
+     *
+     * @param consensusPort the node's consensus (TCP listener) port
+     * @return the effective HTTP frontend port
+     */
+    public static int getAdvertisedHTTPPort(int consensusPort) {
+        if (Config.getGlobalBoolean(RC.ENABLE_ACTIVE_REPLICA_HTTPS)) {
+            return Config.getGlobalInt(RC.ACTIVE_REPLICA_HTTPS_PORT);
+        }
+        if (Config.getGlobalBoolean(RC.ENABLE_ACTIVE_REPLICA_HTTP_PORT_80)) {
+            return 80;
+        }
+        return getHTTPPort(consensusPort);
+    }
+
+    /**
      * @param port
      * @return Translates port to corresponding client facing port.
      */

--- a/src/edu/umass/cs/reconfiguration/Reconfigurator.java
+++ b/src/edu/umass/cs/reconfiguration/Reconfigurator.java
@@ -1334,7 +1334,9 @@ public class Reconfigurator<NodeIDType> implements
         for (NodeIDType node : nodeIds) {
             InetSocketAddress address = this.consistentNodeConfig.getNodeSocketAddress(node);
             addresses.add(address.toString());
-            int httpPort = ReconfigurationConfig.getHTTPPort(address.getPort());
+            // Advertise the port the frontend actually binds (80 / 443 / offset),
+            // not just the offset port, so clients probe a reachable address.
+            int httpPort = ReconfigurationConfig.getAdvertisedHTTPPort(address.getPort());
             httpAddresses.add(
                     new InetSocketAddress(address.getAddress(), httpPort).toString());
         }

--- a/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
+++ b/src/edu/umass/cs/reconfiguration/http/HttpActiveReplica.java
@@ -380,9 +380,21 @@ public class HttpActiveReplica {
                     if (host == null) {
                         host = "";
                     }
-                    int colon = host.indexOf(':');
-                    if (colon >= 0) {
-                        host = host.substring(0, colon); // strip any :port
+                    // Strip the port while keeping a bracketed IPv6 literal intact.
+                    // Splitting on the first colon truncates "[2600::a]" to "[2600"
+                    // and yields a malformed Location; for "[v6]:port" the port is
+                    // after the closing bracket, for "host:port"/"v4:port" after the
+                    // first colon.
+                    if (host.startsWith("[")) {
+                        int end = host.indexOf(']');
+                        if (end >= 0) {
+                            host = host.substring(0, end + 1);
+                        }
+                    } else {
+                        int colon = host.indexOf(':');
+                        if (colon >= 0) {
+                            host = host.substring(0, colon);
+                        }
                     }
                     String portSuffix = httpsPort == 443 ? "" : ":" + httpsPort;
                     String location = "https://" + host + portSuffix + req.uri();

--- a/xdn-cli/cmd/service.go
+++ b/xdn-cli/cmd/service.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -911,19 +912,72 @@ func parseNodeSocketAddress(s string) (host, ip string, port int, ok bool) {
 	return host, ipStr, p, true
 }
 
-// fetchReplicaInfo queries the AR's /replica/info endpoint. The AR HTTP
-// frontend requires the XDN header to route into XDN-specific handling.
+// fetchReplicaInfo queries an AR's /replica/info control endpoint, tolerating a
+// control plane that advertised the wrong HTTP port/scheme. It probes, in order:
+// the advertised address, then https on 443, then http on 80 -- so an HTTPS
+// frontend (ENABLE_ACTIVE_REPLICA_HTTPS) or a :80 frontend
+// (ENABLE_ACTIVE_REPLICA_HTTP_PORT_80) is reached even when the reconfigurator
+// advertised the cleartext offset port. A replica is "unreachable" only when
+// none of these answers /replica/info with 200. URLs use net.JoinHostPort so
+// IPv6 addresses are bracketed.
 func fetchReplicaInfo(r placementReplica, serviceName string) replicaInfo {
-	if r.httpBaseURL == "" {
+	if r.ip == "" {
 		return replicaInfo{fetchErr: fmt.Errorf("no HTTP address from control plane")}
 	}
-	url := fmt.Sprintf("%s/api/v2/services/%s/replica/info", r.httpBaseURL, serviceName)
+
+	type target struct {
+		scheme string
+		port   int
+	}
+	var targets []target
+	seen := map[target]bool{}
+	add := func(scheme string, port int) {
+		t := target{scheme, port}
+		if port > 0 && !seen[t] {
+			seen[t] = true
+			targets = append(targets, t)
+		}
+	}
+	// Advertised address first (443 implies https), then the well-known
+	// externally-exposed frontends.
+	if r.httpPort == 443 {
+		add("https", 443)
+	} else {
+		add("http", r.httpPort)
+	}
+	add("https", 443)
+	add("http", 80)
+
+	var lastErr error
+	for _, t := range targets {
+		info := probeReplicaInfo(t.scheme, r.ip, t.port, serviceName)
+		if info.fetchErr == nil {
+			return info
+		}
+		lastErr = info.fetchErr
+	}
+	return replicaInfo{fetchErr: lastErr}
+}
+
+// probeReplicaInfo does one GET of /replica/info at scheme://host:port. The
+// "XDN" header is required: it routes the request into the XDN control handler,
+// which returns the replica-info JSON; without it the endpoint answers 200 with
+// an empty body. https uses InsecureSkipVerify since AR frontends may present a
+// self-signed certificate.
+func probeReplicaInfo(scheme, host string, port int, serviceName string) replicaInfo {
+	url := fmt.Sprintf("%s://%s/api/v2/services/%s/replica/info",
+		scheme, net.JoinHostPort(host, strconv.Itoa(port)), serviceName)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return replicaInfo{fetchErr: err}
 	}
 	req.Header.Set("XDN", serviceName)
 	client := http.Client{Timeout: 5 * time.Second}
+	if scheme == "https" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return replicaInfo{fetchErr: err}


### PR DESCRIPTION
## Problem

`xdn service info` reports healthy replicas as **unreachable** when the AR HTTP frontend is exposed on something other than the cleartext offset port. On the live `cp.xdnapp.com` deployment (HTTPS on `:443`, `:80` = HTTPS-redirect), every replica showed `unreachable` even though the service serves fine — the CLI probed `http :2300`.

Root cause: mismatch between what the frontend *binds* and what the reconfigurator *advertises*. `HttpActiveReplica` binds `:443` (`ENABLE_ACTIVE_REPLICA_HTTPS`) or `:80` (`ENABLE_ACTIVE_REPLICA_HTTP_PORT_80`), but `Reconfigurator` computed `HTTP_ADDRESS` as `getHTTPPort(consensusPort)` — the offset port (2300) — **unconditionally**.

## Fix

**1. RC advertises the port the frontend actually binds.** New `ReconfigurationConfig.getAdvertisedHTTPPort()` mirrors `HttpActiveReplica`'s precedence (HTTPS 443 > port 80 > offset); `Reconfigurator` uses it for `HTTP_ADDRESS`.

**2. CLI probes the real frontend.** `fetchReplicaInfo` now tries, in order: the advertised address (https when the advertised port is 443), then **https on 443**, then **http on 80** — reaching an HTTPS or `:80` frontend even when the RC advertised the offset port. URLs use `net.JoinHostPort` (IPv6 bracketing); https uses `InsecureSkipVerify` for the self-signed cert. The `XDN` header is kept — it is **required** (the control endpoint returns an empty `200` without it; the `:80` 308 was the HTTPS-redirect, not header-based app routing).

**3. Bracket IPv6 in the `:80`→HTTPS redirect `Location`.** The redirect handler stripped the port with `indexOf(':')`, which for a bracketed IPv6 Host (`[2600::a]`) cut inside the address and emitted a malformed `Location` (`https://[2600/...`) clients can't follow. Now keeps the bracketed literal intact.

## Validation

- `ant jar` + Google Java Format: clean. `go build` + gofmt: clean.
- **Live-verified against `cp.xdnapp.com` (HTTPS deployment):** replicas that showed `unreachable` now render their real role/status — 2 followers + a leader, all `running` — via the `https:443` fallback probe.

## Enabling external exposure

Set `ENABLE_ACTIVE_REPLICA_HTTP_PORT_80=true` (or `ENABLE_ACTIVE_REPLICA_HTTPS=true`); binding 80/443 is a privileged port, so the AR process needs the capability (root or `setcap cap_net_bind_service`). With this change the placement then advertises that port.

4 files: 3 Java + 1 Go.